### PR TITLE
Add v2 parity of page read fields in API v3

### DIFF
--- a/wagtail/api/v3/registry.py
+++ b/wagtail/api/v3/registry.py
@@ -82,7 +82,7 @@ class ContentTypeRegistry:
     def register_defaults(self) -> None:
         """Register the content types shipped with Wagtail (currently ``pages``)."""
         from wagtail.api.v3.schemas import (
-            BasePageSchema,
+            PageSchema,
             create_generator,
             patch_generator,
             read_generator,
@@ -98,7 +98,7 @@ class ContentTypeRegistry:
             ContentTypeRegistration(
                 name="pages",
                 label="Pages",
-                read_schema=BasePageSchema,
+                read_schema=PageSchema,
             )
         )
 
@@ -108,7 +108,7 @@ class ContentTypeRegistry:
                     name=model._meta.label,
                     label=str(model._meta.verbose_name),
                     read_schema=read_generator.generate_schema(
-                        model, base_class=BasePageSchema
+                        model, base_class=PageSchema
                     ),
                     create_schema=create_generator.generate_schema(
                         model,

--- a/wagtail/api/v3/schemas/__init__.py
+++ b/wagtail/api/v3/schemas/__init__.py
@@ -12,6 +12,7 @@ from .pages import (
     PageCreateBaseSchema,
     PageCreateMetaSchema,
     PageMetaSchema,
+    PageSchema,
     PageUpdateBaseSchema,
     PageUpdateMetaSchema,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "create_generator",
     "patch_generator",
     "BasePageSchema",
+    "PageSchema",
     "PageCreateBaseSchema",
     "PageCreateMetaSchema",
     "PageMetaSchema",

--- a/wagtail/api/v3/schemas/pages.py
+++ b/wagtail/api/v3/schemas/pages.py
@@ -12,6 +12,27 @@ from wagtail.models import AbstractPage
 
 Page = swapper.load_model("wagtailcore", "Page")
 
+#: Page's own fields that every concrete page type can accept on creation,
+#: beyond whatever extra fields a model declares through ``api_fields``.
+BASE_PAGE_FIELDS = [
+    "title",
+    "slug",
+]
+for field in ["seo_title", "search_description", "show_in_menus"]:
+    try:
+        Page._meta.get_field(field)
+    except FieldDoesNotExist:
+        pass
+    else:
+        BASE_PAGE_FIELDS.append(field)
+
+BASE_PAGE_READ_FIELDS = BASE_PAGE_FIELDS + [
+    "pk",
+    "first_published_at",
+    "locale",
+]
+BASE_PAGE_READ_FIELDS_SET = set(BASE_PAGE_READ_FIELDS)
+
 
 class SimpleBasePageMetaSchema(Schema):
     type: str | None = None
@@ -66,6 +87,15 @@ class BasePageSchema(SimpleBasePageSchema):
 
 
 class PageMetaSchema(BasePageMetaSchema):
+    if "show_in_menus" in BASE_PAGE_READ_FIELDS_SET:
+        show_in_menus: bool | None = None
+
+    if "seo_title" in BASE_PAGE_READ_FIELDS_SET:
+        seo_title: str | None = None
+
+    if "search_description" in BASE_PAGE_READ_FIELDS_SET:
+        search_description: str | None = None
+
     alias_of: SimpleBasePageSchema | None = None
     parent: SimpleBasePageSchema | None = None
 
@@ -76,27 +106,6 @@ class PageMetaSchema(BasePageMetaSchema):
 
 class PageSchema(BasePageSchema):
     meta: PageMetaSchema
-
-
-#: Page's own fields that every concrete page type can accept on creation,
-#: beyond whatever extra fields a model declares through ``api_fields``.
-BASE_PAGE_FIELDS = [
-    "title",
-    "slug",
-]
-for field in ["seo_title", "search_description", "show_in_menus"]:
-    try:
-        Page._meta.get_field(field)
-    except FieldDoesNotExist:
-        pass
-    else:
-        BASE_PAGE_FIELDS.append(field)
-
-BASE_PAGE_READ_FIELDS = BASE_PAGE_FIELDS + [
-    "pk",
-    "first_published_at",
-    "locale",
-]
 
 
 class PageCreateMetaSchema(Schema):

--- a/wagtail/api/v3/schemas/pages.py
+++ b/wagtail/api/v3/schemas/pages.py
@@ -13,49 +13,69 @@ from wagtail.models import AbstractPage
 Page = swapper.load_model("wagtailcore", "Page")
 
 
-class PageMetaSchema(Schema):
+class SimpleBasePageMetaSchema(Schema):
     type: str | None = None
     detail_url: str | None = None
     html_url: str | None = None
+
+    @staticmethod
+    def resolve_type(obj: AbstractPage, context: dict) -> str | None:
+        return (obj.specific_class or Page)._meta.label
+
+    @staticmethod
+    def resolve_detail_url(obj: AbstractPage, context: dict) -> str | None:
+        request = context["request"]
+        try:
+            path = reverse("wagtailapi_v3:detail_page", kwargs={"page_id": obj.pk})
+            return get_full_url(request, path)
+        except NoReverseMatch:
+            return None
+
+    @staticmethod
+    def resolve_html_url(obj: AbstractPage, context: dict) -> str | None:
+        request = context["request"]
+        try:
+            return obj.get_full_url(request)
+        except NoReverseMatch:
+            return None
+
+
+class SimpleBasePageSchema(Schema):
+    id: int
+    title: str
+    meta: SimpleBasePageMetaSchema
+
+    @staticmethod
+    def resolve_meta(obj: AbstractPage, context: dict) -> AbstractPage:
+        # Pass through so resolve_* methods on meta schema works with the page
+        return obj
+
+
+class BasePageMetaSchema(SimpleBasePageMetaSchema):
     locale: str | None = None
     slug: str
     first_published_at: datetime | None = None
 
+    @staticmethod
+    def resolve_locale(obj: AbstractPage, context: dict) -> str | None:
+        return obj.locale.language_code if obj.locale else None
 
-class BasePageSchema(Schema):
-    id: int
-    title: str
-    meta: PageMetaSchema
+
+class BasePageSchema(SimpleBasePageSchema):
+    meta: BasePageMetaSchema
+
+
+class PageMetaSchema(BasePageMetaSchema):
+    alias_of: SimpleBasePageSchema | None = None
+    parent: SimpleBasePageSchema | None = None
 
     @staticmethod
-    def resolve_meta(obj: AbstractPage, context: dict) -> PageMetaSchema:
-        request = context["request"]
+    def resolve_parent(obj: AbstractPage, context: dict) -> AbstractPage | None:
+        return obj.get_parent()
 
-        try:
-            path = reverse("wagtailapi_v3:detail_page", kwargs={"page_id": obj.pk})
-            detail_url = get_full_url(request, path)
-        except NoReverseMatch:
-            detail_url = None
 
-        try:
-            html_url = obj.get_full_url(request)
-        except NoReverseMatch:
-            html_url = None
-
-        return PageMetaSchema(
-            # specific_class reflects obj's real content type even when obj
-            # itself hasn't been upcast via .specific (e.g. in a listing).
-            # If the content type's model class is missing entirely,
-            # specific_class is None - get_specific() would then fall back
-            # to returning the page as a plain Page instance, so Page's own
-            # label is the correct fallback here too, rather than None.
-            type=(obj.specific_class or Page)._meta.label,
-            detail_url=detail_url,
-            html_url=html_url,
-            locale=obj.locale and obj.locale.language_code,
-            slug=obj.slug,
-            first_published_at=obj.first_published_at,
-        )
+class PageSchema(BasePageSchema):
+    meta: PageMetaSchema
 
 
 #: Page's own fields that every concrete page type can accept on creation,

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -98,6 +98,16 @@
       },
       "AddedStreamFieldWithEmptyListDefaultPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -142,6 +152,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -377,6 +397,16 @@
       },
       "AddedStreamFieldWithEmptyStringDefaultPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -421,6 +451,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -656,6 +696,16 @@
       },
       "AddedStreamFieldWithoutDefaultPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -700,6 +750,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -935,6 +995,16 @@
       },
       "AlwaysShowInMenusPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -979,6 +1049,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -1117,6 +1197,73 @@
         "title": "AlwaysShowInMenusPageSchema",
         "type": "object"
       },
