### PR TITLE
Apply EXIF orientation when resizing avatar uploads

### DIFF
--- a/wagtail/admin/forms/account.py
+++ b/wagtail/admin/forms/account.py
@@ -8,7 +8,7 @@ from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.utils.translation import get_language_info
 from django.utils.translation import gettext_lazy as _
-from PIL import Image
+from PIL import Image, ImageOps
 
 from wagtail.admin.localization import (
     get_available_admin_languages,
@@ -135,6 +135,8 @@ class AvatarPreferencesForm(forms.ModelForm):
             return self._original_avatar
 
         image = Image.open(file)
+        orig_format = image.format or "JPEG"
+        image = ImageOps.exif_transpose(image)
         width, height = image.size
 
         if width <= 400 and height <= 400:
@@ -151,10 +153,8 @@ class AvatarPreferencesForm(forms.ModelForm):
 
         resized_image = image.resize((new_width, new_height))
 
-        orig_format = image.format or "JPEG"
-
         output = io.BytesIO()
-        resized_image.save(output, format=image.format)
+        resized_image.save(output, format=orig_format)
         output.seek(0)
 
         new_ext = (

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -885,6 +885,27 @@ class TestAccountUploadAvatar(WagtailTestUtils, TestCase, TestAccountSectionUtil
         new_ratio = resized_image.width / resized_image.height
         self.assertAlmostEqual(original_ratio, new_ratio, places=2)
 
+    def test_avatar_resize_applies_exif_orientation(self):
+        img = Image.new("RGB", (800, 450), color="red")
+        exif = Image.Exif()
+        exif[0x0112] = 6  # EXIF orientation: rotate 90 degrees clockwise
+        img_byte_arr = io.BytesIO()
+        img.save(img_byte_arr, format="JPEG", exif=exif)
+        img_byte_arr.seek(0)
+        uploaded_file = SimpleUploadedFile(
+            name="rotated_image.jpg",
+            content=img_byte_arr.read(),
+            content_type="image/jpeg",
+        )
+
+        form = AvatarPreferencesForm(files={"avatar": uploaded_file})
+        self.assertTrue(form.is_valid())
+
+        avatar_file = form.clean_avatar()
+        resized_image = Image.open(avatar_file)
+        self.assertEqual(resized_image.size, (225, 400))
+        self.assertIsNone(resized_image.getexif().get(0x0112))
+
     def test_avatar_preserves_original_format(self):
         # Test JPG format
         jpg_file = self.create_image_file(size=(500, 500), name="test.jpg")


### PR DESCRIPTION
### Description

Avatars uploaded from phones often end up sideways: since #13515, `AvatarPreferencesForm.clean_avatar` resizes large images with Pillow, and `Image.resize()` discards the EXIF orientation tag without applying it, so the stored avatar keeps the un-rotated pixel data. The main image pipeline handles this with `willow.auto_orient()` when generating renditions, but the avatar path doesn't go through it. The fix applies `ImageOps.exif_transpose()` before the size check and resize, and saves with the format captured from the original image — the transposed copy has no `format`, so this also makes the existing `orig_format or "JPEG"` fallback effective instead of dead. Small images (400x400 or less) are still returned untouched, with their EXIF intact for the browser to handle. Added a test that uploads a JPEG with EXIF orientation 6 and asserts the resized avatar comes out portrait with no leftover orientation tag.

### AI usage

This pull request includes code written with the assistance of AI. The change and tests were reviewed and verified by me: the new test fails on `main` and passes with the fix, and the full `wagtail.admin.tests.test_account_management` module passes via `python runtests.py`.
