### PR TITLE
Fix shared EditorState reference on duplicating Draftail rich text blocks

### DIFF
--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -334,6 +334,10 @@ class BoundDraftailWidget {
     return this.input.draftailEditor.getEditorState();
   }
 
+  getDuplicatedState() {
+    return this.getValue();
+  }
+
   setState(editorState) {
     this.input.draftailEditor.onChange(editorState);
   }

--- a/client/src/components/Draftail/index.test.js
+++ b/client/src/components/Draftail/index.test.js
@@ -221,4 +221,22 @@ describe('Draftail', () => {
     expect(draftail.ModalWorkflowSource).toBeDefined());
   it('#Tooltip', () => expect(draftail.Tooltip).toBeDefined());
   it('#TooltipEntity', () => expect(draftail.TooltipEntity).toBeDefined());
+
+  describe('DraftailRichTextArea', () => {
+    it('getDuplicatedState returns the serialized JSON value', () => {
+      document.body.innerHTML = '<div id="container"></div>';
+      const container = document.querySelector('#container');
+      const widget = new draftail.DraftailRichTextArea({});
+      const boundWidget = widget.render(
+        container,
+        'text',
+        'id-text',
+        '{"blocks": [{"text": "hello"}], "entityMap": {}}',
+        new Map(),
+      );
+      expect(boundWidget.getDuplicatedState()).toBe(
+        '{"blocks": [{"text": "hello"}], "entityMap": {}}',
+      );
+    });
+  });
 });


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->

Fixes #14412

### Description

This PR fixes a bug where copying/duplicating a Draftail rich text block in a StreamField results in the duplicated block sharing the same mutable `EditorState` instance as the original block.

#### The Problem:
When duplicating a block via the sequence block controls, child blocks that do not explicitly define a `getDuplicatedState` method fall back to calling `getState()`. 
For `BoundDraftailWidget`, `getState()` returns the current active `EditorState` instance of Draft.js. When this `EditorState` instance is passed as `initialState` to the duplicated block's constructor, `DraftailRichTextArea.render` detects it is an `EditorState` object and calls `setState(initialState)`, causing both widgets to share the exact same `EditorState` reference. Consequently, editing inline links (or other elements) in the duplicated block directly modifies the original block's editor state.

#### The Solution:
Implemented `getDuplicatedState()` on `BoundDraftailWidget` to return the serialized JSON representation of the editor's content state (retrieved via `this.getValue()`). This forces the new widget's initialization flow to parse the JSON string and instantiate a fresh, independent `EditorState` instance, which mimics the standard behavior of loading a page from the database and ensures no mutable references are shared.

A unit test has been added to verify that `getDuplicatedState()` correctly returns the serialized JSON representation.