+      "BasePageMetaSchema": {
+        "properties": {
+          "detail_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail Url"
+          },
+          "first_published_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Published At"
+          },
+          "html_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Html Url"
+          },
+          "locale": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Locale"
+          },
+          "slug": {
+            "title": "Slug",
+            "type": "string"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "required": ["slug"],
+        "title": "BasePageMetaSchema",
+        "type": "object"
+      },
       "BasePageSchema": {
         "properties": {
           "id": {
@@ -1124,7 +1271,7 @@
             "type": "integer"
           },
           "meta": {
-            "$ref": "#/components/schemas/PageMetaSchema"
+            "$ref": "#/components/schemas/BasePageMetaSchema"
           },
           "title": {
             "title": "Title",
@@ -1533,6 +1680,16 @@
       },
       "BlogEntryPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -1577,6 +1734,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -2097,6 +2264,16 @@
       },
       "BlogIndexPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -2141,6 +2318,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -2468,6 +2655,16 @@
       },
       "BusinessChildMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -2512,6 +2709,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -2747,6 +2954,16 @@
       },
       "BusinessIndexMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -2791,6 +3008,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -3026,6 +3253,16 @@
       },
       "BusinessNowherePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -3070,6 +3307,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -3305,6 +3552,16 @@
       },
       "BusinessSubIndexMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -3349,6 +3606,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -3584,6 +3851,16 @@
       },
       "CommentableJSONPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -3628,6 +3905,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -3863,6 +4150,16 @@
       },
       "ComplexDefaultStreamPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -3907,6 +4204,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -4142,6 +4449,16 @@
       },
       "ContactPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -4186,6 +4503,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -4555,6 +4882,16 @@
       },
       "CustomCopyFormPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -4599,6 +4936,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -4834,6 +5181,16 @@
       },
       "CustomManagerPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -4878,6 +5235,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -5113,6 +5480,16 @@
       },
       "CustomPermissionPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -5157,6 +5534,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -5392,6 +5779,16 @@
       },
       "CustomPreviewSizesPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -5436,6 +5833,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -5671,6 +6078,16 @@
       },
       "CustomRichBlockFieldPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -5715,6 +6132,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -5950,6 +6377,16 @@
       },
       "CustomRichTextFieldPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -5994,6 +6431,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -6229,6 +6676,16 @@
       },
       "DeadlyStreamPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -6273,6 +6730,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -6508,6 +6975,16 @@
       },
       "DefaultRichBlockFieldPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -6552,6 +7029,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -6787,6 +7274,16 @@
       },
       "DefaultRichTextFieldPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -6831,6 +7328,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -7066,6 +7573,16 @@
       },
       "DefaultStreamPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -7110,6 +7627,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -7378,6 +7905,16 @@
       },
       "EarlyPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -7422,6 +7959,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -7657,6 +8204,16 @@
       },
       "EventIndexMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -7701,6 +8258,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -7813,6 +8380,16 @@
       },
       "EventIndexPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -7857,6 +8434,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -8983,6 +9570,16 @@
       },
       "FilePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -9027,6 +9624,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -9262,6 +9869,16 @@
       },
       "FormClassAdditionalFieldPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -9306,6 +9923,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -9640,6 +10267,16 @@
       },
       "FormPageWithCustomFormBuilderMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -9684,6 +10321,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -10014,6 +10661,16 @@
       },
       "FormPageWithCustomSubmissionListViewMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -10058,6 +10715,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -10198,6 +10865,16 @@
       },
       "FormPageWithCustomSubmissionMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -10242,6 +10919,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -10477,6 +11164,16 @@
       },
       "FormPageWithRedirectMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -10521,6 +11218,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -10756,6 +11463,16 @@
       },
       "GalleryPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -10800,6 +11517,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -11035,6 +11762,16 @@
       },
       "GenericSnippetNoFieldIndexPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -11079,6 +11816,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -11314,6 +12061,16 @@
       },
       "GenericSnippetNoIndexPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -11358,6 +12115,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -11593,6 +12360,16 @@
       },
       "GenericSnippetPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -11637,6 +12414,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -12156,6 +12943,16 @@
       },
       "HomePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -12200,6 +12997,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -12703,6 +13510,16 @@
       },
       "InlineStreamPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -12747,6 +13564,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -13000,6 +13827,16 @@
       },
       "JadeFormPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -13044,6 +13881,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -13279,6 +14126,16 @@
       },
       "MTIBasePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -13323,6 +14180,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -13558,6 +14425,16 @@
       },
       "MTIChildPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -13602,6 +14479,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -13837,6 +14724,16 @@
       },
       "ManyToManyBlogPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -13881,6 +14778,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -14116,6 +15023,16 @@
       },
       "MultiPreviewModesPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -14160,6 +15077,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -14395,6 +15322,16 @@
       },
       "MyCustomPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -14439,6 +15376,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -14674,6 +15621,16 @@
       },
       "NoCreatableSubpageTypesPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -14718,6 +15675,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -14953,6 +15920,16 @@
       },
       "NoPromotePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -14997,6 +15974,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -15232,6 +16219,16 @@
       },
       "NoSubpageTypesPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -15276,6 +16273,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -15511,6 +16518,16 @@
       },
       "OneToOnePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -15555,6 +16572,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -16123,73 +17150,6 @@
         "title": "PageForeignKeySchema",
         "type": "object"
       },
