### PR TITLE
Create site history entries for image and document upload/deletion in multiple/bulk mode

### DIFF
--- a/wagtail/admin/views/generic/multiple_upload.py
+++ b/wagtail/admin/views/generic/multiple_upload.py
@@ -2,6 +2,7 @@ import os.path
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
@@ -11,6 +12,7 @@ from django.views.decorators.vary import vary_on_headers
 from django.views.generic.base import TemplateView, View
 
 from wagtail.admin.views.generic import PermissionCheckedMixin
+from wagtail.log_actions import log
 from wagtail.models import UploadedFile
 
 
@@ -145,6 +147,7 @@ class AddView(PermissionCheckedMixin, TemplateView):
         if form.is_valid():
             # Save it
             self.object = self.save_object(form)
+            log(instance=self.object, action="wagtail.create", content_changed=True)
 
             # Success! Send back an edit form for this object to the user
             return JsonResponse(self.get_edit_object_response_data())
@@ -235,6 +238,11 @@ class EditView(PermissionCheckedMixin, View):
 
         if form.is_valid():
             self.save_object(form)
+            log(
+                instance=self.object,
+                action="wagtail.edit",
+                content_changed=form.has_changed(),
+            )
 
             return JsonResponse(
                 {
@@ -286,7 +294,10 @@ class DeleteView(PermissionCheckedMixin, View):
         ):
             raise PermissionDenied
 
-        self.object.delete()
+        with transaction.atomic():
+            # Log before deleting, while the object still exists.
+            log(instance=self.object, action="wagtail.delete", deleted=True)
+            self.object.delete()
 
         return JsonResponse(
             {
@@ -342,6 +353,7 @@ class CreateFromUploadView(View):
 
         if form.is_valid():
             self.save_object(form)
+            log(instance=self.object, action="wagtail.create", content_changed=True)
             self.upload.file.delete()
             self.upload.delete()
 

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -22,6 +22,7 @@ from wagtail.documents.tests.utils import get_test_document_file
 from wagtail.models import (
     Collection,
     GroupCollectionPermission,
+    ModelLogEntry,
     ReferenceIndex,
     UploadedFile,
 )
@@ -1433,6 +1434,29 @@ class TestMultipleDocumentUploader(AdminTemplateTestUtils, WagtailTestUtils, Tes
         # form should not contain a collection chooser
         self.assertNotIn("Collection", response_json["form"])
 
+    def test_add_post_logs_create_action(self):
+        """
+        A POST request to the add view logs a "wagtail.create" action, so that the
+        upload shows up in the site history report
+        """
+        response = self.client.post(
+            reverse("wagtaildocs:add_multiple"),
+            {
+                "files[]": SimpleUploadedFile("test.png", b"Simple text document"),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        doc = get_document_model().objects.get(title="test.png")
+        log_entries = ModelLogEntry.objects.for_instance(doc).filter(
+            action="wagtail.create"
+        )
+        self.assertEqual(log_entries.count(), 1)
+        log_entry = log_entries.first()
+        self.assertEqual(log_entry.user, self.user)
+        self.assertTrue(log_entry.content_changed)
+
     def test_add_post_with_title(self):
         """
         This tests that a POST request to the add view saves the document with a supplied title and returns an edit form
@@ -1593,6 +1617,48 @@ class TestMultipleDocumentUploader(AdminTemplateTestUtils, WagtailTestUtils, Tes
 
         self.check_doc_after_edit()
 
+    def test_edit_post_logs_edit_action(self):
+        """
+        A POST request to the edit view logs a "wagtail.edit" action, so that the
+        change shows up in the site history report
+        """
+        response = self.client.post(
+            reverse("wagtaildocs:edit_multiple", args=(self.doc.id,)),
+            {
+                "doc-%d-%s" % (self.doc.id, field): data
+                for field, data in self.edit_post_data.items()
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        log_entries = ModelLogEntry.objects.for_instance(self.doc).filter(
+            action="wagtail.edit"
+        )
+        self.assertEqual(log_entries.count(), 1)
+        log_entry = log_entries.first()
+        self.assertEqual(log_entry.user, self.user)
+        self.assertTrue(log_entry.content_changed)
+
+    def test_edit_post_validation_error_does_not_log(self):
+        """
+        A POST request to the edit view that fails validation must not log an action
+        """
+        response = self.client.post(
+            reverse("wagtaildocs:edit_multiple", args=(self.doc.id,)),
+            {
+                ("doc-%d-title" % self.doc.id): "",  # Required
+                ("doc-%d-tags" % self.doc.id): "",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(
+            ModelLogEntry.objects.for_instance(self.doc)
+            .filter(action="wagtail.edit")
+            .exists()
+        )
+
     def test_edit_post_validation_error(self):
         """
         This tests that a POST request to the edit page returns a json document with "success=False"
@@ -1661,6 +1727,26 @@ class TestMultipleDocumentUploader(AdminTemplateTestUtils, WagtailTestUtils, Tes
         self.assertIn("success", response_json)
         self.assertEqual(response_json["doc_id"], self.doc.id)
         self.assertTrue(response_json["success"])
+
+    def test_delete_post_logs_delete_action(self):
+        """
+        A POST request to the delete view logs a "wagtail.delete" action, so that the
+        deletion shows up in the site history report
+        """
+        response = self.client.post(
+            reverse("wagtaildocs:delete_multiple", args=(self.doc.id,))
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # self.doc is a separate in-memory copy, so its pk is still available for lookup
+        log_entries = ModelLogEntry.objects.for_instance(self.doc).filter(
+            action="wagtail.delete"
+        )
+        self.assertEqual(log_entries.count(), 1)
+        log_entry = log_entries.first()
+        self.assertEqual(log_entry.user, self.user)
+        self.assertTrue(log_entry.deleted)
 
 
 @override_settings(WAGTAILDOCS_DOCUMENT_MODEL="tests.CustomDocument")
@@ -1765,6 +1851,26 @@ class TestMultipleCustomDocumentUploaderWithRequiredField(TestMultipleDocumentUp
 
         # form should not contain a collection chooser
         self.assertNotIn("Collection", response_json["form"])
+
+    def test_add_post_logs_create_action(self):
+        """
+        A POST request to the add view only creates an UploadedFile, so there is no
+        document to log a "wagtail.create" action against yet
+        """
+        response = self.client.post(
+            reverse("wagtaildocs:add_multiple"),
+            {
+                "files[]": SimpleUploadedFile("test.png", b"Simple text document"),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(
+            ModelLogEntry.objects.filter(
+                content_type=ContentType.objects.get_for_model(get_document_model()),
+                action="wagtail.create",
+            ).exists()
+        )
 
     def test_add_post_with_title(self):
         """
@@ -1969,6 +2075,42 @@ class TestMultipleCustomDocumentUploaderWithRequiredField(TestMultipleDocumentUp
         self.assertTrue(doc.file_hash)
         self.assertTrue(doc.file_size)
         self.assertIn("donkey", doc.tags.names())
+
+    def test_create_from_upload_logs_create_action(self):
+        """
+        Creating a document from an UploadedFile logs a "wagtail.create" action, so
+        that the upload shows up in the site history report
+        """
+        response = self.client.post(
+            reverse(
+                "wagtaildocs:create_multiple_from_uploaded_document",
+                args=(self.uploaded_document.id,),
+            ),
+            {
+                (
+                    "uploaded-document-%d-title" % self.uploaded_document.id
+                ): "New title!",
+                (
+                    "uploaded-document-%d-tags" % self.uploaded_document.id
+                ): "fairies, donkey",
+                (
+                    "uploaded-document-%d-author" % self.uploaded_document.id
+                ): "William Shakespeare",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        response_json = json.loads(response.content.decode())
+        self.assertTrue(response_json["success"])
+
+        doc = CustomDocumentWithAuthor.objects.get(id=response_json["doc_id"])
+        log_entries = ModelLogEntry.objects.for_instance(doc).filter(
+            action="wagtail.create"
+        )
+        self.assertEqual(log_entries.count(), 1)
+        log_entry = log_entries.first()
+        self.assertEqual(log_entry.user, self.user)
+        self.assertTrue(log_entry.content_changed)
 
     def test_delete_uploaded_document(self):
         """

--- a/wagtail/documents/tests/test_bulk_actions/test_bulk_delete.py
+++ b/wagtail/documents/tests/test_bulk_actions/test_bulk_delete.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.utils.http import urlencode
 
 from wagtail.documents import get_document_model
+from wagtail.models import ModelLogEntry
 from wagtail.test.testapp.models import VariousOnDeleteModel
 from wagtail.test.utils import WagtailTestUtils
 
@@ -74,6 +75,26 @@ class TestDocumentBulkDeleteView(WagtailTestUtils, TestCase):
         # Documents should be deleted
         for document in self.documents:
             self.assertFalse(Document.objects.filter(id=document.id).exists())
+
+    def test_delete_logs_delete_action(self):
+        """
+        Bulk deletion logs a "wagtail.delete" action for each document, so that the
+        deletions show up in the site history report
+        """
+        response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, 302)
+
+        # self.documents are separate in-memory copies, so their pks are still available
+        for document in self.documents:
+            log_entries = ModelLogEntry.objects.for_instance(document).filter(
+                action="wagtail.delete"
+            )
+            self.assertEqual(log_entries.count(), 1)
+            log_entry = log_entries.first()
+            self.assertEqual(log_entry.user, self.user)
+            self.assertEqual(log_entry.label, document.title)
+            self.assertTrue(log_entry.deleted)
 
     def test_usage_link(self):
         response = self.client.get(self.url)

--- a/wagtail/documents/views/bulk_actions/delete.py
+++ b/wagtail/documents/views/bulk_actions/delete.py
@@ -3,6 +3,7 @@ from django.utils.translation import ngettext
 
 from wagtail.admin.views.bulk_action.mixins import ReferenceIndexMixin
 from wagtail.documents.views.bulk_actions.document_bulk_action import DocumentBulkAction
+from wagtail.log_actions import log
 
 
 class DeleteBulkAction(ReferenceIndexMixin, DocumentBulkAction):
@@ -21,6 +22,9 @@ class DeleteBulkAction(ReferenceIndexMixin, DocumentBulkAction):
     @classmethod
     def execute_action(cls, objects, **kwargs):
         num_parent_objects = len(objects)
+        for obj in objects:
+            # Log before deleting, while the objects still exist.
+            log(instance=obj, action="wagtail.delete", deleted=True)
         cls.get_default_model().objects.filter(
             pk__in=[obj.pk for obj in objects]
         ).delete()

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -39,6 +39,7 @@ from wagtail.images.views.images import BulkActionsColumn, ImagesFilterSet
 from wagtail.models import (
     Collection,
     GroupCollectionPermission,
+    ModelLogEntry,
     UploadedFile,
     get_root_collection_id,
 )
@@ -3201,6 +3202,32 @@ class TestMultipleImageUploader(AdminTemplateTestUtils, WagtailTestUtils, TestCa
         self.assertTrue(response_json["success"])
         self.assertFalse(response_json["duplicate"])
 
+    def test_add_post_logs_create_action(self):
+        """
+        A POST request to the add view logs a "wagtail.create" action, so that the
+        upload shows up in the site history report
+        """
+        response = self.client.post(
+            reverse("wagtailimages:add_multiple"),
+            {
+                "title": "test title",
+                "files[]": SimpleUploadedFile(
+                    "test.png", get_test_image_file().file.getvalue()
+                ),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        image = get_image_model().objects.get(title="test title")
+        log_entries = ModelLogEntry.objects.for_instance(image).filter(
+            action="wagtail.create"
+        )
+        self.assertEqual(log_entries.count(), 1)
+        log_entry = log_entries.first()
+        self.assertEqual(log_entry.user, self.user)
+        self.assertTrue(log_entry.content_changed)
+
     def test_add_post_no_title(self):
         """
         A POST request to the add view without the title value saves the image and uses file title if needed
@@ -3477,6 +3504,48 @@ class TestMultipleImageUploader(AdminTemplateTestUtils, WagtailTestUtils, TestCa
         self.assertEqual(image.title, "New title!")
         self.assertIn("cromarty", image.tags.names())
 
+    def test_edit_post_logs_edit_action(self):
+        """
+        A POST request to the edit view logs a "wagtail.edit" action, so that the
+        change shows up in the site history report
+        """
+        response = self.client.post(
+            reverse("wagtailimages:edit_multiple", args=(self.image.id,)),
+            {
+                ("image-%d-title" % self.image.id): "New title!",
+                ("image-%d-tags" % self.image.id): "cromarty, finisterre",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        log_entries = ModelLogEntry.objects.for_instance(self.image).filter(
+            action="wagtail.edit"
+        )
+        self.assertEqual(log_entries.count(), 1)
+        log_entry = log_entries.first()
+        self.assertEqual(log_entry.user, self.user)
+        self.assertTrue(log_entry.content_changed)
+
+    def test_edit_post_validation_error_does_not_log(self):
+        """
+        A POST request to the edit view that fails validation must not log an action
+        """
+        response = self.client.post(
+            reverse("wagtailimages:edit_multiple", args=(self.image.id,)),
+            {
+                ("image-%d-title" % self.image.id): "",  # Required
+                ("image-%d-tags" % self.image.id): "",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(
+            ModelLogEntry.objects.for_instance(self.image)
+            .filter(action="wagtail.edit")
+            .exists()
+        )
+
     def test_edit_post_validation_error(self):
         """
         This tests that a POST request to the edit page returns a json document with "success=False"
@@ -3545,6 +3614,26 @@ class TestMultipleImageUploader(AdminTemplateTestUtils, WagtailTestUtils, TestCa
         self.assertIn("success", response_json)
         self.assertEqual(response_json["image_id"], self.image.id)
         self.assertTrue(response_json["success"])
+
+    def test_delete_post_logs_delete_action(self):
+        """
+        A POST request to the delete view logs a "wagtail.delete" action, so that the
+        deletion shows up in the site history report
+        """
+        response = self.client.post(
+            reverse("wagtailimages:delete_multiple", args=(self.image.id,))
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # self.image is a separate in-memory copy, so its pk is still available for lookup
+        log_entries = ModelLogEntry.objects.for_instance(self.image).filter(
+            action="wagtail.delete"
+        )
+        self.assertEqual(log_entries.count(), 1)
+        log_entry = log_entries.first()
+        self.assertEqual(log_entry.user, self.user)
+        self.assertTrue(log_entry.deleted)
 
 
 @override_settings(WAGTAILIMAGES_IMAGE_MODEL="tests.CustomImage")
@@ -4041,6 +4130,38 @@ class TestMultipleImageUploaderWithCustomRequiredFields(WagtailTestUtils, TestCa
         self.assertEqual(image.width, 640)
         self.assertEqual(image.height, 480)
         self.assertIn("abstract", image.tags.names())
+
+    def test_create_from_upload_logs_create_action(self):
+        """
+        Creating an image from an UploadedFile logs a "wagtail.create" action, so that
+        the upload shows up in the site history report
+        """
+        response = self.client.post(
+            reverse(
+                "wagtailimages:create_multiple_from_uploaded_image",
+                args=(self.uploaded_image.id,),
+            ),
+            {
+                ("uploaded-image-%d-title" % self.uploaded_image.id): "New title!",
+                (
+                    "uploaded-image-%d-tags" % self.uploaded_image.id
+                ): "abstract, squares",
+                ("uploaded-image-%d-author" % self.uploaded_image.id): "Piet Mondrian",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        response_json = json.loads(response.content.decode())
+        self.assertTrue(response_json["success"])
+
+        image = CustomImageWithAuthor.objects.get(id=response_json["image_id"])
+        log_entries = ModelLogEntry.objects.for_instance(image).filter(
+            action="wagtail.create"
+        )
+        self.assertEqual(log_entries.count(), 1)
+        log_entry = log_entries.first()
+        self.assertEqual(log_entry.user, self.user)
+        self.assertTrue(log_entry.content_changed)
 
     def test_delete_uploaded_image(self):
         """

--- a/wagtail/images/tests/test_bulk_actions/test_bulk_delete.py
+++ b/wagtail/images/tests/test_bulk_actions/test_bulk_delete.py
@@ -5,6 +5,7 @@ from django.utils.http import urlencode
 
 from wagtail.images import get_image_model
 from wagtail.images.tests.utils import get_test_image_file
+from wagtail.models import ModelLogEntry
 from wagtail.test.testapp.models import VariousOnDeleteModel
 from wagtail.test.utils import WagtailTestUtils
 
@@ -77,6 +78,26 @@ class TestImageBulkDeleteView(WagtailTestUtils, TestCase):
         # Images should be deleted
         for image in self.images:
             self.assertFalse(Image.objects.filter(id=image.id).exists())
+
+    def test_delete_logs_delete_action(self):
+        """
+        Bulk deletion logs a "wagtail.delete" action for each image, so that the
+        deletions show up in the site history report
+        """
+        response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, 302)
+
+        # self.images are separate in-memory copies, so their pks are still available
+        for image in self.images:
+            log_entries = ModelLogEntry.objects.for_instance(image).filter(
+                action="wagtail.delete"
+            )
+            self.assertEqual(log_entries.count(), 1)
+            log_entry = log_entries.first()
+            self.assertEqual(log_entry.user, self.user)
+            self.assertEqual(log_entry.label, image.title)
+            self.assertTrue(log_entry.deleted)
 
     def test_usage_link(self):
         response = self.client.get(self.url)

--- a/wagtail/images/views/bulk_actions/delete.py
+++ b/wagtail/images/views/bulk_actions/delete.py
@@ -3,6 +3,7 @@ from django.utils.translation import ngettext
 
 from wagtail.admin.views.bulk_action.mixins import ReferenceIndexMixin
 from wagtail.images.views.bulk_actions.image_bulk_action import ImageBulkAction
+from wagtail.log_actions import log
 
 
 class DeleteBulkAction(ReferenceIndexMixin, ImageBulkAction):
@@ -21,6 +22,9 @@ class DeleteBulkAction(ReferenceIndexMixin, ImageBulkAction):
     @classmethod
     def execute_action(cls, objects, **kwargs):
         num_parent_objects = len(objects)
+        for obj in objects:
+            # Log before deleting, while the objects still exist.
+            log(instance=obj, action="wagtail.delete", deleted=True)
         cls.get_default_model().objects.filter(
             pk__in=[obj.pk for obj in objects]
         ).delete()


### PR DESCRIPTION
Fixes #14435

### Description

Images and documents created, edited or deleted through the multiple upload views or the bulk delete actions produced no audit log entry, so they never showed up in the site history report. Doing the same operations one at a time did log, which made the report quietly incomplete rather than obviously broken.

The cause is that single-object views inherit from `wagtail.admin.views.generic.models`, whose `save_instance()` and `delete_action()` run `CreateAction` / `EditAction` / `DeleteAction`, and those log. The multiple upload views call `form.save()` and `obj.delete()` directly, and the image/document bulk delete actions use a queryset `.delete()`, so all of them bypass that machinery.

#### Why here, and not in `wagtail/images/forms.py`

The issue suggested logging in `BaseImageForm.save()`. That form is shared with the single-add view, so logging there would double-log every single upload, and it would still leave documents unfixed. Logging in the generic multiple upload views instead fixes images and documents in one place, and covers third-party subclasses such as wagtailmedia for free.

#### Behaviour

| Operation | Before | After |
| --- | --- | --- |
| `images/add/`, `documents/add/` (single) | `wagtail.create` | unchanged |
| `images/multiple/add/`, `documents/multiple/add/` | nothing | `wagtail.create` |
| `create_from_uploaded_image` / `_document` | nothing | `wagtail.create` |
| `images/multiple/<id>/`, `documents/multiple/<id>/` (edit) | nothing | `wagtail.edit` |
| `images/multiple/<id>/delete/` and documents equivalent | nothing | `wagtail.delete` |
| Bulk delete for images and documents | nothing | `wagtail.delete` per object |

#### Implementation notes

`wagtail/admin/views/generic/multiple_upload.py` logs via `wagtail.log_actions.log` in `post()` rather than in `save_object()`, so that subclass overrides of `save_object()` cannot silently skip logging.

`EditView` takes `content_changed` from `form.has_changed()` to match `EditAction`, so an unchanged resubmit is recorded the same way it would be in single-object mode.

`DeleteView` logs before deleting, inside `transaction.atomic()`. Delete is the only case where the entry has to be written before the operation it describes, because `log_action()` raises on a null pk and needs the object for the entry label. Without the transaction, a failed delete would leave an entry claiming a deletion that never happened. This mirrors `DeleteAction._delete()`.

The bulk delete actions log per object before the bulk delete, preserving the single-query delete. No transaction is added there because `BulkAction.form_valid()` already wraps `execute_action()` in one.

All `log()` calls rely on the ambient `LogContext` for the user, as other direct `log()` call sites in the codebase do.

#### Areas that would benefit from careful review

1. **`wagtail.edit` logging in the multiple upload `EditView`** goes slightly beyond the issue's "upload and deletion" wording. The reasoning is that this view is how a multiple upload is actually completed (title and tags are entered there), so without it the flow still skips history. It is a self-contained hunk and easy to drop if you would rather keep this strictly to create and delete.
2. **One log entry per object on bulk delete.** `ModelLogEntry` is keyed on `content_type` plus `object_id` and `log()` requires an instance, so there is no aggregate row shape to use instead. Per-object entries match single-object deletion and what `PageBulkAction` already does, and they keep `for_instance()` lookups and report filters working. The cost is row volume: deleting 500 images writes 500 unbatched inserts and 500 report rows. Entries from one request already share a `LogContext` uuid, and `latest_by_uuid_and_action()` exists to collapse them, but the site history report does not apply it, so the report shows them individually today. Happy to change the approach if you would prefer batching or report-level grouping.
3. **Relying on the ambient `LogContext` for the user.** This depends on hook-registered admin URLs being decorated with `require_admin_access`, which they are: `wagtail/admin/urls/__init__.py:137` appends them before line 141 applies the decorator. Had the ordering been the other way round, every entry would have landed with `user=None`. Each new test asserts the logged user for that reason.
4. **Third-party subclasses** of the generic multiple upload views now log automatically. That seems desirable, but it is a behaviour change outside this repo.

#### Testing

Written test-first: every assertion was confirmed failing against unpatched code before the fix went in.

13 new test methods, running as 24 test cases once the inherited custom-model document uploader subclasses are counted, across:

- `wagtail/images/tests/test_admin_views.py`
- `wagtail/documents/tests/test_admin_views.py`
- `wagtail/images/tests/test_bulk_actions/test_bulk_delete.py`
- `wagtail/documents/tests/test_bulk_actions/test_bulk_delete.py`

Each checks the action code, the logged user, and the `content_changed` / `deleted` flags. Two negative tests confirm that a validation-error edit POST logs nothing, and that an upload which only produces an `UploadedFile` does not log a create until the object actually exists.

I also ran a throwaway end-to-end check against `/admin/reports/site-history/` itself, which failed before the change and passed after, confirming uploads appear as "Created" and bulk deletions as "Deleted" in the report the issue is about. That scratch file is not part of this PR.

Full suite passes: 7035 tests, `OK (skipped=38, expected failures=9)`. `ruff format --check` and `ruff check` are clean.

#### Not included

No `CHANGELOG.txt`, release notes or `CONTRIBUTORS.md` entries, since `docs/contributing/committing.md` marks those as core committer tasks after review. Glad to add them if you would prefer.

The same gap still exists for the bulk `add_tags` and `add_to_collection` actions on images and documents, and for the snippets bulk delete. Those are separate user journeys not covered by this issue, so I have left them out, but I am happy to open a follow-up.

### AI usage

> This pull request includes code written with the assistance of AI.  
> The code has been reviewed by a human.

This change, its tests and this description were produced by Claude Code (Opus 5) working test-first, under human direction on the design decisions (where to log, the transaction boundary, and whether to pass the user explicitly or use the ambient log context).