### PR TITLE
Don't run scheduled `latest-deps.yml` workflow on forks

### DIFF
--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -21,6 +21,8 @@ permissions:
 
 jobs:
   test:
+    # Don't run scheduled workflows on forks
+    if: ${{ github.repository == 'wagtail/wagtail' }}
     name: Latest dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
My forks also runs the scheduled workflows, lets not do that.

https://github.com/Stormheg/wagtail/actions/workflows/latest-deps.yml