-      "PageMetaSchema": {
-        "properties": {
-          "detail_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detail Url"
-          },
-          "first_published_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "First Published At"
-          },
-          "html_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Html Url"
-          },
-          "locale": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locale"
-          },
-          "slug": {
-            "title": "Slug",
-            "type": "string"
-          },
-          "type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Type"
-          }
-        },
-        "required": ["slug"],
-        "title": "PageMetaSchema",
-        "type": "object"
-      },
       "PageMoveSchema": {
         "properties": {
           "destination_id": {
@@ -16471,6 +17431,16 @@
       },
       "PageWithExcludedCopyFieldMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -16515,6 +17485,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -16750,6 +17730,16 @@
       },
       "PageWithGenericRelationMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -16794,6 +17784,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -17029,6 +18029,16 @@
       },
       "PageWithOldStyleRouteMethodMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -17073,6 +18083,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -17435,6 +18455,16 @@
       },
       "PromotionalPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -17479,6 +18509,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -17837,6 +18877,16 @@
       },
       "RequiredDatePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -17881,6 +18931,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -18116,6 +19176,16 @@
       },
       "RestaurantPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -18160,6 +19230,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -18395,6 +19475,16 @@
       },
       "RichTextFieldWithFeaturesPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -18439,6 +19529,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -18674,6 +19774,16 @@
       },
       "RoutablePageTestMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -18718,6 +19828,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -18953,6 +20073,16 @@
       },
       "RoutablePageWithOverriddenIndexRouteTestMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -18997,6 +20127,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -19232,6 +20372,16 @@
       },
       "SamplePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -19276,6 +20426,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -19582,6 +20742,16 @@
       },
       "SecretPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -19626,6 +20796,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -19861,6 +21041,16 @@
       },
       "SectionedRichTextPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -19905,6 +21095,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -20043,6 +21243,63 @@
         "title": "SectionedRichTextPageSchema",
         "type": "object"
       },
