### PR TITLE
Ensure deprecated permissions module in optional apps do not register a fallback policy

### DIFF
--- a/wagtail/contrib/redirects/permissions.py
+++ b/wagtail/contrib/redirects/permissions.py
@@ -8,5 +8,20 @@ warnings.warn(
     "wagtail.contrib.redirects.permissions.permission_policy is deprecated. "
     "Use wagtail.permissions.policy_registry.get_by_type(Redirect) instead.",
     RemovedInWagtail90Warning,
+    stacklevel=2,
 )
-permission_policy = policy_registry.get_by_type(Redirect)
+# Do not use a fallback here, as it would prevent the real permission policy
+# from being registered if there is code that imports this module before the
+# app's ready() is called.
+permission_policy = policy_registry.get_by_type(Redirect, fallback=False)
+if not permission_policy:
+    from wagtail.permission_policies import ModelPermissionPolicy
+
+    permission_policy = ModelPermissionPolicy(Redirect)
+    warnings.warn(
+        "wagtail.contrib.redirects.permissions was imported before "
+        "wagtail.contrib.redirects app is ready. Avoid importing "
+        "wagtail.contrib.redirects.permissions at the module level.",
+        RuntimeWarning,
+        stacklevel=2,
+    )

--- a/wagtail/documents/apps.py
+++ b/wagtail/documents/apps.py
@@ -2,7 +2,7 @@ from django.apps import AppConfig
 from django.db.models import ForeignKey
 from django.utils.translation import gettext_lazy as _
 
-from . import get_document_model
+from . import get_document_model, get_permission_policy
 
 
 class WagtailDocsAppConfig(AppConfig):
@@ -13,10 +13,11 @@ class WagtailDocsAppConfig(AppConfig):
 
     def ready(self):
         from wagtail.documents.signal_handlers import register_signal_handlers
-
-        register_signal_handlers()
+        from wagtail.permissions import register_permission_policy
 
         Document = get_document_model()
+        register_permission_policy(Document, get_permission_policy())
+        register_signal_handlers()
 
         from wagtail.admin.ui.fields import register_display_class
 
@@ -27,9 +28,3 @@ class WagtailDocsAppConfig(AppConfig):
         from wagtail.models.reference_index import ReferenceIndex
 
         ReferenceIndex.register_model(Document)
-
-        from wagtail.permissions import register_permission_policy
-
-        from . import get_permission_policy
-
-        register_permission_policy(Document, get_permission_policy())

--- a/wagtail/documents/permissions.py
+++ b/wagtail/documents/permissions.py
@@ -1,6 +1,6 @@
 import warnings
 
-from wagtail.documents import get_document_model
+from wagtail.documents import get_document_model, get_permission_policy
 from wagtail.permissions import policy_registry
 from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
@@ -8,5 +8,17 @@ warnings.warn(
     "wagtail.documents.permissions.permission_policy is deprecated. "
     "Use wagtail.permissions.policy_registry.get_by_type(get_document_model()) instead.",
     RemovedInWagtail90Warning,
+    stacklevel=2,
 )
-permission_policy = policy_registry.get_by_type(get_document_model())
+# Do not use a fallback here, as it would prevent the real permission policy
+# from being registered if there is code that imports this module before the
+# app's ready() is called.
+permission_policy = policy_registry.get_by_type(get_document_model(), fallback=False)
+if not permission_policy:
+    permission_policy = get_permission_policy()
+    warnings.warn(
+        "wagtail.documents.permissions was imported before wagtail.documents app is "
+        "ready. Avoid importing wagtail.documents.permissions at the module level.",
+        RuntimeWarning,
+        stacklevel=2,
+    )

--- a/wagtail/images/apps.py
+++ b/wagtail/images/apps.py
@@ -2,7 +2,7 @@ from django.apps import AppConfig
 from django.db.models import ForeignKey
 from django.utils.translation import gettext_lazy as _
 
-from . import checks, get_image_model  # NOQA: F401
+from . import checks, get_image_model, get_permission_policy  # NOQA: F401
 
 
 class WagtailImagesAppConfig(AppConfig):
@@ -13,6 +13,11 @@ class WagtailImagesAppConfig(AppConfig):
     default_attrs = {}
 
     def ready(self):
+        from wagtail.permissions import register_permission_policy
+
+        Image = get_image_model()
+        register_permission_policy(Image, get_permission_policy())
+
         from .signal_handlers import register_signal_handlers
 
         register_signal_handlers()
@@ -22,7 +27,6 @@ class WagtailImagesAppConfig(AppConfig):
 
         from .widgets import AdminImageChooser
 
-        Image = get_image_model()
         register_form_field_override(
             ForeignKey, to=Image, override={"widget": AdminImageChooser}
         )
