### PR TITLE
Pin intersphinx refs for django-treebeard to 5.3.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -193,7 +193,7 @@ intersphinx_mapping = {
         None,
     ),
     "treebeard": (
-        "https://django-treebeard.readthedocs.io/en/stable/",
+        "https://django-treebeard.readthedocs.io/en/5.3.0/",
         None,
     ),
     "sphinx": (


### PR DESCRIPTION
Supersedes #14448. Treebeard 6.x moves various tree operations to the manager class (breaking our existing documentation refs) and we don't support it yet.

### AI usage

None