+      "SimpleBasePageMetaSchema": {
+        "properties": {
+          "detail_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail Url"
+          },
+          "html_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Html Url"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "title": "SimpleBasePageMetaSchema",
+        "type": "object"
+      },
+      "SimpleBasePageSchema": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/SimpleBasePageMetaSchema"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": ["id", "title", "meta"],
+        "title": "SimpleBasePageSchema",
+        "type": "object"
+      },
       "SimpleChildPageCreateMetaSchema": {
         "properties": {
           "action": {
@@ -20140,6 +21397,16 @@
       },
       "SimpleChildPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -20184,6 +21451,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -20419,6 +21696,16 @@
       },
       "SimplePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -20463,6 +21750,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -20698,6 +21995,16 @@
       },
       "SimpleParentPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -20742,6 +22049,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -20977,6 +22294,16 @@
       },
       "SingleEventPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -21021,6 +22348,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -21256,6 +22593,16 @@
       },
       "SingletonPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -21300,6 +22647,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -21535,6 +22892,16 @@
       },
       "SingletonPageViaMaxCountMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -21579,6 +22946,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -21882,6 +23259,16 @@
       },
       "StandardChildMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -21926,6 +23313,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -22161,6 +23558,16 @@
       },
       "StandardIndexMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -22205,6 +23612,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -22317,6 +23734,16 @@
       },
       "StandardIndexPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -22361,6 +23788,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -22921,6 +24358,16 @@
       },
       "StandardPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -22965,6 +24412,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -23327,6 +24784,16 @@
       },
       "StreamPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -23371,6 +24838,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -23618,6 +25095,16 @@
       },
       "TableBlockStreamPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -23662,6 +25149,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -23897,6 +25394,16 @@
       },
       "TaggedChildPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -23941,6 +25448,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -24176,6 +25693,16 @@
       },
       "TaggedGrandchildPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -24220,6 +25747,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -24455,6 +25992,16 @@
       },
       "TaggedPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -24499,6 +26046,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -24734,6 +26291,16 @@
       },
       "TestPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -24778,6 +26345,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -25013,6 +26590,16 @@
       },
       "ValidatedPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -25057,6 +26644,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -25508,6 +27105,16 @@
       },
       "abc__EventPageMetaSchema__1": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -25552,6 +27159,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -25569,6 +27186,16 @@
       },
       "abc__EventPageMetaSchema__2": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -25613,6 +27240,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -26326,6 +27963,16 @@
       },
       "abc__FormPageMetaSchema__1": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -26370,6 +28017,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -26387,6 +28044,16 @@
       },
       "abc__FormPageMetaSchema__2": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -26431,6 +28098,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -26702,6 +28379,16 @@
       },
       "abc__PageMetaSchema__1": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -26746,6 +28433,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -26965,6 +28662,16 @@
       },
       "abc__PersonPageMetaSchema__1": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -27009,6 +28716,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -27026,6 +28743,16 @@
       },
       "abc__PersonPageMetaSchema__2": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -27070,6 +28797,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -163,6 +163,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -461,6 +494,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -761,6 +827,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -1059,6 +1158,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -1745,6 +1877,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -2329,6 +2494,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -2720,6 +2918,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -3018,6 +3249,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -3318,6 +3582,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -3616,6 +3913,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -3916,6 +4246,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -4215,6 +4578,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -4513,6 +4909,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -4947,6 +5376,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -5245,6 +5707,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -5545,6 +6040,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -5843,6 +6371,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -6143,6 +6704,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -6441,6 +7035,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -6741,6 +7368,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -7039,6 +7699,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -7339,6 +8032,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -7637,6 +8363,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -7970,6 +8729,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -8269,6 +9061,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -8444,6 +9269,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -9635,6 +10493,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -9933,6 +10824,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -10332,6 +11256,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -10726,6 +11683,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -10929,6 +11919,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -11229,6 +12252,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -11527,6 +12583,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -11827,6 +12916,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -12126,6 +13248,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -12424,6 +13579,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -13008,6 +14196,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -13575,6 +14796,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -13892,6 +15146,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -14190,6 +15477,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -14490,6 +15810,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -14788,6 +16141,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -15088,6 +16474,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -15386,6 +16805,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -15686,6 +17138,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -15984,6 +17469,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -16284,6 +17802,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -16582,6 +18133,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -17496,6 +19080,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -17795,6 +19412,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -18093,6 +19743,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -18520,6 +20203,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -18942,6 +20658,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -19240,6 +20989,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -19540,6 +21322,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -19838,6 +21653,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -20138,6 +21986,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -20436,6 +22317,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -20807,6 +22721,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -21105,6 +23052,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -21462,6 +23442,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -21760,6 +23773,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -22060,6 +24106,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -22358,6 +24437,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -22658,6 +24770,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -22956,6 +25101,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -23324,6 +25502,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -23623,6 +25834,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -23798,6 +26042,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -24423,6 +26700,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -24849,6 +27159,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -25160,6 +27503,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -25458,6 +27834,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -25758,6 +28167,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -26056,6 +28498,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -26356,6 +28831,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -26654,6 +29162,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -27170,6 +29711,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -27250,6 +29824,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -28028,6 +30635,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -28108,6 +30748,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",