@@ -46,9 +50,3 @@ class WagtailImagesAppConfig(AppConfig):
         from wagtail.models.reference_index import ReferenceIndex
 
         ReferenceIndex.register_model(Image)
-
-        from wagtail.permissions import register_permission_policy
-
-        from . import get_permission_policy
-
-        register_permission_policy(Image, get_permission_policy())

--- a/wagtail/images/permissions.py
+++ b/wagtail/images/permissions.py
@@ -1,6 +1,6 @@
 import warnings
 
-from wagtail.images import get_image_model
+from wagtail.images import get_image_model, get_permission_policy
 from wagtail.permissions import policy_registry
 from wagtail.utils.deprecation import RemovedInWagtail90Warning
 
@@ -8,5 +8,17 @@ warnings.warn(
     "wagtail.images.permissions.permission_policy is deprecated. "
     "Use wagtail.permissions.policy_registry.get_by_type(get_image_model()) instead.",
     RemovedInWagtail90Warning,
+    stacklevel=2,
 )
-permission_policy = policy_registry.get_by_type(get_image_model())
+# Do not use a fallback here, as it would prevent the real permission policy
+# from being registered if there is code that imports this module before the
+# app's ready() is called.
+permission_policy = policy_registry.get_by_type(get_image_model(), fallback=False)
+if not permission_policy:
+    permission_policy = get_permission_policy()
+    warnings.warn(
+        "wagtail.images.permissions was imported before wagtail.images app is "
+        "ready. Avoid importing wagtail.images.permissions at the module level.",
+        RuntimeWarning,
+        stacklevel=2,
+    )

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -45,7 +45,11 @@ from wagtail.models import (
 )
 from wagtail.permissions import policy_registry
 from wagtail.snippets.action_menu import SnippetActionMenu
-from wagtail.snippets.models import SnippetAdminURLFinder, get_snippet_models
+from wagtail.snippets.models import (
+    SNIPPET_MODELS,
+    SnippetAdminURLFinder,
+    get_snippet_models,
+)
 from wagtail.snippets.side_panels import SnippetStatusSidePanel
 from wagtail.snippets.views.chooser import SnippetChooserViewSet
 
@@ -1235,13 +1239,15 @@ class SnippetViewSet(ModelViewSet):
         checks.register(snippets_model_check, "panels")
 
     def register_snippet_model(self):
-        snippet_models = get_snippet_models()
-        if self.model in snippet_models:
+        # Do not use get_snippet_models here to avoid searching for hooks. We
+        # only care if the model is already registered, not any other models
+        # that may be registered later.
+        if self.model in SNIPPET_MODELS:
             raise ImproperlyConfigured(
                 f"The {self.model.__name__} model is already registered as a snippet"
             )
-        snippet_models.append(self.model)
-        snippet_models.sort(key=lambda x: x._meta.verbose_name)
+        SNIPPET_MODELS.append(self.model)
+        SNIPPET_MODELS.sort(key=lambda x: x._meta.verbose_name)
 
     def on_register(self):
         super().on_register()


### PR DESCRIPTION
### Description

We found an issue where a Wagtail project couldn't start with the following error:

```shell
django.core.exceptions.ImproperlyConfigured: A fallback permission policy has already been created for custom_media.CustomImage. Please ensure your custom CollectionOwnershipPermissionPolicy is registered earlier on, such as at the top of wagtail_hooks.py or in your AppConfig.ready().
```

<details><summary>Full traceback</summary>

```shell
Traceback (most recent call last):
  File "/Users/sabdullah/Code/github/wagtail/guide/manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/Users/sabdullah/Library/Caches/pypoetry/virtualenvs/guide-LyniOpWN-py3.14/lib/python3.14/site-packages/django/core/management/__init__.py", line 443, in execute_from_command_line
    utility.execute()
    ~~~~~~~~~~~~~~~^^
  File "/Users/sabdullah/Library/Caches/pypoetry/virtualenvs/guide-LyniOpWN-py3.14/lib/python3.14/site-packages/django/core/management/__init__.py", line 417, in execute
    django.setup()
    ~~~~~~~~~~~~^^
  File "/Users/sabdullah/Library/Caches/pypoetry/virtualenvs/guide-LyniOpWN-py3.14/lib/python3.14/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sabdullah/Library/Caches/pypoetry/virtualenvs/guide-LyniOpWN-py3.14/lib/python3.14/site-packages/django/apps/registry.py", line 124, in populate
    app_config.ready()
    ~~~~~~~~~~~~~~~~^^
  File "/Users/sabdullah/Library/Caches/pypoetry/virtualenvs/guide-LyniOpWN-py3.14/lib/python3.14/site-packages/wagtail/images/apps.py", line 54, in ready
    register_permission_policy(Image, get_permission_policy())
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sabdullah/Library/Caches/pypoetry/virtualenvs/guide-LyniOpWN-py3.14/lib/python3.14/site-packages/wagtail/permissions.py", line 95, in register_permission_policy
    policy_registry.register(model, value=policy, exact_class=exact_class)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sabdullah/Library/Caches/pypoetry/virtualenvs/guide-LyniOpWN-py3.14/lib/python3.14/site-packages/wagtail/permissions.py", line 63, in register
    raise ImproperlyConfigured(
    ...<4 lines>...
    )
django.core.exceptions.ImproperlyConfigured: A fallback permission policy has already been created for custom_media.CustomImage. Please ensure your custom CollectionOwnershipPermissionPolicy is registered earlier on, such as at the top of wagtail_hooks.py or in your AppConfig.ready().
```

