### PR TITLE
Handle missing wagtail.documents in wagtail_config

### DIFF
--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -4,6 +4,7 @@ import warnings
 from urllib.parse import urljoin, urlsplit
 
 from django import template
+from django.apps import apps
 from django.conf import settings
 from django.contrib.admin.utils import quote
 from django.contrib.humanize.templatetags.humanize import intcomma, naturaltime
@@ -922,16 +923,18 @@ def get_comments_enabled():
 @register.simple_tag(takes_context=True)
 def wagtail_config(context):
     request = context["request"]
+    admin_api = {
+        "PAGES": reverse("wagtailadmin_api:pages:listing"),
+        "IMAGES": reverse("wagtailadmin_api:images:listing"),
+        "EXTRA_CHILDREN_PARAMETERS": "",
+    }
+    if apps.is_installed("wagtail.documents"):
+        admin_api["DOCUMENTS"] = reverse("wagtailadmin_api:documents:listing")
+
     config = {
         "CSRF_TOKEN": get_token(request),
         "CSRF_HEADER_NAME": HttpHeaders.parse_header_name(settings.CSRF_HEADER_NAME),
-        "ADMIN_API": {
-            "PAGES": reverse("wagtailadmin_api:pages:listing"),
-            "DOCUMENTS": reverse("wagtailadmin_api:documents:listing"),
-            "IMAGES": reverse("wagtailadmin_api:images:listing"),
-            # Used to add an extra query string on all API requests. Example value: '&order=-id'
-            "EXTRA_CHILDREN_PARAMETERS": "",
-        },
+        "ADMIN_API": admin_api,
         "ADMIN_URLS": {
             "DISMISSIBLES": reverse("wagtailadmin_dismissibles"),
             "PAGES": reverse("wagtailadmin_explore_root"),

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -3,6 +3,7 @@ import unittest
 from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 from unittest import mock
+from unittest.mock import patch
 
 from django import forms
 from django.conf import settings
@@ -1253,3 +1254,26 @@ class FormattedfieldTagTestCase(WagtailTestUtils, SimpleTestCase):
             },
             soup.attrs,
         )
+
+
+class WagtailConfigTemplateTagTest(TestCase):
+    @patch("wagtail.admin.templatetags.wagtailadmin_tags.apps.is_installed")
+    def test_wagtail_config_without_documents(self, mock_is_installed):
+        def mock_installed(app):
+            return app != "wagtail.documents"
+
+        mock_is_installed.side_effect = mock_installed
+
+        template = Template("""
+            {% load wagtailadmin_tags %}
+            {% wagtail_config as config %}
+        """)
+
+        request = get_dummy_request()
+        context = Context({"request": request})
+
+        template.render(context)
+
+        config = context["config"]
+
+        self.assertNotIn("DOCUMENTS", config["ADMIN_API"])


### PR DESCRIPTION

Fixes #14418.

### Description

When `wagtail.documents` is not installed, the `wagtail_config`
template tag always attempts to reverse the documents admin API URL,
which results in a `NoReverseMatch` exception.

This change only includes the `DOCUMENTS` admin API endpoint when
`wagtail.documents` is installed.

A regression test has been added to cover this scenario.


### AI usage

AI assistance was used to help understand the codebase, discuss implementation approaches, and review the proposed changes. The code, testing, and final changes were reviewed and validated by the author.