@@ -28444,6 +31117,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -28727,6 +31433,39 @@
               }
             ]
           },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -28807,6 +31546,39 @@
                 "type": "null"
               }
             ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
           },
           "slug": {
             "title": "Slug",

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -60,6 +60,16 @@
       },
       "AddedStreamFieldWithEmptyListDefaultPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -104,6 +114,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -263,6 +283,16 @@
       },
       "AddedStreamFieldWithEmptyStringDefaultPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -307,6 +337,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -466,6 +506,16 @@
       },
       "AddedStreamFieldWithoutDefaultPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -510,6 +560,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -669,6 +729,16 @@
       },
       "AlwaysShowInMenusPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -713,6 +783,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -889,6 +969,73 @@
         },
         "required": ["meta"],
         "title": "BasePageForeignKeySchema",
+        "type": "object"
+      },
+      "BasePageMetaSchema": {
+        "properties": {
+          "detail_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail Url"
+          },
+          "first_published_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Published At"
+          },
+          "html_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Html Url"
+          },
+          "locale": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Locale"
+          },
+          "slug": {
+            "title": "Slug",
+            "type": "string"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "required": ["slug"],
+        "title": "BasePageMetaSchema",
         "type": "object"
       },
       "BasePagePatchMetaSchema": {
@@ -1343,6 +1490,16 @@
       },
       "BlogEntryPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -1387,6 +1544,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -1831,6 +1998,16 @@
       },
       "BlogIndexPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -1875,6 +2052,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -2126,6 +2313,16 @@
       },
       "BusinessChildMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -2170,6 +2367,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -2329,6 +2536,16 @@
       },
       "BusinessIndexMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -2373,6 +2590,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -2532,6 +2759,16 @@
       },
       "BusinessNowherePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -2576,6 +2813,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -2735,6 +2982,16 @@
       },
       "BusinessSubIndexMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -2779,6 +3036,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -2938,6 +3205,16 @@
       },
       "CommentableJSONPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -2982,6 +3259,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -3141,6 +3428,16 @@
       },
       "ComplexDefaultStreamPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -3185,6 +3482,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -3344,6 +3651,16 @@
       },
       "ContactPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -3388,6 +3705,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -3681,6 +4008,16 @@
       },
       "CustomCopyFormPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -3725,6 +4062,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -3884,6 +4231,16 @@
       },
       "CustomManagerPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -3928,6 +4285,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -4087,6 +4454,16 @@
       },
       "CustomPermissionPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -4131,6 +4508,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -4290,6 +4677,16 @@
       },
       "CustomPreviewSizesPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -4334,6 +4731,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -4493,6 +4900,16 @@
       },
       "CustomRichBlockFieldPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -4537,6 +4954,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -4696,6 +5123,16 @@
       },
       "CustomRichTextFieldPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -4740,6 +5177,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -4899,6 +5346,16 @@
       },
       "DeadlyStreamPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -4943,6 +5400,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -5102,6 +5569,16 @@
       },
       "DefaultRichBlockFieldPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -5146,6 +5623,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -5305,6 +5792,16 @@
       },
       "DefaultRichTextFieldPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -5349,6 +5846,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -5508,6 +6015,16 @@
       },
       "DefaultStreamPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -5552,6 +6069,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -5744,6 +6271,16 @@
       },
       "EarlyPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -5788,6 +6325,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -5947,6 +6494,16 @@
       },
       "EventIndexMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -5991,6 +6548,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -6065,6 +6632,16 @@
       },
       "EventIndexPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -6109,6 +6686,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -7121,6 +7708,16 @@
       },
       "FilePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -7165,6 +7762,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -7324,6 +7931,16 @@
       },
       "FormClassAdditionalFieldPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -7368,6 +7985,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -7626,6 +8253,16 @@
       },
       "FormPageWithCustomFormBuilderMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -7670,6 +8307,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -7886,6 +8533,16 @@
       },
       "FormPageWithCustomSubmissionListViewMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -7930,6 +8587,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -8032,6 +8699,16 @@
       },
       "FormPageWithCustomSubmissionMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -8076,6 +8753,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -8235,6 +8922,16 @@
       },
       "FormPageWithRedirectMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -8279,6 +8976,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -8438,6 +9145,16 @@
       },
       "GalleryPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -8482,6 +9199,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -8641,6 +9368,16 @@
       },
       "GenericSnippetNoFieldIndexPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -8685,6 +9422,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -8844,6 +9591,16 @@
       },
       "GenericSnippetNoIndexPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -8888,6 +9645,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -9047,6 +9814,16 @@
       },
       "GenericSnippetPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -9091,6 +9868,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -9534,6 +10321,16 @@
       },
       "HomePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -9578,6 +10375,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -10005,6 +10812,16 @@
       },
       "InlineStreamPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -10049,6 +10866,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -10226,6 +11053,16 @@
       },
       "JadeFormPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -10270,6 +11107,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -10429,6 +11276,16 @@
       },
       "MTIBasePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -10473,6 +11330,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -10632,6 +11499,16 @@
       },
       "MTIChildPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -10676,6 +11553,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -10835,6 +11722,16 @@
       },
       "ManyToManyBlogPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -10879,6 +11776,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -11038,6 +11945,16 @@
       },
       "MultiPreviewModesPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -11082,6 +11999,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -11241,6 +12168,16 @@
       },
       "MyCustomPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -11285,6 +12222,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -11444,6 +12391,16 @@
       },
       "NoCreatableSubpageTypesPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -11488,6 +12445,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -11647,6 +12614,16 @@
       },
       "NoPromotePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -11691,6 +12668,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -11850,6 +12837,16 @@
       },
       "NoSubpageTypesPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -11894,6 +12891,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -12053,6 +13060,16 @@
       },
       "OneToOnePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -12097,6 +13114,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -12511,73 +13538,6 @@
         "title": "PageFilterSchema",
         "type": "object"
       },