</details> 

The main reason was that there is code that imports `wagtail.images.permissions` before the `wagtail.images` app's `ready()` method is called.

The offending code comes from [an incorrect import](https://github.com/wagtail/wagtail-ai/blob/a399063e89181faddd69fd4e6c001a9ac25c7462/src/wagtail_ai/views.py#L13) in `wagtail-ai`, which imports `get_image_model` from `wagtail.images.permissions` (instead of `wagtail.images`) in a `views.py` that gets imported by a `wagtail_hooks.py`.

However, it seems plausible that a legitimate import of `wagtail.permissions` (e.g. to obtain the image model's `permission_policy` prior to the introduction of the registry) could cause the same issue.

We found this in the project for the Wagtail Guide website while testing with the latest nightly: https://github.com/wagtail/guide/pull/461

The offending code path was rather convoluted:

- `ready()` is called for `wagtail.snippets`
- this calls `register_deferred_snippets()` https://github.com/wagtail/wagtail/blob/c83ea1a4695089c0bbf45eace0c16c964ef8bba1/wagtail/snippets/apps.py#L14-L17
- which registers the viewsets, and calls the viewset's `on_register()`
- which calls `SnippetViewSet.register_snippet_model()`
- which calls `get_snippet_models()` to avoid double registration: https://github.com/wagtail/wagtail/blob/c83ea1a4695089c0bbf45eace0c16c964ef8bba1/wagtail/snippets/views/snippets.py#L1237-L1238
- which searches for hooks https://github.com/wagtail/wagtail/blob/c83ea1a4695089c0bbf45eace0c16c964ef8bba1/wagtail/snippets/models.py#L28-L32
- which imports the hooks from `wagtail_ai`, [which imports the views](https://github.com/wagtail/wagtail-ai/blob/a399063e89181faddd69fd4e6c001a9ac25c7462/src/wagtail_ai/wagtail_hooks.py#L19)
- [which imports `wagtail.images.permissions`](https://github.com/wagtail/wagtail-ai/blob/a399063e89181faddd69fd4e6c001a9ac25c7462/src/wagtail_ai/views.py#L13)
- at this point, `ready()` for `wagtail.images` hasn't been called, because `wagtail.snippets` comes before `wagtail.images` in the project's `INSTALLED_APPS` list
- this means the default permission policy for images hasn't been registered
- as a result, the `policy_registry.get_by_type()` in `wagtail.permissions` registers a fallback policy
- when `ready()` for `wagtail.images` is eventually called, the registration for the real permission policy for images fails, because a fallback has been registered.

A workaround for the project is to move `wagtail.images` to come before `wagtail.snippets`. This sidesteps the issue, but honestly this might be a symptom of a bigger problem.

### Possible solutions

- `SnippetViewSet.register_snippet_model()` probably shouldn't call `get_snippet_models()` (which searches for hooks).
  - We only care about whether the snippet model has been previously registered (to avoid double registrations), and we don't care about other models (that may be registered later), so we don't need to search for hooks.
  - Quick fix: work with the `SNIPPET_MODELS` list directly instead of calling `get_snippet_models()`.
  - Alternative fix: move the code for `register_snippet_model` to the `_register_snippet_immediately()` function.
    - Might be a bit tricky as this function accepts a model, a `SnippetViewSet`, or a `SnippetViewSetGroup` (possibly nested). Will need to properly inspect where the model is.
- As additional safeguard, ensure the deprecated `permissions` module does not register a fallback if it couldn't find the policy in the registry (due to the code being run before `ready()`). Instead, just instantiate a fresh policy instance without registering it, and maybe raise a warning.

### Testing

Check out the PR branch https://github.com/wagtail/guide/pull/461, and run `make backend`. Afterwards, you can try `make run` or even `python manage.py shell` and it wouldn't work. This can also be seen on CI: https://github.com/wagtail/guide/actions/runs/30985666242/job/92239713794?pr=461

I tried to write unit tests for this but it's really difficult, since the issue comes from module initialisation behaviour.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
GitHub Copilot in VSCode for code completion.