### PR TITLE
Fix for_explorer API filter failing when combined with ordering

### DIFF
--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -572,6 +572,28 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
 
         self.assertEqual(page_id_list, [6, 20, 4, 12, 5])
 
+    def test_for_explorer_filter_with_ordering(self):
+        # Regression test for #11859: the ChildOfFilter stores the parent page
+        # as an attribute on the queryset, which the ForExplorerFilter relies on.
+        # order_by() returns a fresh queryset that drops that attribute, so
+        # combining for_explorer with the order filter must not lose the
+        # child_of context (which previously raised a spurious 400 error).
+        movies = self.make_simple_page(Page.objects.get(pk=1), "Movies")
+        pages = [
+            self.make_simple_page(movies, "The Way of the Dragon"),
+            self.make_simple_page(movies, "Enter the Dragon"),
+            self.make_simple_page(movies, "Dragons Forever"),
+        ]
+
+        response = self.get_response(child_of=movies.pk, for_explorer=1, order="title")
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content.decode("UTF-8"))
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(
+            page_id_list,
+            [page.pk for page in sorted(pages, key=lambda page: page.title)],
+        )
+
     # HAS CHILDREN FILTER
 
     def test_has_children_filter(self):

--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -83,6 +83,12 @@ class OrderingFilter(BaseFilterBackend):
         if not order_param:
             return queryset
 
+        # order_by() returns a fresh queryset, which would drop the marker set
+        # by ChildOfFilter. Preserve it so that filters running afterwards (such
+        # as ForExplorerFilter) still have access to it, matching the handling in
+        # TranslationOfFilter and LocaleFilter.
+        _filtered_by_child_of = getattr(queryset, "_filtered_by_child_of", None)
+
         order_by_list = order_param.split(",")
 
         # Handle random ordering separately
@@ -93,23 +99,30 @@ class OrderingFilter(BaseFilterBackend):
                 )
             if "offset" in request.GET:
                 raise BadRequestError("random ordering with offset is not supported")
-            return queryset.order_by("?")
+            queryset = queryset.order_by("?")
+        else:
+            allowed_fields = view.get_available_fields(
+                queryset.model, db_fields_only=True
+            )
+            validated_fields = []
 
-        allowed_fields = view.get_available_fields(queryset.model, db_fields_only=True)
-        validated_fields = []
+            for field in order_by_list:
+                field_name = field.lstrip("-")
+                if field_name not in allowed_fields:
+                    raise BadRequestError(f"cannot order by '{field}' (unknown field)")
+                validated_fields.append(field)
 
-        for field in order_by_list:
-            field_name = field.lstrip("-")
-            if field_name not in allowed_fields:
-                raise BadRequestError(f"cannot order by '{field}' (unknown field)")
-            validated_fields.append(field)
+            try:
+                queryset = queryset.order_by(*validated_fields)
+            except FieldError as e:
+                raise BadRequestError(
+                    f"cannot order by '{order_param}' (invalid field)"
+                ) from e
 
-        try:
-            return queryset.order_by(*validated_fields)
-        except FieldError as e:
-            raise BadRequestError(
-                f"cannot order by '{order_param}' (invalid field)"
-            ) from e
+        if _filtered_by_child_of:
+            queryset._filtered_by_child_of = _filtered_by_child_of
+
+        return queryset
 
 
 class SearchFilter(BaseFilterBackend):


### PR DESCRIPTION
Fixes #11859

### Description

The admin pages API raises a spurious 400 error ("filtering by for_explorer without child_of is not supported") when a request combines `for_explorer` with the `order` parameter, e.g. `?child_of=4&for_explorer=1&order=-id`. Without `order` the same request works fine.

`ChildOfFilter` records the parent page as a `_filtered_by_child_of` attribute on the queryset, which `ForExplorerFilter` relies on later in the filter chain. `OrderingFilter` calls `queryset.order_by(...)`, which returns a fresh queryset and drops that attribute, so by the time `ForExplorerFilter` runs the context is gone.

This is the same pitfall that `TranslationOfFilter` and `LocaleFilter` already guard against by re-attaching `_filtered_by_child_of` after transforming the queryset. This change applies the same handling to `OrderingFilter` (covering both the field-ordered and random-ordering paths).

Added a regression test covering `child_of` + `for_explorer` + `order`.

### AI usage

This fix was written with the assistance of AI. I reviewed and verified it myself: I confirmed the root cause by tracing the filter-backend order (the marker is set by `ChildOfFilter`, dropped by `order_by()` in `OrderingFilter`, and read by `ForExplorerFilter`), and verified the change with a new regression test that fails before the fix (400) and passes after (200), run via `runtests.py`, plus `ruff check`/`ruff format` clean. AI assistance was also used to help draft this description.
