### PR TITLE
Fix clean_name not being set when field was saved blank before its label was filled in

### DIFF
--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -157,10 +157,8 @@ class AbstractFormField(Orderable):
         as this would invalidate any previously submitted data.
         """
 
-        is_new = self.pk is None
-        if is_new:
-            clean_name = self.get_field_clean_name()
-            self.clean_name = clean_name
+        if not self.clean_name:
+            self.clean_name = self.get_field_clean_name()
 
         super().save(*args, **kwargs)
 

--- a/wagtail/contrib/forms/tests/test_models.py
+++ b/wagtail/contrib/forms/tests/test_models.py
@@ -870,6 +870,21 @@ class TestFormFieldCleanNameCreation(WagtailTestUtils, TestCase):
 
         self.assertEqual(field.clean_name, "telefon_nummer")
 
+    def test_form_field_clean_name_set_when_blank_on_save(self):
+        """clean_name should be derived on save whenever it's still blank"""
+
+        field = FormFieldWithCustomSubmission.objects.create(
+            page=self.form_page,
+            label="",
+            field_type="number",
+        )
+        self.assertEqual(field.clean_name, "")
+
+        field.label = "Telefón-nummer"
+        field.save()
+
+        self.assertEqual(field.clean_name, "telefon_nummer")
+
 
 class TestFormFieldCleanNameCreationOverride(WagtailTestUtils, TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes https://wagtailcms.slack.com/archives/C81FGJR2S/p1782467248943829

### Description

With the new autosave functionality, a form field could be saved without populating the clean_name field. This can cause issues, because the form field will have no name yet.


### AI usage

I did not use AI for this PR
