### PR TITLE
Fix Treebeard intersphinx references

### DIFF
--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -440,7 +440,7 @@ See also [django-treebeard](inv:treebeard:std:doc#index)'s [node API](inv:treebe
     .. method:: move(new_parent, pos=None)
 
         Move a page and all its descendants to a new parent.
-        See :meth:`django-treebeard <treebeard.models.Node.move>` for more information.
+        See :meth:`django-treebeard <treebeard.models.NodeManager.move>` for more information.
 
 
     .. automethod:: create_alias

--- a/wagtail/models/pages.py
+++ b/wagtail/models/pages.py
@@ -737,8 +737,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
           a :ref:`page_slug_changed` signal is sent
 
         New pages should be saved by passing the unsaved page instance to the
-        :meth:`~treebeard.mp_tree.MP_Node.add_child`
-        or :meth:`~treebeard.mp_tree.MP_Node.add_sibling` method of an existing page, which will correctly update
+        :meth:`~treebeard.mp_tree.MP_NodeManager.add_child`
+        or :meth:`~treebeard.mp_tree.MP_NodeManager.add_sibling` method of an existing page, which will correctly update
         the fields responsible for tracking the page's location in the tree.
 
         If ``clean=False`` is passed, the page is saved without validation. This is appropriate for updates that only


### PR DESCRIPTION
### Description

In the current stable branch of treebeard, various methods previously implemented and documented on the `Node`/`MP_Node` class are now defined on `NodeManager`/`MP_NodeManager` and thus documentation links need to be updated accordingly.

### AI usage

None
