### PR TITLE
images: Support non-integer primary keys in image URL patterns

### DIFF
--- a/wagtail/images/admin_urls.py
+++ b/wagtail/images/admin_urls.py
@@ -1,35 +1,45 @@
 from django.urls import path
 
+from wagtail.images import get_image_model
+from wagtail.images.utils import get_image_pk_converter
 from wagtail.images.views import images, multiple
+
+conv = get_image_pk_converter(get_image_model())
 
 app_name = "wagtailimages"
 urlpatterns = [
     path("", images.IndexView.as_view(), name="index"),
     path("results/", images.IndexView.as_view(results_only=True), name="index_results"),
-    path("<int:image_id>/", images.EditView.as_view(), name="edit"),
-    path("<int:image_id>/delete/", images.DeleteView.as_view(), name="delete"),
+    path(f"<{conv}:image_id>/", images.EditView.as_view(), name="edit"),
+    path(f"<{conv}:image_id>/delete/", images.DeleteView.as_view(), name="delete"),
     path(
-        "<int:image_id>/generate_url/",
+        f"<{conv}:image_id>/generate_url/",
         images.URLGeneratorView.as_view(),
         name="url_generator",
     ),
     path(
-        "<int:image_id>/generate_url/output/",
+        f"<{conv}:image_id>/generate_url/output/",
         images.URLGeneratorView.as_view(output_only=True),
         name="url_generator_output",
     ),
-    path("<int:image_id>/preview/<str:filter_spec>/", images.preview, name="preview"),
+    path(
+        f"<{conv}:image_id>/preview/<str:filter_spec>/", images.preview, name="preview"
+    ),
     path("add/", images.CreateView.as_view(), name="add"),
-    path("usage/<int:image_id>/", images.UsageView.as_view(), name="image_usage"),
+    path(f"usage/<{conv}:image_id>/", images.UsageView.as_view(), name="image_usage"),
     path("multiple/add/", multiple.AddView.as_view(), name="add_multiple"),
-    path("multiple/<int:image_id>/", multiple.EditView.as_view(), name="edit_multiple"),
+    path(
+        f"multiple/<{conv}:image_id>/",
+        multiple.EditView.as_view(),
+        name="edit_multiple",
+    ),
     path(
         "multiple/create_from_uploaded_image/<int:uploaded_file_id>/",
         multiple.CreateFromUploadedImageView.as_view(),
         name="create_multiple_from_uploaded_image",
     ),
     path(
-        "multiple/<int:image_id>/delete/",
+        f"multiple/<{conv}:image_id>/delete/",
         multiple.DeleteView.as_view(),
         name="delete_multiple",
     ),

--- a/wagtail/images/utils.py
+++ b/wagtail/images/utils.py
@@ -159,3 +159,15 @@ def get_accept_attributes():
         accept_attrs += ", image/avif"
 
     return accept_attrs
+
+
+def get_image_pk_converter(model):
+    """
+    Returns the URL path converter to use for the given image model's primary key.
+    Returns "uuid" for UUIDField PKs, and "int" for all other types.
+    """
+    from django.db import models
+
+    if isinstance(model._meta.pk, models.UUIDField):
+        return "uuid"
+    return "int"

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -32,7 +32,7 @@ from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.images import get_image_model
 from wagtail.images.formats import get_image_format
 from wagtail.images.forms import ImageInsertionForm, get_image_form
-from wagtail.images.utils import find_image_duplicates
+from wagtail.images.utils import find_image_duplicates, get_image_pk_converter
 from wagtail.models import ReferenceIndex
 from wagtail.permissions import policy_registry
 
@@ -412,9 +412,10 @@ class ImageChooserViewSet(ChooserViewSet):
         )
 
     def get_urlpatterns(self):
+        conv = get_image_pk_converter(self.model)
         return super().get_urlpatterns() + [
             path(
-                "<int:image_id>/select_format/",
+                f"<{conv}:image_id>/select_format/",
                 self.select_format_view,
                 name="select_format",
             ),


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #14442 

### Description
Image admin URLs were hardcoded to only accept integer primary keys 
(`<int:image_id>`), causing errors when a custom image model uses a 
non-integer primary key such as UUID.

This fix dynamically determines the correct URL path converter based 
on the image model's primary key field type:
- UUIDField → "uuid"
- IntegerField → "int"
- Anything else → "str"

Changes made:
- `wagtail/images/admin_urls.py`: Dynamically set URL converter based 
  on image model PK type
- `wagtail/images/views/chooser.py`: Same fix for the select_format URL 
  in ImageChooserViewSet

<!-- Please describe the problem you're fixing. -->


### AI usage
None

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
