### PR TITLE
Fix: Vector and Rect __repr__ silently truncates float coordinates

### DIFF
--- a/wagtail/images/rect.py
+++ b/wagtail/images/rect.py
@@ -16,7 +16,7 @@ class Vector:
         return tuple(self) == tuple(other)
 
     def __repr__(self):
-        return "Vector(x: %d, y: %d)" % (self.x, self.y)
+        return f"Vector(x: {self.x:g}, y: {self.y:g})"
 
 
 class Rect:
@@ -185,11 +185,9 @@ class Rect:
         return tuple(self) == tuple(other)
 
     def __repr__(self):
-        return "Rect(left: %d, top: %d, right: %d, bottom: %d)" % (
-            self.left,
-            self.top,
-            self.right,
-            self.bottom,
+        return (
+            f"Rect(left: {self.left:g}, top: {self.top:g},"
+            f" right: {self.right:g}, bottom: {self.bottom:g})"
         )
 
     @classmethod

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -712,6 +712,16 @@ class TestRect(TestCase):
             repr(rect), "Rect(left: 100, top: 150, right: 200, bottom: 250)"
         )
 
+    def test_vector_repr_with_floats(self):
+        v = Vector(1.7, 3.9)
+        self.assertEqual(repr(v), "Vector(x: 1.7, y: 3.9)")
+
+    def test_rect_repr_with_floats(self):
+        r = Rect(1.5, 3.1, 8.5, 9.7)
+        self.assertEqual(
+            repr(r), "Rect(left: 1.5, top: 3.1, right: 8.5, bottom: 9.7)"
+        )
+
     def test_from_point(self):
         rect = Rect.from_point(100, 200, 50, 20)
         self.assertEqual(rect, Rect(75, 190, 125, 210))


### PR DESCRIPTION
Fixes #14382

### Description

`Vector.__repr__` and `Rect.__repr__` use `%d` formatting, which silently
truncates float coordinates to integers. This is misleading since `_set_size()`
and `_set_centroid()` use float division, producing non-integer coordinates
that are hidden during debugging.

**Before:**
> Vector(1.7, 3.9)
Vector(x: 1, y: 3)      # wrong — truncated

**After:**
> Vector(1.7, 3.9)
Vector(x: 1.7, y: 3.9)  # correct — preserved

**Changes:**
- Replaced `%d` with f-string + `:g` format specifier in both `__repr__` methods
- `:g` preserves float precision without unnecessary trailing zeros
  (e.g. `100` instead of `100.0`)
- Added regression tests for both `Vector` and `Rect` repr with float coordinates
- All existing image tests (637) pass

### AI usage

This pull request includes code written with the assistance of AI.
This code was reviewed and verified by me.