-      "PageMetaSchema": {
-        "properties": {
-          "detail_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detail Url"
-          },
-          "first_published_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "First Published At"
-          },
-          "html_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Html Url"
-          },
-          "locale": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locale"
-          },
-          "slug": {
-            "title": "Slug",
-            "type": "string"
-          },
-          "type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Type"
-          }
-        },
-        "required": ["slug"],
-        "title": "PageMetaSchema",
-        "type": "object"
-      },
       "PageMoveSchema": {
         "properties": {
           "destination_id": {
@@ -12691,6 +13651,16 @@
       },
       "PageWithExcludedCopyFieldMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -12735,6 +13705,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -12894,6 +13874,16 @@
       },
       "PageWithGenericRelationMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -12938,6 +13928,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -13097,6 +14097,16 @@
       },
       "PageWithOldStyleRouteMethodMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -13141,6 +14151,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -13427,6 +14447,16 @@
       },
       "PromotionalPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -13471,6 +14501,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -13753,6 +14793,16 @@
       },
       "RequiredDatePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -13797,6 +14847,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -13956,6 +15016,16 @@
       },
       "RestaurantPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -14000,6 +15070,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -14159,6 +15239,16 @@
       },
       "RichTextFieldWithFeaturesPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -14203,6 +15293,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -14362,6 +15462,16 @@
       },
       "RoutablePageTestMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -14406,6 +15516,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -14565,6 +15685,16 @@
       },
       "RoutablePageWithOverriddenIndexRouteTestMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -14609,6 +15739,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -14768,6 +15908,16 @@
       },
       "SamplePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -14812,6 +15962,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -15042,6 +16202,16 @@
       },
       "SecretPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -15086,6 +16256,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -15245,6 +16425,16 @@
       },
       "SectionedRichTextPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -15289,6 +16479,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -15389,6 +16589,63 @@
         "title": "SectionedRichTextPageSchema",
         "type": "object"
       },
