### PR TITLE
Distinguish locales with unsupported language codes in the admin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changelog
  * Fix: Use canonical URL for TED oEmbed provider (Marquis Nobles)
  * Fix: Prevent icons from capturing clicks inside buttons (Maciek Baron)
  * Fix: Prevent stale content types from breaking audit log message formatting (Thibaud Colas)
+ * Fix: Distinguish locales with unsupported language codes in the admin by appending the language code to their display name (Shresth Samyak)
  * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
  * Docs: Fix panel classname and deprecated usage of `format_html` in `construct_homepage_panels` example (Andreas Nüßlein)
  * Maintenance: Rename `request` argument to `cache_object` in `Page._get_site_root_paths()` for correctness (Kailesh)

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -39,6 +39,7 @@ Wagtail 8.0 introduces a new API transport layer at `/api/v3/`, built on [Django
  * Use canonical URL for TED oEmbed provider (Marquis Nobles)
  * Prevent stale content types from breaking audit log message formatting (Thibaud Colas)
  * Prevent icons from capturing clicks inside buttons (Maciek Baron)
+ * Distinguish locales with unsupported language codes in the admin by appending the language code to their display name (Shresth Samyak)
 
 ### Documentation
 

--- a/wagtail/models/i18n.py
+++ b/wagtail/models/i18n.py
@@ -87,8 +87,13 @@ class Locale(models.Model):
             return get_content_languages()[self.language_code]
         except KeyError:
             pass
+        # The language code is not configured in WAGTAIL_CONTENT_LANGUAGES, so this
+        # locale is flagged as unsupported in the admin. Include the language code
+        # alongside the name so that locales whose names resolve to the same value
+        # remain distinguishable - for example, Django reports both "en-us" and
+        # "en-ca" as "English", which would otherwise render identically.
         try:
-            return self.language_name
+            return f"{self.language_name} ({self.language_code})"
         except KeyError:
             pass
 

--- a/wagtail/tests/test_locale_model.py
+++ b/wagtail/tests/test_locale_model.py
@@ -145,18 +145,20 @@ class TestLocaleModel(TestCase):
                 self.assertEqual(locale.get_display_name(), expected_result)
 
     def test_get_display_name_disambiguates_unconfigured_variants(self):
-        # Django reports several English variants under the generic "English"
-        # name. Unconfigured variants must not collapse to the same label,
-        # otherwise they are indistinguishable in the Locales admin listing.
-        display_names = {
-            Locale(language_code=code).get_display_name()
-            for code in ("en-us", "en-ca", "en-nz")
-        }
-        self.assertEqual(len(display_names), 3)
-        self.assertEqual(
-            display_names,
-            {"English (en-us)", "English (en-ca)", "English (en-nz)"},
-        )
+        # Django reports several English variants under the same generic
+        # language name, so without the language code suffix these unconfigured
+        # locales would collapse to the same label and be indistinguishable in
+        # the Locales admin listing. Assert the suffix and uniqueness rather
+        # than the exact base name, which can vary across Django versions and
+        # locale data.
+        codes = ("en-us", "en-ca", "en-nz")
+        display_names = [
+            Locale(language_code=code).get_display_name() for code in codes
+        ]
+        for code, display_name in zip(codes, display_names):
+            with self.subTest(code):
+                self.assertTrue(display_name.endswith(f"({code})"))
+        self.assertEqual(len(set(display_names)), len(codes))
 
     def test_str_reflects_get_display(self):
         for language_code in ("en", "zh-hans", "foo"):

--- a/wagtail/tests/test_locale_model.py
+++ b/wagtail/tests/test_locale_model.py
@@ -135,12 +135,28 @@ class TestLocaleModel(TestCase):
     def test_get_display_name(self):
         for language_code, expected_result in (
             ("en", "English"),  # configured
-            ("zh-hans", "Simplified Chinese"),  # not configured but valid
-            ("foo", "foo"),  # not configured or valid
+            # not configured but recognised - the language code is appended so
+            # that unsupported locales remain distinguishable in the admin
+            ("zh-hans", "Simplified Chinese (zh-hans)"),
+            ("foo", "foo"),  # not configured or recognised
         ):
             locale = Locale(language_code=language_code)
             with self.subTest(language_code):
                 self.assertEqual(locale.get_display_name(), expected_result)
+
+    def test_get_display_name_disambiguates_unconfigured_variants(self):
+        # Django reports several English variants under the generic "English"
+        # name. Unconfigured variants must not collapse to the same label,
+        # otherwise they are indistinguishable in the Locales admin listing.
+        display_names = {
+            Locale(language_code=code).get_display_name()
+            for code in ("en-us", "en-ca", "en-nz")
+        }
+        self.assertEqual(len(display_names), 3)
+        self.assertEqual(
+            display_names,
+            {"English (en-us)", "English (en-ca)", "English (en-nz)"},
+        )
 
     def test_str_reflects_get_display(self):
         for language_code in ("en", "zh-hans", "foo"):


### PR DESCRIPTION
<!-- Insert the issue number that you're fixing here, if any -->
Fixes #...

### Description

In the Locales admin listing, locales whose language code is not present in `WAGTAIL_CONTENT_LANGUAGES` are flagged as unsupported (the warning triangle). However, `Locale.get_display_name()` fell back to the generic language name reported by Django, so several distinct unconfigured variants collapsed to the *same* label.

For example, Django reports `en-us`, `en-ca` and `en-nz` all as **"English"**, so multiple such locales rendered identically and were impossible to tell apart in the listing — you couldn't identify which one to edit or delete.

This change appends the language code to the display name when the code is not a configured content language (the same condition that already flags the locale as unsupported), so `en-us` now shows as `English (en-us)`, `en-ca` as `English (en-ca)`, and so on. Configured locales are unaffected.

Areas worth a careful look:

- `get_display_name()` backs `Locale.__str__`, so the new suffix also appears anywhere an unsupported locale is rendered (choosers, switchers). This is intentional and desirable for disambiguation, but reviewers may want to confirm the behaviour in those contexts.

### AI usage

This PR was written with the assistance of an AI coding agent (Claude Code)
