### PR TITLE
Fix workflow action race: guard concurrent POSTs and lock submit buttons

### DIFF
--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -39,6 +39,8 @@ Wagtail 8.0 introduces a new API transport layer at `/api/v3/`, built on [Django
  * Use canonical URL for TED oEmbed provider (Marquis Nobles)
  * Prevent stale content types from breaking audit log message formatting (Thibaud Colas)
  * Prevent icons from capturing clicks inside buttons (Maciek Baron)
+ * Prevent a crash and page revert when a workflow action POST arrives after the workflow was already completed by a concurrent request (Nick Moreton, Jakub Mastalerz)
+ * Prevent duplicate workflow action POSTs from being submitted by adding a progress lock to direct-submit workflow buttons (Nick Moreton, Jakub Mastalerz)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/workflow_menu_item.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/workflow_menu_item.html
@@ -1,4 +1,18 @@
-{% load wagtailadmin_tags %}
-<button class="button" data-workflow-action-name="{{ name }}" {% if launch_modal %}data-workflow-action-modal-url="{% url 'wagtailadmin_pages:collect_workflow_action_data' page.id name current_task_state.id %}"{% endif %}>
+{% load i18n wagtailadmin_tags %}
+{% if launch_modal %}
+<button class="button" data-workflow-action-name="{{ name }}" data-workflow-action-modal-url="{% url 'wagtailadmin_pages:collect_workflow_action_data' page.id name current_task_state.id %}">
     {% if icon_name %}{% icon name=icon_name %}{% endif %}{{ label }}
 </button>
+{% else %}
+<button
+    type="submit"
+    class="button button-longrunning"
+    data-workflow-action-name="{{ name }}"
+    data-controller="w-progress"
+    data-action="w-progress#activate"
+>
+    {% if icon_name %}{% icon name=icon_name classname="button-longrunning__icon" %}{% endif %}
+    {% icon name="spinner" %}
+    <em data-w-progress-target="label">{{ label }}</em>
+</button>
+{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/workflow_menu_item.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/workflow_menu_item.html
@@ -1,18 +1,18 @@
 {% load i18n wagtailadmin_tags %}
 {% if launch_modal %}
-<button class="button" data-workflow-action-name="{{ name }}" data-workflow-action-modal-url="{% url 'wagtailadmin_pages:collect_workflow_action_data' page.id name current_task_state.id %}">
-    {% if icon_name %}{% icon name=icon_name %}{% endif %}{{ label }}
-</button>
+    <button class="button" data-workflow-action-name="{{ name }}" data-workflow-action-modal-url="{% url 'wagtailadmin_pages:collect_workflow_action_data' page.id name current_task_state.id %}">
+        {% if icon_name %}{% icon name=icon_name %}{% endif %}{{ label }}
+    </button>
 {% else %}
-<button
-    type="submit"
-    class="button button-longrunning"
-    data-workflow-action-name="{{ name }}"
-    data-controller="w-progress"
-    data-action="w-progress#activate"
->
-    {% if icon_name %}{% icon name=icon_name classname="button-longrunning__icon" %}{% endif %}
-    {% icon name="spinner" %}
-    <em data-w-progress-target="label">{{ label }}</em>
-</button>
+    <button
+        type="submit"
+        class="button button-longrunning"
+        data-workflow-action-name="{{ name }}"
+        data-controller="w-progress"
+        data-action="w-progress#activate"
+    >
+        {% if icon_name %}{% icon name=icon_name classname="button-longrunning__icon" %}{% endif %}
+        {% icon name="spinner" %}
+        <em data-w-progress-target="label">{{ label }}</em>
+    </button>
 {% endif %}

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -3184,6 +3184,38 @@ class TestApproveRejectPageWorkflow(BasePageWorkflowTests):
             "Edited Title",
         )
 
+    def test_perform_workflow_action_race_condition_does_not_crash(self):
+        """
+        https://github.com/wagtail/wagtail/issues/11235
+
+        When the workflow task disappears between workflow_action_is_valid()
+        returning True and perform_workflow_action() executing (a duplicate-POST
+        race), the view must redirect gracefully without raising AttributeError
+        or reverting the just-published page to draft.
+        """
+        workflow_state = self.object.current_workflow_state
+        # Simulate the winning request: complete the task via the model API.
+        workflow_state.current_task_state.approve(user=self.moderator)
+        self.object.refresh_from_db()
+        self.assertTrue(self.object.live)
+        self.assertIsNone(self.object.current_workflow_task)
+
+        # Simulate the losing (duplicate) request. Mock workflow_action_is_valid
+        # to return True, as it would have before the task was cleared.
+        with mock.patch(
+            "wagtail.admin.views.pages.edit.EditView.workflow_action_is_valid",
+            return_value=True,
+        ):
+            response = self.post(
+                "workflow-action",
+                {"workflow-action-name": "approve"},
+            )
+
+        self.assertEqual(response.status_code, 302)
+        # The page must remain live — not reverted to draft by a stale form.save().
+        self.object.refresh_from_db()
+        self.assertTrue(self.object.live)
+
 
 class TestApproveRejectSnippetWorkflow(
     TestApproveRejectPageWorkflow, BaseSnippetWorkflowTests

--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -590,6 +590,11 @@ class CreateEditViewOptionalFeaturesMixin:
         return None
 
     def workflow_action_action(self):
+        # Guard against duplicate POSTs racing the view: if the workflow task
+        # has been completed by a concurrent request, skip gracefully.
+        if not self.current_workflow_task:
+            return None
+
         extra_workflow_data_json = self.request.POST.get(
             "workflow-action-extra-data", "{}"
         )

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -867,6 +867,17 @@ class EditView(
         return self.redirect_away()
 
     def perform_workflow_action(self):
+        # Guard against duplicate POSTs racing EditView: if the workflow task
+        # is already gone (the concurrent winning request already completed the
+        # workflow), redirect gracefully rather than reverting the just-published
+        # page to draft or raising AttributeError on current_workflow_task.
+        if not self.page.current_workflow_task:
+            messages.info(
+                self.request,
+                _("This page has already been moderated."),
+            )
+            return self.redirect_away()
+
         self.page = self.form.save(commit=not self.page.live)
         self.subscription.save()
 

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/workflow_menu_item.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/workflow_menu_item.html
@@ -1,4 +1,18 @@
-{% load wagtailadmin_tags %}
-<button class="button" data-workflow-action-name="{{ name }}" {% if launch_modal %}data-workflow-action-modal-url="{{ url }}"{% endif %}>
+{% load i18n wagtailadmin_tags %}
+{% if launch_modal %}
+<button class="button" data-workflow-action-name="{{ name }}" data-workflow-action-modal-url="{{ url }}">
     {% if icon_name %}{% icon name=icon_name %}{% endif %}{{ label }}
 </button>
+{% else %}
+<button
+    type="submit"
+    class="button button-longrunning"
+    data-workflow-action-name="{{ name }}"
+    data-controller="w-progress"
+    data-action="w-progress#activate"
+>
+    {% if icon_name %}{% icon name=icon_name classname="button-longrunning__icon" %}{% endif %}
+    {% icon name="spinner" %}
+    <em data-w-progress-target="label">{{ label }}</em>
+</button>
+{% endif %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/workflow_menu_item.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/workflow_menu_item.html
@@ -1,18 +1,18 @@
 {% load i18n wagtailadmin_tags %}
 {% if launch_modal %}
-<button class="button" data-workflow-action-name="{{ name }}" data-workflow-action-modal-url="{{ url }}">
-    {% if icon_name %}{% icon name=icon_name %}{% endif %}{{ label }}
-</button>
+    <button class="button" data-workflow-action-name="{{ name }}" data-workflow-action-modal-url="{{ url }}">
+        {% if icon_name %}{% icon name=icon_name %}{% endif %}{{ label }}
+    </button>
 {% else %}
-<button
-    type="submit"
-    class="button button-longrunning"
-    data-workflow-action-name="{{ name }}"
-    data-controller="w-progress"
-    data-action="w-progress#activate"
->
-    {% if icon_name %}{% icon name=icon_name classname="button-longrunning__icon" %}{% endif %}
-    {% icon name="spinner" %}
-    <em data-w-progress-target="label">{{ label }}</em>
-</button>
+    <button
+        type="submit"
+        class="button button-longrunning"
+        data-workflow-action-name="{{ name }}"
+        data-controller="w-progress"
+        data-action="w-progress#activate"
+    >
+        {% if icon_name %}{% icon name=icon_name classname="button-longrunning__icon" %}{% endif %}
+        {% icon name="spinner" %}
+        <em data-w-progress-target="label">{{ label }}</em>
+    </button>
 {% endif %}


### PR DESCRIPTION
### Description

**Background**

When a user double-clicks an "Approve" workflow button (or a network retry sends a duplicate POST), two requests can race in  EditView. The winning request completes the workflow and publishes the page; the losing request then finds current_workflow_task is None and either:
- reverts the just-published page back to draft (stale form.save() runs before the None check), or                            
- raises AttributeError: 'NoneType' object has no attribute 'on_action' → HTTP 500

This PR adds two defensive layers:

**Layer 1 — Backend guard (Python)**

`EditView.perform_workflow_action` in _wagtail/admin/views/pages/edit.py_ now checks `current_workflow_task` at the very top of the method, before `form.save()`. If the task is gone, the view redirects gracefully with an informational message instead of reverting or crashing. The equivalent guard is also added to `workflow_action_action` in _wagtail/admin/views/generic/mixins.py_.

**Layer 2 — Frontend lock**

Both _workflow_menu_item.html_ templates (pages and snippets) now apply Wagtail's existing `w-progress` / `button-longrunning` pattern to direct-submit workflow buttons, matching the behaviour of the Publish and Save Draft buttons. This disables the button immediately on click, preventing a second POST from being sent at all.

### AI usage

This PR was developed with Claude Code assistance. The fix approach and core logic originate from an internal site-level workaround authored by Nick Moreton.