+      "SimpleBasePageMetaSchema": {
+        "properties": {
+          "detail_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail Url"
+          },
+          "html_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Html Url"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "title": "SimpleBasePageMetaSchema",
+        "type": "object"
+      },
+      "SimpleBasePageSchema": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/SimpleBasePageMetaSchema"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": ["id", "title", "meta"],
+        "title": "SimpleBasePageSchema",
+        "type": "object"
+      },
       "SimpleChildPageCreateMetaSchema": {
         "properties": {
           "action": {
@@ -15448,6 +16705,16 @@
       },
       "SimpleChildPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -15492,6 +16759,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -15651,6 +16928,16 @@
       },
       "SimplePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -15695,6 +16982,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -15854,6 +17151,16 @@
       },
       "SimpleParentPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -15898,6 +17205,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -16057,6 +17374,16 @@
       },
       "SingleEventPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -16101,6 +17428,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -16260,6 +17597,16 @@
       },
       "SingletonPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -16304,6 +17651,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -16463,6 +17820,16 @@
       },
       "SingletonPageViaMaxCountMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -16507,6 +17874,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -16734,6 +18111,16 @@
       },
       "StandardChildMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -16778,6 +18165,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -16937,6 +18334,16 @@
       },
       "StandardIndexMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -16981,6 +18388,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -17055,6 +18472,16 @@
       },
       "StandardIndexPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -17099,6 +18526,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -17545,6 +18982,16 @@
       },
       "StandardPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -17589,6 +19036,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -17875,6 +19332,16 @@
       },
       "StreamPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -17919,6 +19386,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -18090,6 +19567,16 @@
       },
       "TableBlockStreamPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -18134,6 +19621,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -18293,6 +19790,16 @@
       },
       "TaggedChildPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -18337,6 +19844,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -18496,6 +20013,16 @@
       },
       "TaggedGrandchildPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -18540,6 +20067,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -18699,6 +20236,16 @@
       },
       "TaggedPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -18743,6 +20290,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -18902,6 +20459,16 @@
       },
       "TestPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -18946,6 +20513,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -19105,6 +20682,16 @@
       },
       "ValidatedPageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -19149,6 +20736,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -19251,6 +20848,16 @@
       },
       "abc__BasePageMetaSchema__1": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -19295,6 +20902,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -19559,6 +21176,16 @@
       },
       "abc__EventPageMetaSchema__1": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -19603,6 +21230,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -19620,6 +21257,16 @@
       },
       "abc__EventPageMetaSchema__2": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -19664,6 +21311,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -20225,6 +21882,16 @@
       },
       "abc__FormPageMetaSchema__1": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -20269,6 +21936,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -20286,6 +21963,16 @@
       },
       "abc__FormPageMetaSchema__2": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -20330,6 +22017,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -20639,6 +22336,16 @@
       },
       "abc__PersonPageMetaSchema__1": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -20683,6 +22390,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",
@@ -20700,6 +22417,16 @@
       },
       "abc__PersonPageMetaSchema__2": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -20744,6 +22471,16 @@
               }
             ],
             "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "slug": {
             "title": "Slug",

