### PR TITLE
Fix recipe for customising form submission listing views

### DIFF
--- a/docs/reference/contrib/forms/customization.md
+++ b/docs/reference/contrib/forms/customization.md
@@ -589,16 +589,13 @@ class FormPage(AbstractEmailForm):
 
 ## Customize form submissions listing in Wagtail Admin
 
-The Admin listing of form submissions can be customized by setting the attribute `submissions_list_view_class` on your FormPage model.
-
-The list view class must be a subclass of `SubmissionsListView` from `wagtail.contrib.forms.views`, which is a subclass of `wagtail.admin.views.generic.base.BaseListingView` and Django's class based {class}`~django.views.generic.list.ListView`.
+The Admin listing of form submissions can be customized by overriding the `get_submissions_list_view_class` method on your FormPage model. This method must return a subclass of `SubmissionsListView` from `wagtail.contrib.forms.views`, which is a subclass of `wagtail.admin.views.generic.base.BaseListingView` and Django's class based {class}`~django.views.generic.list.ListView`.
 
 Example:
 
 ```python
-from wagtail.contrib.forms.models import AbstractEmailForm, AbstractFormField
+# myapp/views.py
 from wagtail.contrib.forms.views import SubmissionsListView
-
 
 class CustomSubmissionsListView(SubmissionsListView):
     paginate_by = 50  # show more submissions per page, default is 20
@@ -610,7 +607,11 @@ class CustomSubmissionsListView(SubmissionsListView):
         """ Returns the filename for CSV file with page slug at start"""
         filename = super().get_csv_filename()
         return self.form_page.slug + '-' + filename
+```
 
+```python
+# myapp/models.py
+from wagtail.contrib.forms.models import AbstractEmailForm, AbstractFormField
 
 class FormField(AbstractFormField):
     page = ParentalKey('FormPage', related_name='form_fields')
@@ -619,8 +620,9 @@ class FormField(AbstractFormField):
 class FormPage(AbstractEmailForm):
     """Form Page with customized submissions listing view"""
 
-    # set custom view class as class attribute
-    submissions_list_view_class = CustomSubmissionsListView
+    def get_submissions_list_view_class(self):
+        from myapp.views import CustomSubmissionsListView
+        return CustomSubmissionsListView
 
     intro = RichTextField(blank=True)
     thank_you_text = RichTextField(blank=True)

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -168,6 +168,22 @@ The [`SnippetChooserViewSet.widget_class`](wagtail.snippets.views.chooser.Snippe
 
 If you rely on the previous behavior that used the `items` ordering, remove {attr}`~wagtail.admin.viewsets.base.ViewSet.menu_order` in your `ViewSet` definition.
 
+### Setting `submissions_list_view_class` on form page models no longer works
+
+The `submissions_list_view_class` attribute on the form builder's `AbstractForm` model, previously documented at [](custom_form_submission_listing), is no longer directly usable. This is because the `wagtail.contrib.forms.views` module can no longer be imported at model load time without introducing a circular import, and so there is no way to refer to a subclass of `SubmissionsListView` within a model definition. Instead, the `get_submissions_list_view_class` method can be overridden to achieve the same result. First, the definition of the `SubmissionsListView` subclass, and the import of `SubmissionsListView`, should be moved to a separate `views` module within the app. Then, the line:
+
+```python
+    submissions_list_view_class = CustomSubmissionsListView
+```
+
+can be replaced with:
+
+```python
+    def get_submissions_list_view_class(self):
+        from myapp.views import CustomSubmissionsListView
+        return CustomSubmissionsListView
+```
+
 ## Upgrade considerations - changes to undocumented internals
 
 ### `request` argument to `Page._get_site_root_paths` is now `cache_object`

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -628,14 +628,6 @@ class FormPage(EmailFormMixin, FormMixin, Page):
         context["greeting"] = "hello world"
         return context
 
-    # FIXME: replace the recipe at
-    # https://docs.wagtail.org/en/stable/reference/contrib/forms/customization.html#customise-form-submissions-listing-in-wagtail-admin
-    # which no longer works because wagtail.contrib.forms.views cannot be imported before models are loaded.
-    # Overriding get_submissions_list_view_class is the quick fix, but a registry mapping form page models to viewsets
-    # would be cleaner.
-    #
-    # submissions_list_view_class = SubmissionsListView
-
     def get_submissions_list_view_class(self):
         from wagtail.contrib.forms.views import SubmissionsListView
 


### PR DESCRIPTION
Follow-up to #14368. The recipe previously given at https://github.com/wagtail/wagtail/blob/main/docs/reference/contrib/forms/customization.md#customize-form-submissions-listing-in-wagtail-admin no longer works, as `wagtail.contrib.forms.views` cannot be imported at model definition time without introducing a circular import. Change this to override the `get_submissions_list_view_class` method (with a run-time import) instead.

### AI usage

None