### PR TITLE
Fix model with uuid as pk can't be previewed on add

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -48,6 +48,12 @@ Changelog
  * Maintenance: Format Python code in documentation using ruff (Thibaud Colas)
 
 
+7.4.3 (xx.xx.xxxx) - IN DEVELOPMENT
+~~~~~~~~~~~~~~~~~~
+
+ * Fix: Ensure models with a UUID primary key can be previewed when creating a new instance (Sébastien Corbin)
+
+
 7.4.2 (15.06.2026)
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/7.4.3.md
+++ b/docs/releases/7.4.3.md
@@ -1,0 +1,16 @@
+# Wagtail 7.4.3 release notes - IN DEVELOPMENT
+
+_Unreleased_
+
+```{contents}
+---
+local:
+depth: 1
+---
+```
+
+## What's new
+
+### Bug fixes
+
+ * Ensure models with a UUID primary key can be previewed when creating a new instance (Sébastien Corbin)

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -7,6 +7,7 @@ Release notes
    upgrading
    release_process
    8.0
+   7.4.3
    7.4.2
    7.4.1
    7.4

--- a/wagtail/admin/models.py
+++ b/wagtail/admin/models.py
@@ -138,7 +138,7 @@ class FormStateQuerySet(models.QuerySet):
             content_type=ContentType.objects.get_for_model(
                 instance, for_concrete_model=False
             ),
-            object_id=str(instance.pk or ""),
+            object_id="" if instance._state.adding else str(instance.pk),
         )
 
     def for_preview(self, user, instance, parent_object_id=""):
@@ -161,7 +161,7 @@ class FormStateManager(models.Manager.from_queryset(FormStateQuerySet)):
             content_type=ContentType.objects.get_for_model(
                 instance, for_concrete_model=False
             ),
-            object_id=str(instance.pk or ""),
+            object_id="" if instance._state.adding else str(instance.pk),
             parent_object_id=parent_object_id,
             **kwargs,
         )

--- a/wagtail/snippets/tests/test_preview.py
+++ b/wagtail/snippets/tests/test_preview.py
@@ -160,6 +160,27 @@ class TestPreview(WagtailTestUtils, TestCase):
         self.assertNotContains(response, "<li>Parties</li>")
         self.assertContains(response, "<li>Holidays</li>")
 
+    def test_preview_on_create_with_uuid_as_pk(self):
+        url = reverse(
+            "wagtailsnippets_tests_advertwithcustomuuidprimarykey:preview_on_add"
+        )
+        response = self.client.post(url, {"text": "A new advert", "url": ""})
+
+        # Check the JSON response
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(
+            response.content.decode(),
+            {"is_valid": True, "is_available": True},
+        )
+
+        # Check the user can refresh the preview
+        response = self.client.get(url)
+
+        # Check the HTML response
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "tests/previewable_model.html")
+        self.assertContains(response, "<h1>A new advert</h1>", html=True)
+
     def test_preview_on_create_without_permissions(self):
         # Remove privileges from user
         self.user.is_superuser = False

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -1126,7 +1126,7 @@ class AdvertWithCustomPrimaryKey(ClusterableModel):
 register_snippet(AdvertWithCustomPrimaryKey)
 
 
-class AdvertWithCustomUUIDPrimaryKey(index.Indexed, ClusterableModel):
+class AdvertWithCustomUUIDPrimaryKey(index.Indexed, PreviewableMixin, ClusterableModel):
     advert_id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     url = models.URLField(null=True, blank=True)
     text = models.CharField(max_length=255)
@@ -1144,6 +1144,9 @@ class AdvertWithCustomUUIDPrimaryKey(index.Indexed, ClusterableModel):
 
     def __str__(self):
         return self.text
+
+    def get_preview_template(self, request, mode_name):
+        return "tests/previewable_model.html"
 
 
 register_snippet(AdvertWithCustomUUIDPrimaryKey)


### PR DESCRIPTION
Fixes #14462 

### Description

`FormStateQuerySet.for_instance` builds the lookup with `object_id=str(instance.pk or "")`, but for UUID-based pk is already assigned (generated via `default=uuid.uuid4`)

This should be also backported to 7.4 LTS


### AI usage

Used to create stub unit test, reviewed by myself