--- a/wagtail/api/v3/tests/test_pages.py
+++ b/wagtail/api/v3/tests/test_pages.py
@@ -993,6 +993,10 @@ class TestV3PageDetail(PageFixturesMixin, WagtailTestUtils, TestCase):
         )
         content = response.json()
 
+        extra_meta = set()
+        if not swapper.is_swapped("wagtailcore", "Page"):
+            extra_meta = {"show_in_menus", "seo_title", "search_description"}
+
         self.assertEqual(
             set(content["meta"].keys()),
             {
@@ -1004,7 +1008,8 @@ class TestV3PageDetail(PageFixturesMixin, WagtailTestUtils, TestCase):
                 "locale",
                 "parent",
                 "alias_of",
-            },
+            }
+            | extra_meta,
         )
         self.assertEqual(content["meta"]["slug"], blog_index.slug)
         self.assertEqual(content["meta"]["type"], "demosite.BlogIndexPage")

--- a/wagtail/api/v3/tests/test_pages.py
+++ b/wagtail/api/v3/tests/test_pages.py
@@ -987,9 +987,9 @@ class TestV3PageDetail(PageFixturesMixin, WagtailTestUtils, TestCase):
 
     @override_settings(WAGTAILAPI_BASE_URL="https://api.example.com")
     def test_detail_meta_values(self):
-        homepage = Page.objects.get(id=2).specific
+        blog_index = models.BlogIndexPage.objects.first()
         response = self.client.get(
-            reverse("wagtailapi_v3:detail_page", kwargs={"page_id": homepage.id})
+            reverse("wagtailapi_v3:detail_page", kwargs={"page_id": blog_index.id})
         )
         content = response.json()
 
@@ -1002,15 +1002,32 @@ class TestV3PageDetail(PageFixturesMixin, WagtailTestUtils, TestCase):
                 "slug",
                 "first_published_at",
                 "locale",
+                "parent",
+                "alias_of",
             },
         )
-        self.assertEqual(content["meta"]["slug"], homepage.slug)
-        self.assertEqual(content["meta"]["type"], "demosite.HomePage")
+        self.assertEqual(content["meta"]["slug"], blog_index.slug)
+        self.assertEqual(content["meta"]["type"], "demosite.BlogIndexPage")
         self.assertTrue(
             content["meta"]["detail_url"].startswith("https://api.example.com")
         )
-        self.assertIn(f"/api/v3/pages/{homepage.id}/", content["meta"]["detail_url"])
+        self.assertIn(f"/api/v3/pages/{blog_index.id}/", content["meta"]["detail_url"])
         self.assertIsNotNone(content["meta"]["html_url"])
+        parent = blog_index.get_parent()
+        self.assertEqual(
+            content["meta"]["parent"],
+            {
+                "id": parent.id,
+                "meta": {
+                    "type": parent.specific_class._meta.label,
+                    "detail_url": (
+                        f"https://api.example.com/api/v3/pages/{parent.id}/"
+                    ),
+                    "html_url": "http://localhost/",
+                },
+                "title": parent.title,
+            },
+        )
 
     def test_detail_meta_type_uses_specific_class(self):
         blog_entry = models.BlogEntryPage.objects.get(id=16)

--- a/wagtail/api/v3/tests/test_schema_discovery.py
+++ b/wagtail/api/v3/tests/test_schema_discovery.py
@@ -11,6 +11,8 @@ PAGE_READ_META_SCHEMA_FIELDS = {
     "slug",
     "first_published_at",
     "locale",
+    "parent",
+    "alias_of",
 }
 
 

--- a/wagtail/api/v3/tests/test_schema_discovery.py
+++ b/wagtail/api/v3/tests/test_schema_discovery.py
@@ -1,3 +1,4 @@
+import swapper
 from django.test import TestCase
 from django.urls import reverse
 
@@ -14,6 +15,8 @@ PAGE_READ_META_SCHEMA_FIELDS = {
     "parent",
     "alias_of",
 }
+if not swapper.is_swapped("wagtailcore", "Page"):
+    PAGE_READ_META_SCHEMA_FIELDS |= {"show_in_menus", "seo_title", "search_description"}
 
 
 class TestV3SchemaDiscovery(TestV3Base, TestCase):


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->

### Description

<!-- Please describe the problem you're fixing. -->
This adds the `alias_of`, `parent`, `show_in_menu`, `seo_title`, and `search_description` fields to the page detail in API v3.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->

GitHub Copilot in VSCode for autocompletion.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>