### PR TITLE
Fix `import_string` error message assertions for Django 6.2+ compatibility

### DIFF
--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -2715,10 +2715,10 @@ class TestGroupViewSet(TestCase):
         with unittest.mock.patch.object(
             self.app_config, "group_viewset", new="asdfasdf"
         ):
-            with self.assertRaisesMessage(
+            with self.assertRaisesRegex(
                 ImproperlyConfigured,
-                f"Invalid setting for {self.app_config_class_name}.group_viewset: "
-                "asdfasdf doesn't look like a module path",
+                rf"Invalid setting for {self.app_config_class_name}\.group_viewset: "
+                ".*asdfasdf.*",
             ):
                 get_viewset_cls(self.app_config, "group_viewset")
 
@@ -2771,10 +2771,10 @@ class TestUserViewSet(TestCase):
         with unittest.mock.patch.object(
             self.app_config, "user_viewset", new="asdfasdf"
         ):
-            with self.assertRaisesMessage(
+            with self.assertRaisesRegex(
                 ImproperlyConfigured,
-                f"Invalid setting for {self.app_config_class_name}.user_viewset: "
-                "asdfasdf doesn't look like a module path",
+                rf"Invalid setting for {self.app_config_class_name}\.user_viewset: "
+                ".*asdfasdf.*",
             ):
                 get_viewset_cls(self.app_config, "user_viewset")
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes current tests against Django main.

### Description

<!-- Please describe the problem you're fixing. -->
The error message has changed since https://github.com/django/django/pull/21317.

```diff
- Invalid setting for CustomUsersAppConfig.user_viewset: asdfasdf doesn't look like a module path
+ Invalid setting for CustomUsersAppConfig.user_viewset: No module named 'asdfasdf'
```

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
GitHub Copilot in VSCode for autocompletion.