### PR TITLE
v2 API rich text support

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Changelog
  * Use a more accessible label for blank values of dropdowns in locked page report filters (Sage Abdullah)
  * Make audit log messages for scheduling/unscheduling generic (Sage Abdullah)
  * Stop converting AVIF and WebP images to PNG by default (Thibaud Colas)
+ * Add rich text serializing to HTML support in the v2 API (Thibaud Colas)
  * Fix: Make `SnippetChooserViewSet.widget_class` a class instead of an instance (Amrinder Singh, Sage Abdullah)
  * Fix: Prevent an error when approving a workflow that has been cancelled in a different session (Kailesh)
  * Fix: Accommodate multilingual sites in skipping the "choose parent" step when creating a new page from a flat page listing (Amrinder Singh)

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -247,9 +247,11 @@ This adds two fields to the API (other fields omitted for brevity):
 
 ### Rich text in the API
 
-In the above example, we serialize the `body` field using Wagtail’s storage format for rich text, described in [](../../../extending/rich_text_internals). This is useful when the API client will directly manipulate the identifiers referencing external data within rich text, such as fetching more data about page links or images by ID.
+By default, `RichTextField` values are serialized in Wagtail's database HTML format, described in [](rich_text_internals). This is useful when the API client will directly manipulate the identifiers referencing external data within rich text, such as fetching more data about page links or images by ID.
 
-It’s also often useful for the API to directly provide a “display” representation, similarly to the `|richtext` template filter. This can be done with a custom serializer:
+To return display-ready HTML instead (equivalent to the `|richtext` template filter), use the `?rich_text_format=html` query parameter or set the project-wide default with `WAGTAILAPI_RICH_TEXT_FORMAT = 'html'` in your settings. The default format is `db_html`.
+
+For per-field control regardless of the query parameter, you can still use a custom serializer that acts like the `|richtext` template filter:
 
 ```python
 from rest_framework.fields import CharField

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -245,6 +245,8 @@ This adds two fields to the API (other fields omitted for brevity):
 }
 ```
 
+(api_v2_rich_text)=
+
 ### Rich text in the API
 
 By default, `RichTextField` values are serialized in Wagtail's database HTML format, described in [](rich_text_internals). This is useful when the API client will directly manipulate the identifiers referencing external data within rich text, such as fetching more data about page links or images by ID.

