### PR TITLE
Correct tab selection for StreamField content path links on page load

### DIFF
--- a/client/src/controllers/TabsController.test.js
+++ b/client/src/controllers/TabsController.test.js
@@ -1113,6 +1113,52 @@ describe('TabsController', () => {
       expect(tab3Panel.hidden).toBeFalsy();
     });
 
+    it('should retry the contentpath lookup if the element is not yet rendered on connect', async () => {
+      window.location.hash = '#:w:contentpath=abc1.d2e';
+
+      await setup(`
+        <div id="location-tabs" data-controller="w-tabs" data-action="popstate@window->w-tabs#select" data-w-tabs-use-location-value="true">
+          <div role="tablist">
+            <a id="tab-1" href="#tab-panel-1" role="tab" data-w-tabs-target="trigger" data-action="w-tabs#select:prevent" aria-selected="true">A</a>
+            <a id="tab-2" href="#tab-panel-2" role="tab" data-w-tabs-target="trigger" data-action="w-tabs#select:prevent">B</a>
+          </div>
+          <section id="tab-panel-1" role="tabpanel" aria-labelledby="tab-1" data-w-tabs-target="panel">A (content)</section>
+          <section id="tab-panel-2" role="tabpanel" aria-labelledby="tab-2" data-w-tabs-target="panel">B (content)</section>
+        </div>
+      `);
+
+      expect(errors).toHaveLength(0);
+
+      const [tab1, tab2] = document.querySelectorAll('[role="tab"]');
+      const [tab1Panel, tab2Panel] = document.querySelectorAll('section');
+
+      // Nothing matches the contentpath yet, so it falls back to tab-1
+
+      expect(tab1.getAttribute('aria-selected')).toBe('true');
+      expect(tab2.getAttribute('aria-selected')).toBe(null);
+
+      // Simulate telepath.unpack() inserting the StreamField block into the
+      // DOM shortly after TabsController.connect() has already run
+
+      document
+        .getElementById('tab-panel-2')
+        .insertAdjacentHTML(
+          'beforeend',
+          '<div data-contentpath="abc1"><div data-contentpath="d2e">HERE</div></div>',
+        );
+
+      // Let the queued requestAnimationFrame retry run
+
+      jest.advanceTimersByTime(20);
+      await flushPromises();
+
+      expect(tab1.getAttribute('aria-selected')).toBe(null);
+      expect(tab2.getAttribute('aria-selected')).toBe('true');
+
+      expect(tab1Panel.hidden).toBeTruthy();
+      expect(tab2Panel.hidden).toBeFalsy();
+    });
+
     it('should use the current URL hash on load but gracefully handle not found ids', async () => {
       window.location.hash = '#goes-nowhere-does-nothing';
 

--- a/client/src/controllers/TabsController.ts
+++ b/client/src/controllers/TabsController.ts
@@ -119,6 +119,20 @@ export class TabsController extends Controller {
       detail: { current: initialPanelId },
     });
 
+    // If a location hash targets a contentpath (e.g. a StreamField block)
+    // that has not finished rendering yet, retry once the rest of the
+    // page's initial render has completed.
+    if (
+      this.useLocationValue &&
+      window.location.hash &&
+      !this.locationPanelId
+    ) {
+      requestAnimationFrame(() => {
+        const panelId = this.locationPanelId;
+        if (panelId) this.activePanelIdValue = panelId;
+      });
+    }
+
     // Once ready, allow target changed callbacks to reset tabs
 
     const resetTabs = debounce(() => {


### PR DESCRIPTION
Fixes #14433

### Description

When a StreamField block is linked to via a contentpath URL hash (e.g. from the image/document "usage" report), the tab containing that block is not selected on page load if the block hasn't finished rendering yet. Instead, the editor falls back to the default tab (Content), even though the linked content is in a different tab (e.g. Body).

**Root cause** 

`TabsController.connect()` reads `locationPanelId`, which does a synchronous DOM lookup for the element matching the URL's contentpath. If this runs before the StreamField's `telepath.unpack()` has inserted the block into the DOM, the lookup fails and the initial tab falls back to the default.

**Fix** 

if the initial contentpath lookup fails while a location hash is present, retry it once via `requestAnimationFrame`, after the rest of the initial page render (including telepath's DOM insertion) has completed.

Added a Jest test (`should retry the contentpath lookup if the element is not yet rendered on connect`) that reproduces the race by inserting the contentpath element into the DOM after `connect()` has already run, and asserts the tab is corrected.

Tested manually in Chrome on a fresh Wagtail project: reproduced the bug on `main`, confirmed it's fixed after this change, screen recording attached below.



https://github.com/user-attachments/assets/766e8819-84b5-4bb3-a703-bd7a40c3220c





### AI usage

This pull request includes code written with the assistance of AI. I used it to help locate the root cause by reading through TabsController.ts and contentPath.ts, and confirm my solution and the regression test. I reviewed the change, understand why it works, reproduced the bug myself first, and verified the fix and the test both pass locally before opening this PR.