### PR TITLE
Update readthedocs config and always enable Sphinx nitpicky mode

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
-    python: '3.11'
-    nodejs: '22'
+    python: '3.14'
+    nodejs: '24'
   jobs:
     post_install:
       - npm ci

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -184,7 +184,5 @@ pseudoxml:
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
 
-# Override SPHINXOPTS as `sphinx-autobuild` does not have `--keep-going` option
-livehtml: SPHINXOPTS = -W -n -jauto
 livehtml:
 	sphinx-autobuild --port 4000 --host 0.0.0.0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = --fail-on-warning -n -jauto
+SPHINXOPTS    = --fail-on-warning -jauto
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,6 +79,9 @@ autodoc_type_aliases = {
 }
 autodoc_member_order = "groupwise"
 
+# Warn about all references where the target cannot be found.
+nitpicky = True
+
 # Silence warnings that are not due to missing references:
 nitpick_ignore = [
     # Sphinx currently cannot resolve type hint names, warns "target not found":


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->

### Description

<!-- Please describe the problem you're fixing. -->


Looks like we missed updating the RTD Node.js version in #13770. Might as well update the Python and Ubuntu version. Using `ubuntu-lts-latest` (i.e. not pinning to specific version), but use specific versions for Python and Node.js, to better match our CI config.

Also remove redundant `SPHINXOPTS` override for the `make livehtml` command. History:

- We added the `--keep-going` option in adfd8b32dc0545a1a1357dc049240ca88067412c
- `sphinx-autobuild` didn't (doesn't?) have the `--keep-going` option, so I added the override in 8cf301ee5d8c2427c1654769d4e680e1500753f1
- #12076 removed the `--keep-going` option saying "these two options are opposite"
  - which I don't think is accurate: they work in conjunction, rather than the opposite.
  - as of Sphinx 8.1, the [`--keep-going` behaviour is always enabled](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-keep-going).
  - we only define `Sphinx>=7.3` in our `pyproject.toml`, so RTD always installs the latest.
  - in any case, we haven't been using the `--keep-going` arg since #12076, so the override for `livehtml` is no longer necessary.
### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None