--- a/docs/advanced_topics/api/v3/index.md
+++ b/docs/advanced_topics/api/v3/index.md
@@ -28,7 +28,7 @@ urlpatterns = [
 
 Browse the interactive docs at `/api/v3/docs` and the OpenAPI schema at `/api/v3/openapi.json`.
 
-The v3 API reads the same `WAGTAILAPI_*` settings as v2 where applicable (`WAGTAILAPI_BASE_URL`, `WAGTAILAPI_LIMIT_MAX`, `WAGTAILAPI_SEARCH_ENABLED`). See [](api_v2_configuration) and the [API settings reference](/reference/settings).
+The v3 API reads the same `WAGTAILAPI_*` settings as v2 where applicable (`WAGTAILAPI_BASE_URL`, `WAGTAILAPI_LIMIT_MAX`, `WAGTAILAPI_SEARCH_ENABLED`, `WAGTAILAPI_RICH_TEXT_FORMAT`). See [](api_v2_configuration) and the [API settings reference](wagtailapi_settings).
 
 ## Pagination
 
@@ -41,7 +41,9 @@ List endpoints use Django Ninja's limit/offset pagination:
 }
 ```
 
-`count` is the total number of results irrespective of pagination. Use `?limit` and `?offset` query parameters to page through results. `WAGTAILAPI_LIMIT_MAX` caps the maximum `limit` value (see [](api_v2_configuration) and the [API settings reference](/reference/settings)).
+`count` is the total number of results irrespective of pagination. Use `?limit` and `?offset` query parameters to page through results. `WAGTAILAPI_LIMIT_MAX` caps the maximum `limit` value (see [](api_v2_configuration) and the [API settings reference](wagtailapi_settings)).
+
+Rich text fields use the `?rich_text_format=` query parameter, which supports the same options as the project-level default of `WAGTAILAPI_RICH_TEXT_FORMAT`.
 
 ## Error format
 

--- a/docs/extending/rich_text_internals.md
+++ b/docs/extending/rich_text_internals.md
@@ -1,3 +1,5 @@
+(rich_text_internals)=
+
 # Rich text internals
 
 At first glance, Wagtail's rich text capabilities appear to give editors direct control over a block of HTML content. In reality, it's necessary to give editors a representation of rich text content that is several steps removed from the final HTML output, for several reasons:

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -902,6 +902,14 @@ WAGTAILAPI_USE_FRONTENDCACHE = True
 
 Requires `wagtailfrontendcache` app to be installed, indicates the API should use the frontend cache.
 
+### `WAGTAILAPI_RICH_TEXT_FORMAT`
+
+```python
+WAGTAILAPI_RICH_TEXT_FORMAT = 'html'
+```
+
+Format for rich text content in the API. Defaults to `db_html`, which returns rich text in Wagtail's database HTML format (see [](rich_text_internals)). Set to `html` to use display-ready HTML instead. This applies to `RichTextField` values on all API endpoints. The `?rich_text_format=` query parameter overrides this setting on individual requests.
+
 ## Frontend cache
 
 For full documentation on frontend cache invalidation, including these settings, see [](frontend_cache_purging).

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -39,6 +39,7 @@ For more details, refer to the [](permissions_reference) reference documentation
  * Use a more accessible label for blank values of dropdowns in locked page report filters (Sage Abdullah)
  * Make audit log messages for scheduling/unscheduling generic (Sage Abdullah)
  * Stop converting AVIF and WebP images to PNG by default (Thibaud Colas)
+ * Add rich text [serializing to HTML](api_v2_rich_text) support in the v2 API (Thibaud Colas)
 
 ### Bug fixes
 

--- a/wagtail/api/rich_text.py
+++ b/wagtail/api/rich_text.py
@@ -1,0 +1,97 @@
+from collections.abc import Callable
+from typing import Any
+
+from django.conf import settings
+from django.http import HttpRequest
+
+from wagtail.rich_text import expand_db_html
+
+
+class RichTextFormatError(Exception):
+    pass
+
+
+class APIRichText:
+    """
+    Resolves and applies rich text output formats for API responses.
+
+    Built-in formats:
+
+    - ``db_html``: Wagtail database HTML (default)
+    - ``html``: display HTML via ``expand_db_html()``
+
+    To add formats (for example ``markdown`` or ``content_state``), extend
+    :meth:`_serializers` and add a corresponding ``_serialize_*`` method.
+    """
+
+    FORMAT_DB_HTML = "db_html"
+    FORMAT_HTML = "html"
+
+    DEFAULT_FORMAT = FORMAT_DB_HTML
+    SETTING_NAME = "WAGTAILAPI_RICH_TEXT_FORMAT"
+    QUERY_PARAMETER = "rich_text_format"
+
+    @classmethod
+    def formats(cls) -> frozenset[str]:
+        return frozenset(cls._serializers())
+
+    @classmethod
+    def get_default_format(cls) -> str:
+        rich_text_format = getattr(settings, cls.SETTING_NAME, cls.DEFAULT_FORMAT)
+        cls._validate_format(rich_text_format, source=cls.SETTING_NAME)
+        return rich_text_format
+
+    @classmethod
+    def resolve_format(cls, request: HttpRequest | None = None) -> str:
+        """
+        Return the rich text output format for this request.
+
+        The ``?rich_text_format=`` query parameter takes precedence over
+        ``WAGTAILAPI_RICH_TEXT_FORMAT``.
+        """
+        if request is not None and cls.QUERY_PARAMETER in request.GET:
+            rich_text_format = request.GET[cls.QUERY_PARAMETER]
+            cls._validate_format(rich_text_format, source=cls.QUERY_PARAMETER)
+            return rich_text_format
+
+        return cls.get_default_format()
+
+    @classmethod
+    def serialize(cls, value: str | None, *, format: str) -> Any:
+        if value is None:
+            return None
+
+        cls._validate_format(format, source="format")
+        return cls._serializers()[format](value)
+
+    @classmethod
+    def _serializers(cls) -> dict[str, Callable[[str], Any]]:
+        return {
+            cls.FORMAT_DB_HTML: cls._serialize_db_html,
+            cls.FORMAT_HTML: cls._serialize_html,
+        }
+
+    @staticmethod
+    def _serialize_db_html(value: str) -> str:
+        return value
+
+    @staticmethod
+    def _serialize_html(value: str) -> str:
+        return expand_db_html(value)
+
+    @classmethod
+    def _validate_format(cls, rich_text_format: str, *, source: str) -> None:
+        if rich_text_format in cls._serializers():
+            return
+
+        allowed = ", ".join(f"'{name}'" for name in sorted(cls._serializers()))
+        if source == cls.SETTING_NAME:
+            message = (
+                f"{cls.SETTING_NAME} must be one of {allowed}, got '{rich_text_format}'"
+            )
+        elif source == cls.QUERY_PARAMETER:
+            message = f"{cls.QUERY_PARAMETER} must be one of {allowed}, got '{rich_text_format}'"
+        else:
+            message = f"Unknown rich text format '{rich_text_format}'"
+
+        raise RichTextFormatError(message)

--- a/wagtail/api/rich_text.py
+++ b/wagtail/api/rich_text.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from typing import Any
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 from wagtail.rich_text import expand_db_html
 
@@ -30,14 +31,24 @@ class APIRichText:
     SETTING_NAME = "WAGTAILAPI_RICH_TEXT_FORMAT"
 
     @classmethod
-    def formats(cls) -> frozenset[str]:
-        return frozenset(cls._serializers())
+    def check_setting(cls) -> None:
+        """
+        Validate ``WAGTAILAPI_RICH_TEXT_FORMAT``.
+
+        Called at app startup; raises ``ImproperlyConfigured`` if invalid.
+        """
+        rich_text_format = getattr(settings, cls.SETTING_NAME, cls.DEFAULT_FORMAT)
+        if rich_text_format in cls._serializers():
+            return
+
+        allowed = ", ".join(f"'{name}'" for name in sorted(cls._serializers()))
+        raise ImproperlyConfigured(
+            f"{cls.SETTING_NAME} must be one of {allowed}, got '{rich_text_format}'"
+        )
 
     @classmethod
     def get_default_format(cls) -> str:
-        rich_text_format = getattr(settings, cls.SETTING_NAME, cls.DEFAULT_FORMAT)
-        cls._validate_format(rich_text_format, source=cls.SETTING_NAME)
-        return rich_text_format
+        return getattr(settings, cls.SETTING_NAME, cls.DEFAULT_FORMAT)
 
     @classmethod
     def resolve_format(cls, rich_text_format: str | None = None) -> str:
@@ -57,10 +68,15 @@ class APIRichText:
 
     @classmethod
     def serialize(cls, value: str | None, *, format: str) -> Any:
+        """
+        Serialize ``value`` using a previously validated ``format``.
+
+        Callers must resolve the format via :meth:`resolve_format` (or
+        :meth:`check_setting` for the project default) before calling this.
+        """
         if value is None:
             return None
 
-        cls._validate_format(format, source="format")
         return cls._serializers()[format](value)
 
     @classmethod
@@ -79,22 +95,11 @@ class APIRichText:
         return expand_db_html(value)
 
     @classmethod
-    def _validate_format(
-        cls, rich_text_format: str, *, source: str | None = None
-    ) -> None:
+    def _validate_format(cls, rich_text_format: str) -> None:
         if rich_text_format in cls._serializers():
             return
 
         allowed = ", ".join(f"'{name}'" for name in sorted(cls._serializers()))
-        if source == cls.SETTING_NAME:
-            message = (
-                f"{cls.SETTING_NAME} must be one of {allowed}, got '{rich_text_format}'"
-            )
-        elif source is not None:
-            message = f"Unknown rich text format '{rich_text_format}'"
-        else:
-            message = (
-                f"rich_text_format must be one of {allowed}, got '{rich_text_format}'"
-            )
-
-        raise RichTextFormatError(message)
+        raise RichTextFormatError(
+            f"rich_text_format must be one of {allowed}, got '{rich_text_format}'"
+        )

--- a/wagtail/api/rich_text.py
+++ b/wagtail/api/rich_text.py
@@ -2,7 +2,6 @@ from collections.abc import Callable
 from typing import Any
 
 from django.conf import settings
-from django.http import HttpRequest
 
 from wagtail.rich_text import expand_db_html
 
@@ -29,7 +28,6 @@ class APIRichText:
 
     DEFAULT_FORMAT = FORMAT_DB_HTML
     SETTING_NAME = "WAGTAILAPI_RICH_TEXT_FORMAT"
-    QUERY_PARAMETER = "rich_text_format"
 
     @classmethod
     def formats(cls) -> frozenset[str]:
@@ -42,16 +40,17 @@ class APIRichText:
         return rich_text_format
 
     @classmethod
-    def resolve_format(cls, request: HttpRequest | None = None) -> str:
+    def resolve_format(cls, rich_text_format: str | None = None) -> str:
         """
         Return the rich text output format for this request.
 
-        The ``?rich_text_format=`` query parameter takes precedence over
-        ``WAGTAILAPI_RICH_TEXT_FORMAT``.
+        When ``rich_text_format`` is provided (e.g. from a query parameter),
+        it is validated and takes precedence over
+        ``WAGTAILAPI_RICH_TEXT_FORMAT``. When ``None``, falls back to the
+        project-wide default.
         """
-        if request is not None and cls.QUERY_PARAMETER in request.GET:
-            rich_text_format = request.GET[cls.QUERY_PARAMETER]
-            cls._validate_format(rich_text_format, source=cls.QUERY_PARAMETER)
+        if rich_text_format is not None:
+            cls._validate_format(rich_text_format)
             return rich_text_format
 
         return cls.get_default_format()
@@ -80,7 +79,9 @@ class APIRichText:
         return expand_db_html(value)
 
     @classmethod
-    def _validate_format(cls, rich_text_format: str, *, source: str) -> None:
+    def _validate_format(
+        cls, rich_text_format: str, *, source: str | None = None
+    ) -> None:
         if rich_text_format in cls._serializers():
             return
 
@@ -89,9 +90,11 @@ class APIRichText:
             message = (
                 f"{cls.SETTING_NAME} must be one of {allowed}, got '{rich_text_format}'"
             )
-        elif source == cls.QUERY_PARAMETER:
-            message = f"{cls.QUERY_PARAMETER} must be one of {allowed}, got '{rich_text_format}'"
-        else:
+        elif source is not None:
             message = f"Unknown rich text format '{rich_text_format}'"
+        else:
+            message = (
+                f"rich_text_format must be one of {allowed}, got '{rich_text_format}'"
+            )
 
         raise RichTextFormatError(message)

--- a/wagtail/api/tests/test_rich_text_format.py
+++ b/wagtail/api/tests/test_rich_text_format.py
@@ -1,0 +1,61 @@
+from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
+
+from wagtail.api.rich_text import APIRichText, RichTextFormatError
+from wagtail.api.v2.serializers import RichTextFieldSerializer
+from wagtail.models import Page
+
+
+class TestRichTextFormatResolution(SimpleTestCase):
+    def setUp(self):
+        self.request_factory = RequestFactory()
+
+    def test_default_format_is_db_html(self):
+        self.assertEqual(APIRichText.get_default_format(), APIRichText.DEFAULT_FORMAT)
+
+    @override_settings(WAGTAILAPI_RICH_TEXT_FORMAT="html")
+    def test_setting_overrides_default(self):
+        self.assertEqual(APIRichText.get_default_format(), "html")
+
+    def test_query_parameter_overrides_setting(self):
+        request = self.request_factory.get("/", {"rich_text_format": "html"})
+        with override_settings(WAGTAILAPI_RICH_TEXT_FORMAT="db_html"):
+            self.assertEqual(APIRichText.resolve_format(request), "html")
+
+    def test_invalid_query_parameter_raises(self):
+        request = self.request_factory.get("/", {"rich_text_format": "markdown"})
+        with self.assertRaises(RichTextFormatError) as cm:
+            APIRichText.resolve_format(request)
+        self.assertIn("markdown", str(cm.exception))
+
+    @override_settings(WAGTAILAPI_RICH_TEXT_FORMAT="invalid")
+    def test_invalid_setting_raises(self):
+        with self.assertRaises(RichTextFormatError) as cm:
+            APIRichText.get_default_format()
+        self.assertIn("invalid", str(cm.exception))
+
+
+class TestSerializeRichText(TestCase):
+    fixtures = ["test.json"]
+
+    def test_db_html_returns_value_unchanged(self):
+        value = '<p><a linktype="page" id="4">Events</a></p>'
+        self.assertEqual(
+            APIRichText.serialize(value, format=APIRichText.FORMAT_DB_HTML),
+            value,
+        )
+
+    def test_html_expands_entity_references(self):
+        page = Page.objects.get(url_path="/home/events/")
+        value = f'<p><a linktype="page" id="{page.id}">Events</a></p>'
+        result = APIRichText.serialize(value, format="html")
+        self.assertIn('href="/events/"', result)
+        self.assertNotIn("linktype=", result)
+
+    def test_none_returns_none(self):
+        self.assertIsNone(APIRichText.serialize(None, format="html"))
+
+
+class TestRichTextFieldSerializer(SimpleTestCase):
+    def test_accepts_text_field_kwargs(self):
+        field = RichTextFieldSerializer(max_length=120)
+        self.assertEqual(field.max_length, 120)

--- a/wagtail/api/tests/test_rich_text_format.py
+++ b/wagtail/api/tests/test_rich_text_format.py
@@ -1,4 +1,4 @@
-from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 
 from wagtail.api.rich_text import APIRichText, RichTextFormatError
 from wagtail.api.v2.serializers import RichTextFieldSerializer
@@ -6,9 +6,6 @@ from wagtail.models import Page
 
 
 class TestRichTextFormatResolution(SimpleTestCase):
-    def setUp(self):
-        self.request_factory = RequestFactory()
-
     def test_default_format_is_db_html(self):
         self.assertEqual(APIRichText.get_default_format(), APIRichText.DEFAULT_FORMAT)
 
@@ -17,15 +14,14 @@ class TestRichTextFormatResolution(SimpleTestCase):
         self.assertEqual(APIRichText.get_default_format(), "html")
 
     def test_query_parameter_overrides_setting(self):
-        request = self.request_factory.get("/", {"rich_text_format": "html"})
         with override_settings(WAGTAILAPI_RICH_TEXT_FORMAT="db_html"):
-            self.assertEqual(APIRichText.resolve_format(request), "html")
+            self.assertEqual(APIRichText.resolve_format("html"), "html")
 
     def test_invalid_query_parameter_raises(self):
-        request = self.request_factory.get("/", {"rich_text_format": "markdown"})
+        request = self.request_factory.get("/", {"rich_text_format": "invalid"})
         with self.assertRaises(RichTextFormatError) as cm:
             APIRichText.resolve_format(request)
-        self.assertIn("markdown", str(cm.exception))
+        self.assertIn("invalid", str(cm.exception))
 
     @override_settings(WAGTAILAPI_RICH_TEXT_FORMAT="invalid")
     def test_invalid_setting_raises(self):
@@ -47,9 +43,10 @@ class TestSerializeRichText(TestCase):
     def test_html_expands_entity_references(self):
         page = Page.objects.get(url_path="/home/events/")
         value = f'<p><a linktype="page" id="{page.id}">Events</a></p>'
-        result = APIRichText.serialize(value, format="html")
-        self.assertIn('href="/events/"', result)
-        self.assertNotIn("linktype=", result)
+        self.assertEqual(
+            APIRichText.serialize(value, format="html"),
+            '<p><a href="/events/">Events</a></p>',
+        )
 
     def test_none_returns_none(self):
         self.assertIsNone(APIRichText.serialize(None, format="html"))

--- a/wagtail/api/tests/test_rich_text_format.py
+++ b/wagtail/api/tests/test_rich_text_format.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase, TestCase, override_settings
 
 from wagtail.api.rich_text import APIRichText, RichTextFormatError
@@ -18,16 +19,16 @@ class TestRichTextFormatResolution(SimpleTestCase):
             self.assertEqual(APIRichText.resolve_format("html"), "html")
 
     def test_invalid_query_parameter_raises(self):
-        request = self.request_factory.get("/", {"rich_text_format": "invalid"})
         with self.assertRaises(RichTextFormatError) as cm:
-            APIRichText.resolve_format(request)
+            APIRichText.resolve_format("invalid")
         self.assertIn("invalid", str(cm.exception))
 
     @override_settings(WAGTAILAPI_RICH_TEXT_FORMAT="invalid")
     def test_invalid_setting_raises(self):
-        with self.assertRaises(RichTextFormatError) as cm:
-            APIRichText.get_default_format()
+        with self.assertRaises(ImproperlyConfigured) as cm:
+            APIRichText.check_setting()
         self.assertIn("invalid", str(cm.exception))
+        self.assertIn(APIRichText.SETTING_NAME, str(cm.exception))
 
 
 class TestSerializeRichText(TestCase):

--- a/wagtail/api/v2/apps.py
+++ b/wagtail/api/v2/apps.py
@@ -10,6 +10,10 @@ class WagtailAPIV2AppConfig(AppConfig):
     verbose_name = _("Wagtail API v2")
 
     def ready(self):
+        from wagtail.api.rich_text import APIRichText
+
+        APIRichText.check_setting()
+
         # Install cache purging signal handlers
         if getattr(settings, "WAGTAILAPI_USE_FRONTENDCACHE", False):
             if apps.is_installed("wagtail.contrib.frontend_cache"):

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -7,6 +7,7 @@ from rest_framework.fields import Field, SkipField
 from taggit.managers import _TaggableManager
 
 from wagtail import fields as wagtailcore_fields
+from wagtail.api.rich_text import APIRichText
 
 from .utils import get_object_detail_url
 
@@ -265,6 +266,23 @@ class StreamField(Field):
         return value.stream_block.get_api_representation(value, self.context)
 
 
+class RichTextFieldSerializer(serializers.CharField):
+    """
+    Serializes RichTextField values.
+
+    Output format is controlled by the ``?rich_text_format=`` query parameter
+    or the ``WAGTAILAPI_RICH_TEXT_FORMAT`` setting (default: ``db_html``).
+    """
+
+    def to_representation(self, value):
+        rich_text_format = self.context.setdefault(
+            "_wagtail_rich_text_format",
+            APIRichText.resolve_format(self.context.get("request")),
+        )
+        representation = super().to_representation(value)
+        return APIRichText.serialize(representation, format=rich_text_format)
+
+
 class TagsField(Field):
     """
     Serializes django-taggit TaggableManager fields.
@@ -290,6 +308,7 @@ class BaseSerializer(serializers.ModelSerializer):
     serializer_field_mapping.update(
         {
             wagtailcore_fields.StreamField: StreamField,
+            wagtailcore_fields.RichTextField: RichTextFieldSerializer,
         }
     )
     serializer_related_field = RelatedField

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -275,10 +275,10 @@ class RichTextFieldSerializer(serializers.CharField):
     """
 
     def to_representation(self, value):
-        rich_text_format = self.context.setdefault(
-            "_wagtail_rich_text_format",
-            APIRichText.resolve_format(self.context.get("request")),
-        )
+        rich_text_format = self.context.get("_wagtail_rich_text_format")
+        if rich_text_format is None:
+            rich_text_format = APIRichText.resolve_format(self.context.get("request"))
+            self.context["_wagtail_rich_text_format"] = rich_text_format
         representation = super().to_representation(value)
         return APIRichText.serialize(representation, format=rich_text_format)
 

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -277,7 +277,9 @@ class RichTextFieldSerializer(serializers.CharField):
     def to_representation(self, value):
         rich_text_format = self.context.get("_wagtail_rich_text_format")
         if rich_text_format is None:
-            rich_text_format = APIRichText.resolve_format(self.context.get("request"))
+            request = self.context.get("request")
+            raw = request.GET.get("rich_text_format") if request else None
+            rich_text_format = APIRichText.resolve_format(raw)
             self.context["_wagtail_rich_text_format"] = rich_text_format
         representation = super().to_representation(value)
         return APIRichText.serialize(representation, format=rich_text_format)

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -275,6 +275,7 @@ class RichTextFieldSerializer(serializers.CharField):
     """
 
     def to_representation(self, value):
+        # Prefer the format resolved by BaseAPIViewSet; fall back for other callers.
         rich_text_format = self.context.get("_wagtail_rich_text_format")
         if rich_text_format is None:
             request = self.context.get("request")

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1712,6 +1712,69 @@ class TestPageDetail(TestCase):
             ],
         )
 
+    def test_rich_text_format_defaults_to_db_html(self):
+        blog_index = models.BlogIndexPage.objects.get(id=5)
+        db_html = f'<p>Read more on the <a linktype="page" id="{blog_index.id}">blog index</a>.</p>'
+        models.BlogEntryPage.objects.filter(id=16).update(body=db_html)
+
+        content = json.loads(
+            self.get_response(16, fields="body").content.decode("UTF-8")
+        )
+
+        self.assertEqual(content["body"], db_html)
+
+    def test_rich_text_format_html_expands_entity_references(self):
+        blog_index = models.BlogIndexPage.objects.get(id=5)
+        db_html = f'<p>Read more on the <a linktype="page" id="{blog_index.id}">blog index</a>.</p>'
+        models.BlogEntryPage.objects.filter(id=16).update(body=db_html)
+
+        content = json.loads(
+            self.get_response(
+                16, fields="body", rich_text_format="html"
+            ).content.decode("UTF-8")
+        )
+
+        self.assertIn("/blog-index/", content["body"])
+        self.assertNotIn("linktype=", content["body"])
+
+    @override_settings(WAGTAILAPI_RICH_TEXT_FORMAT="html")
+    def test_rich_text_format_project_setting(self):
+        blog_index = models.BlogIndexPage.objects.get(id=5)
+        db_html = f'<p>Read more on the <a linktype="page" id="{blog_index.id}">blog index</a>.</p>'
+        models.BlogEntryPage.objects.filter(id=16).update(body=db_html)
+
+        content = json.loads(
+            self.get_response(16, fields="body").content.decode("UTF-8")
+        )
+
+        self.assertIn("/blog-index/", content["body"])
+
+    def test_rich_text_format_query_parameter_overrides_setting(self):
+        blog_index = models.BlogIndexPage.objects.get(id=5)
+        db_html = f'<p>Read more on the <a linktype="page" id="{blog_index.id}">blog index</a>.</p>'
+        models.BlogEntryPage.objects.filter(id=16).update(body=db_html)
+
+        with override_settings(WAGTAILAPI_RICH_TEXT_FORMAT="html"):
+            content = json.loads(
+                self.get_response(
+                    16, fields="body", rich_text_format="db_html"
+                ).content.decode("UTF-8")
+            )
+
+        self.assertEqual(content["body"], db_html)
+
+    def test_invalid_rich_text_format_gives_error(self):
+        response = self.get_response(16, rich_text_format="markdown")
+        content = json.loads(response.content.decode("UTF-8"))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            content,
+            {
+                "message": "rich_text_format must be one of 'db_html', 'html', got 'markdown'"
+            },
+        )
+
 
 class TestPageFind(TestCase):
     fixtures = ["demosite.json"]

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1763,6 +1763,18 @@ class TestPageDetail(TestCase):
 
         self.assertEqual(content["body"], db_html)
 
+    def test_invalid_rich_text_format_gives_error(self):
+        response = self.get_response(16, rich_text_format="markdown")
+        content = json.loads(response.content.decode("UTF-8"))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            content,
+            {
+                "message": "rich_text_format must be one of 'db_html', 'html', got 'markdown'"
+            },
+        )
+
 
 class TestPageFind(TestCase):
     fixtures = ["demosite.json"]

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1843,6 +1843,18 @@ class TestPageDetail(PageFixturesMixin, TestCase):
 
         self.assertEqual(content["body"], db_html)
 
+    def test_invalid_rich_text_format_gives_error(self):
+        response = self.get_response(16, rich_text_format="markdown")
+        content = json.loads(response.content.decode("UTF-8"))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            content,
+            {
+                "message": "rich_text_format must be one of 'db_html', 'html', got 'markdown'"
+            },
+        )
+
 
 class TestPageFind(PageFixturesMixin, TestCase):
     fixtures = ["demosite.json"]

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1792,6 +1792,69 @@ class TestPageDetail(PageFixturesMixin, TestCase):
             ],
         )
 
+    def test_rich_text_format_defaults_to_db_html(self):
+        blog_index = models.BlogIndexPage.objects.get(id=5)
+        db_html = f'<p>Read more on the <a linktype="page" id="{blog_index.id}">blog index</a>.</p>'
+        models.BlogEntryPage.objects.filter(id=16).update(body=db_html)
+
+        content = json.loads(
+            self.get_response(16, fields="body").content.decode("UTF-8")
+        )
+
+        self.assertEqual(content["body"], db_html)
+
+    def test_rich_text_format_html_expands_entity_references(self):
+        blog_index = models.BlogIndexPage.objects.get(id=5)
+        db_html = f'<p>Read more on the <a linktype="page" id="{blog_index.id}">blog index</a>.</p>'
+        models.BlogEntryPage.objects.filter(id=16).update(body=db_html)
+
+        content = json.loads(
+            self.get_response(
+                16, fields="body", rich_text_format="html"
+            ).content.decode("UTF-8")
+        )
+
+        self.assertIn("/blog-index/", content["body"])
+        self.assertNotIn("linktype=", content["body"])
+
+    @override_settings(WAGTAILAPI_RICH_TEXT_FORMAT="html")
+    def test_rich_text_format_project_setting(self):
+        blog_index = models.BlogIndexPage.objects.get(id=5)
+        db_html = f'<p>Read more on the <a linktype="page" id="{blog_index.id}">blog index</a>.</p>'
+        models.BlogEntryPage.objects.filter(id=16).update(body=db_html)
+
+        content = json.loads(
+            self.get_response(16, fields="body").content.decode("UTF-8")
+        )
+
+        self.assertIn("/blog-index/", content["body"])
+
+    def test_rich_text_format_query_parameter_overrides_setting(self):
+        blog_index = models.BlogIndexPage.objects.get(id=5)
+        db_html = f'<p>Read more on the <a linktype="page" id="{blog_index.id}">blog index</a>.</p>'
+        models.BlogEntryPage.objects.filter(id=16).update(body=db_html)
+
+        with override_settings(WAGTAILAPI_RICH_TEXT_FORMAT="html"):
+            content = json.loads(
+                self.get_response(
+                    16, fields="body", rich_text_format="db_html"
+                ).content.decode("UTF-8")
+            )
+
+        self.assertEqual(content["body"], db_html)
+
+    def test_invalid_rich_text_format_gives_error(self):
+        response = self.get_response(16, rich_text_format="markdown")
+        content = json.loads(response.content.decode("UTF-8"))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            content,
+            {
+                "message": "rich_text_format must be one of 'db_html', 'html', got 'markdown'"
+            },
+        )
+
 
 class TestPageFind(PageFixturesMixin, TestCase):
     fixtures = ["demosite.json"]

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1843,18 +1843,6 @@ class TestPageDetail(PageFixturesMixin, TestCase):
 
         self.assertEqual(content["body"], db_html)
 
-    def test_invalid_rich_text_format_gives_error(self):
-        response = self.get_response(16, rich_text_format="markdown")
-        content = json.loads(response.content.decode("UTF-8"))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            content,
-            {
-                "message": "rich_text_format must be one of 'db_html', 'html', got 'markdown'"
-            },
-        )
-
 
 class TestPageFind(PageFixturesMixin, TestCase):
     fixtures = ["demosite.json"]

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1763,18 +1763,6 @@ class TestPageDetail(TestCase):
 
         self.assertEqual(content["body"], db_html)
 
-    def test_invalid_rich_text_format_gives_error(self):
-        response = self.get_response(16, rich_text_format="markdown")
-        content = json.loads(response.content.decode("UTF-8"))
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            content,
-            {
-                "message": "rich_text_format must be one of 'db_html', 'html', got 'markdown'"
-            },
-        )
-
 
 class TestPageFind(TestCase):
     fixtures = ["demosite.json"]

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -14,6 +14,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from wagtail.api import APIField
+from wagtail.api.rich_text import APIRichText, RichTextFormatError
 from wagtail.models import Page, Site
 
 from .filters import (
@@ -62,6 +63,7 @@ class BaseAPIViewSet(GenericViewSet):
             "order",
             "search",
             "search_operator",
+            "rich_text_format",
             # Used by jQuery for cache-busting. See #1671
             "_",
             # Required by BrowsableAPIRenderer
@@ -102,6 +104,7 @@ class BaseAPIViewSet(GenericViewSet):
         return self._cached_object
 
     def detail_view(self, request, pk):
+        self.validate_rich_text_format()
         instance = self.get_object()
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
@@ -243,6 +246,17 @@ class BaseAPIViewSet(GenericViewSet):
                 "query parameter is not an operation or a recognised field: %s"
                 % ", ".join(sorted(unknown_parameters))
             )
+
+        self.validate_rich_text_format()
+
+    def validate_rich_text_format(self):
+        if "rich_text_format" not in self.request.GET:
+            return
+
+        try:
+            APIRichText.resolve_format(self.request)
+        except RichTextFormatError as exc:
+            raise BadRequestError(str(exc)) from exc
 
     @classmethod
     def _get_serializer_class(

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -107,7 +107,6 @@ class BaseAPIViewSet(GenericViewSet):
         return self._cached_object
 
     def detail_view(self, request, pk):
-        self.validate_rich_text_format()
         instance = self.get_object()
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
@@ -249,17 +248,6 @@ class BaseAPIViewSet(GenericViewSet):
                 "query parameter is not an operation or a recognised field: %s"
                 % ", ".join(sorted(unknown_parameters))
             )
-
-        self.validate_rich_text_format()
-
-    def validate_rich_text_format(self):
-        if "rich_text_format" not in self.request.GET:
-            return
-
-        try:
-            APIRichText.resolve_format(self.request)
-        except RichTextFormatError as exc:
-            raise BadRequestError(str(exc)) from exc
 
     @classmethod
     def _get_serializer_class(

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -403,7 +403,21 @@ class BaseAPIViewSet(GenericViewSet):
             "request": self.request,
             "view": self,
             "router": self.request.wagtailapi_router,
+            "_wagtail_rich_text_format": self.resolve_rich_text_format(),
         }
+
+    def resolve_rich_text_format(self):
+        """
+        Resolve and validate ``?rich_text_format=`` for this request.
+
+        This is the single validation point for API requests; serializers
+        should use the value from the serializer context.
+        """
+        raw = self.request.GET.get("rich_text_format")
+        try:
+            return APIRichText.resolve_format(raw)
+        except RichTextFormatError as exc:
+            raise BadRequestError(str(exc)) from exc
 
     def get_renderer_context(self):
         context = super().get_renderer_context()

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -14,6 +14,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from wagtail.api import APIField
+from wagtail.api.rich_text import APIRichText, RichTextFormatError
 from wagtail.models import Page, Site
 
 from .filters import (
@@ -399,7 +400,21 @@ class BaseAPIViewSet(GenericViewSet):
             "request": self.request,
             "view": self,
             "router": self.request.wagtailapi_router,
+            "_wagtail_rich_text_format": self.resolve_rich_text_format(),
         }
+
+    def resolve_rich_text_format(self):
+        """
+        Resolve and validate ``?rich_text_format=`` for this request.
+
+        This is the single validation point for API requests; serializers
+        should use the value from the serializer context.
+        """
+        raw = self.request.GET.get("rich_text_format")
+        try:
+            return APIRichText.resolve_format(raw)
+        except RichTextFormatError as exc:
+            raise BadRequestError(str(exc)) from exc
 
     def get_renderer_context(self):
         context = super().get_renderer_context()

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -14,7 +14,6 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from wagtail.api import APIField
-from wagtail.api.rich_text import APIRichText, RichTextFormatError
 from wagtail.models import Page, Site
 
 from .filters import (
@@ -104,7 +103,6 @@ class BaseAPIViewSet(GenericViewSet):
         return self._cached_object
 
     def detail_view(self, request, pk):
-        self.validate_rich_text_format()
         instance = self.get_object()
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
@@ -246,17 +244,6 @@ class BaseAPIViewSet(GenericViewSet):
                 "query parameter is not an operation or a recognised field: %s"
                 % ", ".join(sorted(unknown_parameters))
             )
-
-        self.validate_rich_text_format()
-
-    def validate_rich_text_format(self):
-        if "rich_text_format" not in self.request.GET:
-            return
-
-        try:
-            APIRichText.resolve_format(self.request)
-        except RichTextFormatError as exc:
-            raise BadRequestError(str(exc)) from exc
 
     @classmethod
     def _get_serializer_class(

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -16,6 +16,7 @@ from rest_framework.viewsets import GenericViewSet
 
 from wagtail.api import APIField
 from wagtail.api.querysets import get_public_pages_queryset
+from wagtail.api.rich_text import APIRichText, RichTextFormatError
 from wagtail.models import Site
 
 from .filters import (
@@ -65,6 +66,7 @@ class BaseAPIViewSet(GenericViewSet):
             "order",
             "search",
             "search_operator",
+            "rich_text_format",
             # Used by jQuery for cache-busting. See #1671
             "_",
             # Required by BrowsableAPIRenderer
@@ -105,6 +107,7 @@ class BaseAPIViewSet(GenericViewSet):
         return self._cached_object
 
     def detail_view(self, request, pk):
+        self.validate_rich_text_format()
         instance = self.get_object()
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
@@ -246,6 +249,17 @@ class BaseAPIViewSet(GenericViewSet):
                 "query parameter is not an operation or a recognised field: %s"
                 % ", ".join(sorted(unknown_parameters))
             )
+
+        self.validate_rich_text_format()
+
+    def validate_rich_text_format(self):
+        if "rich_text_format" not in self.request.GET:
+            return
+
+        try:
+            APIRichText.resolve_format(self.request)
+        except RichTextFormatError as exc:
+            raise BadRequestError(str(exc)) from exc
 
     @classmethod
     def _get_serializer_class(


### PR DESCRIPTION
Part of #14295. Implements the elements of #14307 that can be done without hooking into the v3 API specifically. Instead, they’re implemented on the v2 API.

v3 API "read" integration should be a matter:

- Add `rich_text_format` support to endpoints
- Validate the requested rich text formats
- Serialize with it

For the v3 "write" integration there will be more schema work in addition.

## Testing this

This is largely reliant on unit tests but to test manually, hit bakerydemo’s v2 page detail endpoint:

```bash
curl http://localhost:8001/api/v2/pages/60/\?rich_text_format\=html | jq '.lead_text'
curl http://localhost:8001/api/v2/pages/60/\?rich_text_format\=db_html | jq '.lead_text'
```

`db_html` will match DB contents. `html` will match `expand_db_html`:

```html
<p data-block-key="v9cww"><a href="/documents/2/Cookbook_Skillet_Cornbread_CUlyevp.pdf">Document</a>, <a href="/">page link</a>, <a href="https://wagtail.org/newsletter/">external link</a>, <a href="mailto:test@example.com">email link</a>, <a href="#test">anchor link</a>, <a href="tel:+447575757575">telephone</a></p><p data-block-key="ec7sk"><b>Bold</b>, <i>italic, </i><b><i>bold italic</i></b></p><ul><li data-block-key="aqq70"><b><i>List</i></b></li></ul><hr/><h2 data-block-key="7kpda">Line<br/>break</h2><p data-block-key="9iv7a"></p><div>\n    <iframe width="200" height="113" src="https://www.youtube.com/embed/V5QKfK8b75w?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen title="Front-end architecture fundamentals for Django-powered open source apps"></iframe>\n</div>\n<p data-block-key="3lrjo"></p><img alt="potato-jesus" class="richtext-image left" height="500" src="/media/images/potato-jesus.width-500.jpg" width="500"><p data-block-key="2qmjb"></p>
```

## AI usage

Docs written without AI, the code was written with OpenCode + GLM 5.2 and manually reviewed.