### PR TITLE
Add v3 images endpoint (write API)

### DIFF
--- a/docs/advanced_topics/api/v3/index.md
+++ b/docs/advanced_topics/api/v3/index.md
@@ -59,3 +59,32 @@ All error responses use [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807
     "errors": []
 }
 ```
+
+## Images
+
+Images are available at `/api/v3/images/`:
+
+- `GET /images/`: list images. Anonymous access, excluding images in restricted collections. Supports `?search=`, `?order=`, and filtering on the image's own fields (`title`, `width`, `height`, plus any `api_fields` the project declares) via query parameters.
+- `GET /images/{id}/`: image detail.
+- `POST /images/`: create an image. This endpoint uses `multipart/form-data`: the `file` field carries the image binary, and writable metadata (title, description, collection, focal point) is sent as individual form fields.
+- `PATCH /images/{id}/`: update the same writable metadata as JSON. Does not support changing the image file itself.
+
+Tags are returned in image responses under `meta.tags`, but are not writable through the images API yet.
+- `DELETE /images/{id}/`: delete an image.
+
+Image writes enforce the same validation (max upload size, max pixels, extensions) and collection permissions as the admin.
+
+### Image renditions
+
+Renditions are exposed per-project through `api_fields`, the same mechanism as [in the v2 API](api_v2_images):
+
+```python
+from wagtail.images.api.fields import ImageRenditionField
+
+class BlogPage(Page):
+    ...
+
+    api_fields = [
+        APIField("thumbnail", serializer=ImageRenditionField("fill-300x300")),
+    ]
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,4 +139,4 @@ version = { attr = "wagtail.__version__" }
 
 [tool.ty.src]
 # Scoped to specific modules for gradual adoption.
-include = ["wagtail/api/v3"]
+include = ["wagtail/api/v3", "wagtail/*/api/v3"]

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -4348,6 +4348,39 @@
         "title": "BusinessSubIndexSchema",
         "type": "object"
       },
+      "CollectionForeignKeySchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetaSchema"
+          }
+        },
+        "required": ["meta"],
+        "title": "CollectionForeignKeySchema",
+        "type": "object"
+      },
+      "CollectionMetaSchema": {
+        "properties": {
+          "type": {
+            "const": "wagtailcore.Collection",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": ["type"],
+        "title": "CollectionMetaSchema",
+        "type": "object"
+      },
       "CommentableJSONPageCreateMetaSchema": {
         "properties": {
           "action": {
@@ -15282,6 +15315,128 @@
         "title": "HomePageSchema",
         "type": "object"
       },
+      "ImageCreateSchema": {
+        "properties": {
+          "collection_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Collection"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "",
+            "title": "Description"
+          },
+          "focal_point_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Height"
+          },
+          "focal_point_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Width"
+          },
+          "focal_point_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point X"
+          },
+          "focal_point_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Y"
+          },
+          "title": {
+            "maxLength": 255,
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": ["title"],
+        "title": "ImageCreateSchema",
+        "type": "object"
+      },
+      "ImageDetailMetaSchema": {
+        "properties": {
+          "detail_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail Url"
+          },
+          "download_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Download Url"
+          },
+          "tags": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
+          },
+          "type": {
+            "const": "wagtailimages.Image",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": ["type"],
+        "title": "ImageDetailMetaSchema",
+        "type": "object"
+      },
       "ImageForeignKeySchema": {
         "properties": {
           "id": {
@@ -15313,6 +15468,183 @@
         },
         "required": ["type"],
         "title": "ImageMetaSchema",
+        "type": "object"
+      },
+      "ImagePatchSchema": {
+        "properties": {
+          "collection_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Collection"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "",
+            "title": "Description"
+          },
+          "focal_point_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Height"
+          },
+          "focal_point_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Width"
+          },
+          "focal_point_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point X"
+          },
+          "focal_point_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Y"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          }
+        },
+        "title": "ImagePatchSchema",
+        "type": "object"
+      },
+      "ImageSchema": {
+        "properties": {
+          "collection": {
+            "$ref": "#/components/schemas/CollectionForeignKeySchema"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "focal_point_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Height"
+          },
+          "focal_point_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Width"
+          },
+          "focal_point_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point X"
+          },
+          "focal_point_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Y"
+          },
+          "height": {
+            "title": "Height",
+            "type": "integer"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ImageDetailMetaSchema"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "width": {
+            "title": "Width",
+            "type": "integer"
+          }
+        },
+        "required": ["meta", "title", "width", "height", "collection"],
+        "title": "ImageSchema",
         "type": "object"
       },
       "InlineStreamPageCreateMetaSchema": {
@@ -21109,6 +21441,24 @@
         },
         "required": ["items", "count"],
         "title": "PagedBasePageSchema",
+        "type": "object"
+      },
+      "PagedImageSchema": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ImageSchema"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": ["items", "count"],
+        "title": "PagedImageSchema",
         "type": "object"
       },
       "PagedLocaleSchema": {
@@ -34175,6 +34525,327 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/v3/images/": {
+      "get": {
+        "operationId": "images_list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "const": "random",
+                  "type": "string"
+                },
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              ],
+              "default": [],
+              "title": "Order"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search_operator",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": ["and", "or"],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search Operator"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedImageSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "BearerTokenAuth": []
+          }
+        ],
+        "summary": "List images",
+        "tags": ["images"]
+      },
+      "post": {
+        "operationId": "images_create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "collection_id": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "title": "Collection"
+                  },
+                  "description": {
+                    "anyOf": [
+                      {
+                        "maxLength": 255,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": "",
+                    "title": "Description"
+                  },
+                  "file": {
+                    "format": "binary",
+                    "title": "File",
+                    "type": "string"
+                  },
+                  "focal_point_height": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "title": "Focal Point Height"
+                  },
+                  "focal_point_width": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "title": "Focal Point Width"
+                  },
+                  "focal_point_x": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "title": "Focal Point X"
+                  },
+                  "focal_point_y": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "title": "Focal Point Y"
+                  },
+                  "title": {
+                    "maxLength": 255,
+                    "title": "Title",
+                    "type": "string"
+                  }
+                },
+                "required": ["file", "title"],
+                "title": "MultiPartBodyParams",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageSchema"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "security": [
+          {
+            "BearerTokenAuth": []
+          }
+        ],
+        "summary": "Create image",
+        "tags": ["images"]
+      }
+    },
+    "/api/v3/images/{image_id}/": {
+      "delete": {
+        "operationId": "images_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "image_id",
+            "required": true,
+            "schema": {
+              "title": "Image Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "BearerTokenAuth": []
+          }
+        ],
+        "summary": "Delete image",
+        "tags": ["images"]
+      },
+      "get": {
+        "operationId": "images_detail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "image_id",
+            "required": true,
+            "schema": {
+              "title": "Image Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "BearerTokenAuth": []
+          }
+        ],
+        "summary": "Image detail",
+        "tags": ["images"]
+      },
+      "patch": {
+        "operationId": "images_update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "image_id",
+            "required": true,
+            "schema": {
+              "title": "Image Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImagePatchSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "BearerTokenAuth": []
+          }
+        ],
+        "summary": "Update image",
+        "tags": ["images"]
+      }
+    },
     "/api/v3/locales/": {
       "get": {
         "operationId": "locales_list",

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -3416,6 +3416,39 @@
         "title": "BusinessSubIndexSchema",
         "type": "object"
       },
+      "CollectionForeignKeySchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetaSchema"
+          }
+        },
+        "required": ["meta"],
+        "title": "CollectionForeignKeySchema",
+        "type": "object"
+      },
+      "CollectionMetaSchema": {
+        "properties": {
+          "type": {
+            "const": "wagtailcore.Collection",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": ["type"],
+        "title": "CollectionMetaSchema",
+        "type": "object"
+      },
       "CommentableJSONPageCreateMetaSchema": {
         "properties": {
           "action": {
@@ -11407,6 +11440,128 @@
         "title": "HomePageSchema",
         "type": "object"
       },
+      "ImageCreateSchema": {
+        "properties": {
+          "collection_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Collection"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "",
+            "title": "Description"
+          },
+          "focal_point_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Height"
+          },
+          "focal_point_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Width"
+          },
+          "focal_point_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point X"
+          },
+          "focal_point_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Y"
+          },
+          "title": {
+            "maxLength": 255,
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": ["title"],
+        "title": "ImageCreateSchema",
+        "type": "object"
+      },
+      "ImageDetailMetaSchema": {
+        "properties": {
+          "detail_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail Url"
+          },
+          "download_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Download Url"
+          },
+          "tags": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
+          },
+          "type": {
+            "const": "wagtailimages.Image",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": ["type"],
+        "title": "ImageDetailMetaSchema",
+        "type": "object"
+      },
       "ImageForeignKeySchema": {
         "properties": {
           "id": {
@@ -11438,6 +11593,183 @@
         },
         "required": ["type"],
         "title": "ImageMetaSchema",
+        "type": "object"
+      },
+      "ImagePatchSchema": {
+        "properties": {
+          "collection_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Collection"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "",
+            "title": "Description"
+          },
+          "focal_point_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Height"
+          },
+          "focal_point_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Width"
+          },
+          "focal_point_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point X"
+          },
+          "focal_point_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Y"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          }
+        },
+        "title": "ImagePatchSchema",
+        "type": "object"
+      },
+      "ImageSchema": {
+        "properties": {
+          "collection": {
+            "$ref": "#/components/schemas/CollectionForeignKeySchema"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "focal_point_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Height"
+          },
+          "focal_point_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Width"
+          },
+          "focal_point_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point X"
+          },
+          "focal_point_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Focal Point Y"
+          },
+          "height": {
+            "title": "Height",
+            "type": "integer"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ImageDetailMetaSchema"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "width": {
+            "title": "Width",
+            "type": "integer"
+          }
+        },
+        "required": ["meta", "title", "width", "height", "collection"],
+        "title": "ImageSchema",
         "type": "object"
       },
       "InlineStreamPageCreateMetaSchema": {
@@ -15456,6 +15788,24 @@
         },
         "required": ["items", "count"],
         "title": "PagedBasePageSchema",
+        "type": "object"
+      },
+      "PagedImageSchema": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ImageSchema"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": ["items", "count"],
+        "title": "PagedImageSchema",
         "type": "object"
       },
       "PagedLocaleSchema": {
@@ -25001,6 +25351,327 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/v3/images/": {
+      "get": {
+        "operationId": "images_list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "const": "random",
+                  "type": "string"
+                },
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              ],
+              "default": [],
+              "title": "Order"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search_operator",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": ["and", "or"],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search Operator"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedImageSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "BearerTokenAuth": []
+          }
+        ],
+        "summary": "List images",
+        "tags": ["images"]
+      },
+      "post": {
+        "operationId": "images_create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "collection_id": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "title": "Collection"
+                  },
+                  "description": {
+                    "anyOf": [
+                      {
+                        "maxLength": 255,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": "",
+                    "title": "Description"
+                  },
+                  "file": {
+                    "format": "binary",
+                    "title": "File",
+                    "type": "string"
+                  },
+                  "focal_point_height": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "title": "Focal Point Height"
+                  },
+                  "focal_point_width": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "title": "Focal Point Width"
+                  },
+                  "focal_point_x": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "title": "Focal Point X"
+                  },
+                  "focal_point_y": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "title": "Focal Point Y"
+                  },
+                  "title": {
+                    "maxLength": 255,
+                    "title": "Title",
+                    "type": "string"
+                  }
+                },
+                "required": ["file", "title"],
+                "title": "MultiPartBodyParams",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageSchema"
+                }
+              }
+            },
+            "description": "Created"
+          }
+        },
+        "security": [
+          {
+            "BearerTokenAuth": []
+          }
+        ],
+        "summary": "Create image",
+        "tags": ["images"]
+      }
+    },
+    "/api/v3/images/{image_id}/": {
+      "delete": {
+        "operationId": "images_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "image_id",
+            "required": true,
+            "schema": {
+              "title": "Image Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "BearerTokenAuth": []
+          }
+        ],
+        "summary": "Delete image",
+        "tags": ["images"]
+      },
+      "get": {
+        "operationId": "images_detail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "image_id",
+            "required": true,
+            "schema": {
+              "title": "Image Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "BearerTokenAuth": []
+          }
+        ],
+        "summary": "Image detail",
+        "tags": ["images"]
+      },
+      "patch": {
+        "operationId": "images_update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "image_id",
+            "required": true,
+            "schema": {
+              "title": "Image Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImagePatchSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "BearerTokenAuth": []
+          }
+        ],
+        "summary": "Update image",
+        "tags": ["images"]
+      }
+    },
     "/api/v3/locales/": {
       "get": {
         "operationId": "locales_list",

--- a/wagtail/images/api/v3/form_data.py
+++ b/wagtail/images/api/v3/form_data.py
@@ -1,0 +1,61 @@
+from typing import Any
+
+from django.contrib.auth.base_user import AbstractBaseUser
+from django.contrib.auth.models import AnonymousUser
+from django.db.models import Model
+from django.forms import ModelForm
+from ninja import UploadedFile
+
+from wagtail.api.v3.form_data import build_form_data
+from wagtail.images.forms import get_image_form
+
+
+def build_image_form(
+    model: type,
+    data: Any,
+    file: UploadedFile,
+    user: AbstractBaseUser | AnonymousUser,
+) -> ModelForm:
+    """Build a bound image form from a validated create-input schema and the
+    uploaded file, using the admin image form (``get_image_form``) so
+    ``WagtailImageField`` validation, collection-scoped choices, and
+    ``BaseImageForm.save()`` metadata/index handling all apply.
+
+    ``data.model_dump()`` uses field names (not aliases), so the wire key
+    ``collection_id`` is converted back to the form field name ``collection``
+    the same way snippets' ``feed_image_id`` maps to ``feed_image``.
+    """
+    form_class = get_image_form(model)
+    payload = data.model_dump()
+    form_data = build_form_data(form_class, payload)
+    instance = model(uploaded_by_user=user)
+    return form_class(
+        data=form_data,
+        files={"file": file},
+        instance=instance,
+        user=user,
+    )
+
+
+def build_image_update_form(
+    instance: Model,
+    data: Any,
+    user: AbstractBaseUser | AnonymousUser,
+) -> ModelForm:
+    """Build a bound image form from a validated, partial update-input schema.
+
+    Only the fields actually present in the request body are put on the form
+    (``exclude_unset``), so a field the request didn't mention is left as-is.
+    ``get_image_form`` forces the collection field in, so the instance's
+    current collection is pre-filled when the request doesn't submit one -
+    otherwise the required collection field would fail validation on every
+    metadata-only patch.
+    """
+    model = type(instance)
+    payload = data.model_dump(exclude_unset=True)
+    form_class = get_image_form(model, fields=payload.keys())
+    form_data = build_form_data(form_class, payload, instance=instance)
+    if "collection" not in payload and "collection" in form_class.base_fields:
+        # Django adds ``<foreign_key>_id`` attributes dynamically.
+        form_data["collection"] = instance.collection_id  # ty: ignore[unresolved-attribute]
+    return form_class(data=form_data, instance=instance, user=user)

--- a/wagtail/images/api/v3/registry.py
+++ b/wagtail/images/api/v3/registry.py
@@ -1,0 +1,19 @@
+from wagtail.api.v3.registry import ContentTypeRegistration, registry
+from wagtail.images import get_image_model
+
+from .schemas import build_image_schemas
+
+
+def register_content_types() -> None:
+    """Register the active image model's read/create/patch schemas."""
+    Image = get_image_model()
+    read_schema, create_schema, patch_schema = build_image_schemas()
+    registry.register(
+        ContentTypeRegistration(
+            name=Image._meta.label,
+            label=str(Image._meta.verbose_name),
+            read_schema=read_schema,
+            create_schema=create_schema,
+            patch_schema=patch_schema,
+        )
+    )

--- a/wagtail/images/api/v3/router.py
+++ b/wagtail/images/api/v3/router.py
@@ -1,0 +1,157 @@
+from typing import cast
+
+from django.http import HttpRequest
+from django.shortcuts import get_object_or_404
+from ninja import Body, File, Form, Query, Router, Status, UploadedFile
+from ninja.pagination import paginate
+from pydantic import BaseModel
+
+from wagtail.actions import action_registry
+from wagtail.api.v3.auth import AllowAnonymous, BearerTokenAuth
+from wagtail.api.v3.pagination import WagtailLimitOffsetPagination
+from wagtail.api.v3.permissions import require_any_permission
+from wagtail.api.v3.registry import ContentTypeRegistration, registry
+from wagtail.api.v3.schemas.params import (
+    APIFieldFilterSchema,
+    OrderingSchema,
+    SearchSchema,
+)
+from wagtail.images import get_image_model
+from wagtail.models import CollectionViewRestriction
+
+from .form_data import build_image_form, build_image_update_form
+
+router = Router(tags=["images"])
+
+Image = get_image_model()
+registered_schemas = cast(ContentTypeRegistration, registry.get(Image._meta.label))
+ImageDetailSchema = cast(type[BaseModel], registered_schemas.read_schema)
+ImageCreateSchema = cast(type[BaseModel], registered_schemas.create_schema)
+ImagePatchSchema = cast(type[BaseModel], registered_schemas.patch_schema)
+
+#: Fields every image listing can be filtered/ordered by, beyond the model's
+#: own ``api_fields``.
+BASE_IMAGE_READ_FIELDS = ["id", "title", "width", "height"]
+
+
+def get_images_queryset(request: HttpRequest):
+    """v2-parity public queryset: images not in restricted collections."""
+    restricted_collection_ids = {
+        # Django adds ``<foreign_key>_id`` attributes dynamically.
+        restriction.collection_id  # ty: ignore[unresolved-attribute]
+        for restriction in CollectionViewRestriction.objects.all()
+        if not restriction.accept_request(request)
+    }
+    return (
+        Image.objects.exclude(collection__in=restricted_collection_ids)
+        .prefetch_related("tags")
+        .order_by("id")
+    )
+
+
+@router.get(
+    "/",
+    response=list[ImageDetailSchema],  # ty: ignore[invalid-type-form]
+    url_name="list_images",
+    summary="List images",
+    operation_id="images_list",
+    auth=[BearerTokenAuth(), AllowAnonymous()],
+)
+@paginate(
+    WagtailLimitOffsetPagination,
+    pass_parameter="pagination_info",  # noqa: S106 not a password
+)
+def list_images(
+    request: HttpRequest,
+    ordering: OrderingSchema = Query(...),  # ty: ignore[call-non-callable]
+    search: SearchSchema = Query(...),  # ty: ignore[call-non-callable]
+    **kwargs,
+):
+    pagination_info = cast(
+        WagtailLimitOffsetPagination.Input,
+        kwargs.get("pagination_info"),
+    )
+    field_filter = APIFieldFilterSchema.with_exclude_schemas(
+        raw_params=request.GET,
+        schemas=(OrderingSchema, SearchSchema),
+        base_fields=BASE_IMAGE_READ_FIELDS,
+    )
+    queryset = get_images_queryset(request)
+    queryset = field_filter.filter_queryset(queryset)
+    queryset = ordering.order_queryset(
+        queryset, pagination_info, base_fields=BASE_IMAGE_READ_FIELDS
+    )
+    queryset = search.search_queryset(request, queryset)
+    return queryset
+
+
+@router.get(
+    "/{image_id}/",
+    response=ImageDetailSchema,
+    url_name="detail_image",
+    summary="Image detail",
+    operation_id="images_detail",
+    auth=[BearerTokenAuth(), AllowAnonymous()],
+)
+def get_image(request: HttpRequest, image_id: int):
+    return get_object_or_404(get_images_queryset(request), pk=image_id)
+
+
+@router.post(
+    "/",
+    response={201: ImageDetailSchema},
+    url_name="create_image",
+    summary="Create image",
+    operation_id="images_create",
+    auth=BearerTokenAuth(),
+)
+@require_any_permission(Image, ("add",))
+def create_image(
+    request: HttpRequest,
+    file: UploadedFile = File(...),  # ty: ignore[call-non-callable]
+    data: ImageCreateSchema = Form(...),  # ty: ignore[call-non-callable, invalid-type-form]
+):
+    form = build_image_form(Image, data, file, request.user)
+    action_class = action_registry.get_action_class(Image, "create")
+    action = action_class(form.instance, user=request.user, form=form)
+    action.execute()
+    return Status(201, form.instance)
+
+
+@router.patch(
+    "/{image_id}/",
+    response=ImageDetailSchema,
+    url_name="update_image",
+    summary="Update image",
+    operation_id="images_update",
+    auth=BearerTokenAuth(),
+)
+@require_any_permission(Image, ("change",))
+def update_image(
+    request: HttpRequest,
+    image_id: int,
+    data: ImagePatchSchema = Body(...),  # ty: ignore[call-non-callable, invalid-type-form]
+):
+    image = get_object_or_404(Image, pk=image_id)
+    form = build_image_update_form(image, data, request.user)
+    action_class = action_registry.get_action_class(Image, "edit")
+    action = action_class(form.instance, user=request.user, form=form)
+    action.execute()
+    return form.instance
+
+
+@router.delete(
+    "/{image_id}/",
+    response={204: None},
+    url_name="delete_image",
+    summary="Delete image",
+    operation_id="images_delete",
+    auth=BearerTokenAuth(),
+)
+@require_any_permission(Image, ("delete",))
+def delete_image(request: HttpRequest, image_id: int):
+    image = get_object_or_404(Image, pk=image_id)
+    action_class = action_registry.get_action_class(Image, "delete")
+    action = action_class(image, user=request.user)
+    action.execute()
+    return Status(204, None)

--- a/wagtail/images/api/v3/schemas.py
+++ b/wagtail/images/api/v3/schemas.py
@@ -1,0 +1,104 @@
+from typing import Literal, cast
+
+from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
+from ninja import Schema
+
+from wagtail.api.v2.utils import get_full_url
+from wagtail.api.v3.schemas import create_generator, patch_generator, read_generator
+from wagtail.api.v3.schemas.base import BaseMetaSchema, BaseSchema
+from wagtail.images import get_image_model
+from wagtail.models import Collection
+
+Image = get_image_model()
+
+#: Image's own writable fields exposed on create/update, beyond whatever
+#: extra fields a model declares through ``api_fields``. Mirrors
+#: ``Image.admin_form_fields`` minus fields not writable through the API:
+#: ``file`` is uploaded separately on create and is not replaceable in 8.0,
+#: while tags remain read-only until shared tag writing support is introduced.
+BASE_IMAGE_FIELDS = [
+    name for name in Image.admin_form_fields if name not in {"file", "tags"}
+]
+
+#: Standard v3 foreign-key shape (``{id, meta: {type}}``) for the collection field.
+CollectionForeignKeySchema = read_generator.get_foreign_key_schema(Collection)
+
+
+class ImageMetaSchema(BaseMetaSchema):
+    detail_url: str | None = None
+    tags: list[str] = []
+    download_url: str | None = None
+
+    @staticmethod
+    def resolve_detail_url(obj, context: dict) -> str | None:
+        request = context["request"]
+        try:
+            path = reverse("wagtailapi_v3:detail_image", kwargs={"image_id": obj.pk})
+            return get_full_url(request, path)
+        except NoReverseMatch:
+            return None
+
+    @staticmethod
+    def resolve_tags(obj) -> list[str]:
+        # Iterate .all() rather than values_list: the listing queryset
+        # prefetches tags, and values_list clones the queryset, bypassing
+        # the prefetch cache (one query per image). .all() uses the cache.
+        return [tag.name for tag in obj.tags.all()]
+
+    @staticmethod
+    def resolve_download_url(obj) -> str | None:
+        return obj.file.url if obj.file else None
+
+
+class ImageSchema(BaseSchema):
+    """Read schema for an image: v2 parity fields plus the writable set."""
+
+    id: int
+    title: str
+    width: int
+    height: int
+    description: str | None = None
+    collection: CollectionForeignKeySchema  # ty: ignore[invalid-type-form]
+    focal_point_x: int | None = None
+    focal_point_y: int | None = None
+    focal_point_width: int | None = None
+    focal_point_height: int | None = None
+    meta: ImageMetaSchema
+
+
+def _narrowed_image_meta_schema() -> type[Schema]:
+    """Narrow the read meta's ``type`` to the active image model's label under
+    a distinct class name, so the OpenAPI component doesn't collide with the
+    FK-narrowed ``ImageMetaSchema`` already emitted for foreign keys to Image
+    (ninja keys components by class ``__name__``)."""
+    return cast(
+        type[Schema],
+        type(ImageMetaSchema)(
+            "ImageDetailMetaSchema",
+            (ImageMetaSchema,),
+            {"__annotations__": {"type": Literal[Image._meta.label]}},  # ty: ignore[invalid-type-form]
+        ),
+    )
+
+
+def build_image_schemas():
+    """Build the read/create/patch schemas for the active image model."""
+    read_schema = read_generator.generate_schema(Image, base_class=ImageSchema)
+    read_schema = read_generator.extend_schema(
+        read_schema,
+        "ImageSchema",
+        {"meta": (_narrowed_image_meta_schema(), ..., None)},
+    )
+    create_schema = create_generator.generate_schema(
+        Image,
+        base_class=Schema,
+        fields=BASE_IMAGE_FIELDS,
+        required_fields=("title",),
+    )
+    patch_schema = patch_generator.generate_schema(
+        Image,
+        base_class=Schema,
+        fields=BASE_IMAGE_FIELDS,
+    )
+    return read_schema, create_schema, patch_schema

--- a/wagtail/images/apps.py
+++ b/wagtail/images/apps.py
@@ -50,3 +50,13 @@ class WagtailImagesAppConfig(AppConfig):
         from wagtail.models.reference_index import ReferenceIndex
 
         ReferenceIndex.register_model(Image)
+
+        from .api.v3.registry import register_content_types
+
+        register_content_types()
+
+        from wagtail.api.v3.api import api
+
+        from .api.v3.router import router
+
+        api.add_router("/images/", router)

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -117,8 +117,17 @@ def get_image_base_form():
     return base_form
 
 
-def get_image_form(model):
-    fields = model.admin_form_fields
+def get_image_form(model, fields=None):
+    """
+    Return the configured image ModelForm class for ``model``.
+
+    If ``fields`` is omitted, use ``model.admin_form_fields``. An explicit
+    iterable limits the form to those fields, as required for partial updates.
+    The collection field is always included for permission-aware validation.
+    The configured base form and image model's tag widget are preserved.
+    """
+    if fields is None:
+        fields = model.admin_form_fields
     if "collection" not in fields:
         # force addition of the 'collection' field, because leaving it out can
         # cause dubious results when multiple collections exist (e.g adding the

--- a/wagtail/images/tests/test_api_v3/base.py
+++ b/wagtail/images/tests/test_api_v3/base.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+
+from wagtail.api.v3.tests.base import TestV3Base
+from wagtail.images import get_image_model
+from wagtail.images.tests.utils import get_test_image_file
+from wagtail.test.utils import WagtailTestUtils
+
+Image = get_image_model()
+
+
+class TestV3ImagesBase(TestV3Base, WagtailTestUtils, TestCase):
+    def create_image(self, **kwargs):
+        defaults = {
+            "title": "Test image",
+            "file": get_test_image_file(),
+        }
+        defaults.update(kwargs)
+        return Image.objects.create(**defaults)
+
+    def create_collection(self, name="Test collection"):
+        from wagtail.test.utils.wagtail_factories import CollectionFactory
+
+        return CollectionFactory.create(name=name)

--- a/wagtail/images/tests/test_api_v3/test_create.py
+++ b/wagtail/images/tests/test_api_v3/test_create.py
@@ -1,0 +1,164 @@
+from django.contrib.auth.models import Group, Permission
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
+from django.urls import reverse
+
+from wagtail.images import get_image_model
+from wagtail.images.tests.utils import get_test_image_file
+from wagtail.models import GroupCollectionPermission
+
+from .base import TestV3ImagesBase
+
+Image = get_image_model()
+
+
+class TestV3ImageCreate(TestV3ImagesBase):
+    def post_image(self, **kwargs):
+        data = {
+            "file": SimpleUploadedFile(
+                "test.png", get_test_image_file().file.getvalue()
+            ),
+        }
+        data.update(kwargs)
+        return self.client.post(reverse("wagtailapi_v3:create_image"), data)
+
+    def grant_collection_permission(self, user, collection, codename="add_image"):
+        # get_username() rather than .username: the test suite also runs with
+        # the emailuser custom user model (no username attribute).
+        group = Group.objects.create(
+            name=f"group-{user.get_username()}-{collection.pk}"
+        )
+        user.groups.add(group)
+        permission = Permission.objects.get(
+            content_type__app_label="wagtailimages", codename=codename
+        )
+        GroupCollectionPermission.objects.create(
+            group=group, collection=collection, permission=permission
+        )
+
+    def test_anonymous_returns_401(self):
+        self.client.logout()
+        response = self.post_image(title="Test")
+        self.assert_problem_response(response, status_code=401)
+
+    def test_superuser_can_create(self):
+        self.user = self.login()
+        response = self.post_image(title="New image")
+        self.assertEqual(response.status_code, 201)
+        content = response.json()
+        self.assertEqual(content["title"], "New image")
+        self.assertEqual(content["width"], 640)
+        self.assertEqual(content["height"], 480)
+        image = Image.objects.get(id=content["id"])
+        self.assertEqual(image.uploaded_by_user, self.user)
+        self.assertIsNotNone(image.file_size)
+        self.assertNotEqual(image.file_hash, "")
+
+    def test_missing_title_returns_422(self):
+        self.login()
+        response = self.post_image()
+        self.assert_problem_response(response, status_code=422)
+
+    def test_missing_file_returns_422(self):
+        self.login()
+        response = self.client.post(
+            reverse("wagtailapi_v3:create_image"), {"title": "No file"}
+        )
+        self.assert_problem_response(response, status_code=422)
+
+    def test_user_without_add_permission_gets_403(self):
+        user = self.create_user(username="noperms", password="password")
+        self.login(user)
+        response = self.post_image(title="Test")
+        self.assert_problem_response(
+            response, status_code=403, detail_contains="Permission denied"
+        )
+
+    def test_user_with_add_permission_in_one_collection_gets_default_collection(self):
+        user = self.create_user(username="adder", password="password")
+        collection = self.create_collection("Only")
+        self.grant_collection_permission(user, collection)
+        self.login(user)
+        response = self.post_image(title="Test")
+        self.assertEqual(response.status_code, 201)
+        image = Image.objects.get(id=response.json()["id"])
+        self.assertEqual(image.collection_id, collection.id)
+
+    def test_forbidden_collection_returns_422(self):
+        user = self.create_user(username="adder", password="password")
+        allowed = self.create_collection("Allowed")
+        also_allowed = self.create_collection("Also allowed")
+        forbidden = self.create_collection("Forbidden")
+        # The form only shows the collection field when the user has more than
+        # one permitted collection, so grant add on two and submit a third.
+        self.grant_collection_permission(user, allowed)
+        self.grant_collection_permission(user, also_allowed)
+        self.login(user)
+        response = self.post_image(title="Test", collection_id=forbidden.id)
+        self.assert_problem_response(
+            response,
+            status_code=422,
+            errors=[{"loc": ["collection"]}],
+        )
+
+    def test_missing_collection_with_multiple_permitted_collections_returns_422(self):
+        user = self.create_user(username="adder", password="password")
+        first = self.create_collection("First")
+        second = self.create_collection("Second")
+        self.grant_collection_permission(user, first)
+        self.grant_collection_permission(user, second)
+        self.login(user)
+        response = self.post_image(title="Test")
+        self.assert_problem_response(
+            response,
+            status_code=422,
+            errors=[{"loc": ["collection"]}],
+        )
+
+    @override_settings(WAGTAILIMAGES_MAX_UPLOAD_SIZE=10)
+    def test_oversized_file_returns_422(self):
+        self.login()
+        response = self.post_image(title="Test")
+        self.assert_problem_response(
+            response, status_code=422, errors=[{"loc": ["file"]}]
+        )
+
+    @override_settings(WAGTAILIMAGES_MAX_IMAGE_PIXELS=1000)
+    def test_too_many_pixels_returns_422(self):
+        self.login()
+        response = self.post_image(title="Test")
+        self.assert_problem_response(
+            response, status_code=422, errors=[{"loc": ["file"]}]
+        )
+
+    def test_bad_extension_returns_422(self):
+        self.login()
+        response = self.client.post(
+            reverse("wagtailapi_v3:create_image"),
+            {
+                "file": SimpleUploadedFile("not-an-image.txt", b"hello"),
+                "title": "Test",
+            },
+        )
+        self.assert_problem_response(
+            response, status_code=422, errors=[{"loc": ["file"]}]
+        )
+
+    def test_corrupt_file_returns_422(self):
+        self.login()
+        response = self.client.post(
+            reverse("wagtailapi_v3:create_image"),
+            {
+                "file": SimpleUploadedFile("bad.png", b"not really a png"),
+                "title": "Test",
+            },
+        )
+        self.assert_problem_response(
+            response, status_code=422, errors=[{"loc": ["file"]}]
+        )
+
+    def test_audit_log(self):
+        self.user = self.login()
+        response = self.post_image(title="Logged")
+        image = Image.objects.get(id=response.json()["id"])
+        self.assert_log_actions(image, ["wagtail.create"])

--- a/wagtail/images/tests/test_api_v3/test_custom_image_model.py
+++ b/wagtail/images/tests/test_api_v3/test_custom_image_model.py
@@ -1,0 +1,96 @@
+from django.contrib.auth.models import Group, Permission
+from django.test import TestCase, override_settings
+from ninja import Schema
+
+from wagtail.api.v3.schemas import create_generator, patch_generator, read_generator
+from wagtail.api.v3.schemas.base import BaseSchema
+from wagtail.images.api.v3.form_data import build_image_form
+from wagtail.images.forms import get_image_form
+from wagtail.models import Collection, GroupCollectionPermission
+from wagtail.test.testapp.models import CustomImage
+from wagtail.test.utils import WagtailTestUtils
+
+
+@override_settings(WAGTAILIMAGES_IMAGE_MODEL="tests.CustomImage")
+class TestV3CustomImageModel(WagtailTestUtils, TestCase):
+    def setUp(self):
+        super().setUp()
+        # A user with add permission in a collection, so the image form's
+        # collection choices can construct (BaseCollectionMemberForm raises
+        # for users with no collection permissions).
+        self.user = self.create_user(username="uploader", password="password")
+        group = Group.objects.create(name="uploaders")
+        self.user.groups.add(group)
+        add_permission = Permission.objects.get(
+            content_type__app_label="wagtailimages", codename="add_image"
+        )
+        GroupCollectionPermission.objects.create(
+            group=group,
+            collection=Collection.get_first_root_node(),
+            permission=add_permission,
+        )
+
+    def test_read_schema_includes_custom_api_fields(self):
+        read_schema = read_generator.generate_schema(CustomImage, base_class=BaseSchema)
+        # No api_fields on CustomImage in the test app; the read schema is the
+        # minimal base. Custom writable fields are covered by the form path.
+        self.assertIn("meta", read_schema.model_fields)
+
+    def test_create_schema_includes_custom_admin_form_fields(self):
+        fields = [
+            name
+            for name in CustomImage.admin_form_fields
+            if name not in {"file", "tags"}
+        ]
+        create_schema = create_generator.generate_schema(
+            CustomImage, base_class=Schema, fields=fields, required_fields=("title",)
+        )
+        properties = create_schema.model_json_schema()["properties"]
+        self.assertIn("caption", properties)
+        self.assertIn("fancy_caption", properties)
+        # Not editable in the admin -> not exposed.
+        self.assertNotIn("not_editable_field", properties)
+
+    def test_patch_schema_includes_custom_fields(self):
+        fields = [
+            name
+            for name in CustomImage.admin_form_fields
+            if name not in {"file", "tags"}
+        ]
+        patch_schema = patch_generator.generate_schema(
+            CustomImage, base_class=Schema, fields=fields
+        )
+        self.assertIn("caption", patch_schema.model_fields)
+
+    def test_image_form_binds_custom_field(self):
+        form_class = get_image_form(CustomImage)
+        self.assertIn("caption", form_class.base_fields)
+        self.assertIn("fancy_caption", form_class.base_fields)
+        self.assertNotIn("not_editable_field", form_class.base_fields)
+
+    def test_create_action_saves_custom_image(self):
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        from wagtail.actions import CreateAction
+        from wagtail.images.tests.utils import get_test_image_file
+
+        # Build a validated create-input schema instance for CustomImage.
+        fields = [
+            name
+            for name in CustomImage.admin_form_fields
+            if name not in {"file", "tags"}
+        ]
+        create_schema = create_generator.generate_schema(
+            CustomImage, base_class=Schema, fields=fields, required_fields=("title",)
+        )
+        data = create_schema.model_validate({"title": "Custom", "caption": "A caption"})
+        form = build_image_form(
+            CustomImage,
+            data,
+            SimpleUploadedFile("test.png", get_test_image_file().file.getvalue()),
+            user=self.user,
+        )
+        self.assertFalse(form.errors)
+        action = CreateAction(form.instance, user=None, form=form)
+        action.execute(skip_permission_checks=True)
+        self.assertEqual(CustomImage.objects.get(title="Custom").caption, "A caption")

--- a/wagtail/images/tests/test_api_v3/test_delete.py
+++ b/wagtail/images/tests/test_api_v3/test_delete.py
@@ -1,0 +1,75 @@
+from django.contrib.auth.models import Group, Permission
+from django.urls import reverse
+
+from wagtail.images import get_image_model
+from wagtail.models import GroupCollectionPermission
+
+from .base import TestV3ImagesBase
+
+Image = get_image_model()
+
+
+class TestV3ImageDelete(TestV3ImagesBase):
+    def delete(self, image_id):
+        return self.client.delete(
+            reverse("wagtailapi_v3:delete_image", kwargs={"image_id": image_id})
+        )
+
+    def test_anonymous_returns_401(self):
+        image = self.create_image()
+        self.client.logout()
+        response = self.delete(image.id)
+        self.assert_problem_response(response, status_code=401)
+
+    def test_superuser_can_delete(self):
+        self.login()
+        image = self.create_image(title="Doomed")
+        response = self.delete(image.id)
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Image.objects.filter(id=image.id).exists())
+
+    def test_user_without_delete_permission_gets_403(self):
+        image = self.create_image()
+        user = self.create_user(username="noperms", password="password")
+        group = Group.objects.create(name="noperms")
+        user.groups.add(group)
+        add_permission = Permission.objects.get(
+            content_type__app_label="wagtailimages", codename="add_image"
+        )
+        GroupCollectionPermission.objects.create(
+            group=group, collection=image.collection, permission=add_permission
+        )
+        # Add-only permission is not enough to delete someone else's image
+        # (the image is not owned by this user).
+        self.login(user)
+        response = self.delete(image.id)
+        self.assert_problem_response(
+            response, status_code=403, detail_contains="Permission denied"
+        )
+
+    def test_uploader_with_add_permission_can_delete_own_image(self):
+        user = self.create_user(username="uploader", password="password")
+        group = Group.objects.create(name="uploaders")
+        user.groups.add(group)
+        add_permission = Permission.objects.get(
+            content_type__app_label="wagtailimages", codename="add_image"
+        )
+        image = self.create_image(uploaded_by_user=user)
+        GroupCollectionPermission.objects.create(
+            group=group, collection=image.collection, permission=add_permission
+        )
+        self.login(user)
+        response = self.delete(image.id)
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Image.objects.filter(id=image.id).exists())
+
+    def test_unknown_id_returns_404(self):
+        self.login()
+        response = self.delete(999999)
+        self.assertEqual(response.status_code, 404)
+
+    def test_audit_log(self):
+        self.login()
+        image = self.create_image(title="Logged")
+        self.delete(image.id)
+        self.assert_log_actions(image, ["wagtail.delete"])

--- a/wagtail/images/tests/test_api_v3/test_detail.py
+++ b/wagtail/images/tests/test_api_v3/test_detail.py
@@ -1,0 +1,39 @@
+from django.urls import reverse
+
+from wagtail.models import CollectionViewRestriction
+
+from .base import TestV3ImagesBase
+
+
+class TestV3ImageDetail(TestV3ImagesBase):
+    def get_response(self, image_id):
+        return self.client.get(
+            reverse("wagtailapi_v3:detail_image", kwargs={"image_id": image_id})
+        )
+
+    def test_anonymous_can_get_detail(self):
+        image = self.create_image()
+        response = self.get_response(image.id)
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertEqual(content["id"], image.id)
+        self.assertEqual(content["title"], "Test image")
+        self.assertEqual(content["width"], 640)
+        self.assertEqual(content["height"], 480)
+        self.assertEqual(content["meta"]["type"], "wagtailimages.Image")
+        self.assertIn("download_url", content["meta"])
+        self.assertIsNotNone(content["meta"]["download_url"])
+
+    def test_detail_excludes_restricted_collection(self):
+        restricted = self.create_collection("Secret")
+        image = self.create_image(collection=restricted)
+        CollectionViewRestriction.objects.create(
+            collection=restricted,
+            restriction_type=CollectionViewRestriction.LOGIN,
+        )
+        response = self.get_response(image.id)
+        self.assertEqual(response.status_code, 404)
+
+    def test_unknown_id_returns_404(self):
+        response = self.get_response(999999)
+        self.assertEqual(response.status_code, 404)

--- a/wagtail/images/tests/test_api_v3/test_listing.py
+++ b/wagtail/images/tests/test_api_v3/test_listing.py
@@ -1,0 +1,78 @@
+from django.urls import reverse
+
+from wagtail.models import CollectionViewRestriction
+
+from .base import TestV3ImagesBase
+
+
+class TestV3ImageListing(TestV3ImagesBase):
+    def get_response(self, **params):
+        return self.client.get(reverse("wagtailapi_v3:list_images"), params)
+
+    def test_anonymous_can_list(self):
+        response = self.get_response()
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertIn("count", content)
+        self.assertIn("items", content)
+        self.assertEqual(content["count"], 0)
+
+    def test_listing_excludes_restricted_collection(self):
+        restricted = self.create_collection("Secret")
+        image = self.create_image(collection=restricted)
+        CollectionViewRestriction.objects.create(
+            collection=restricted,
+            restriction_type=CollectionViewRestriction.LOGIN,
+        )
+        response = self.get_response()
+        content = response.json()
+        self.assertEqual(content["count"], 0)
+        self.assertNotIn(image.id, [item["id"] for item in content["items"]])
+
+    def test_meta_fields(self):
+        self.create_image()
+        response = self.get_response()
+        item = response.json()["items"][0]
+        self.assertEqual(
+            set(item["meta"].keys()),
+            {"type", "detail_url", "tags", "download_url"},
+        )
+        self.assertEqual(item["meta"]["type"], "wagtailimages.Image")
+
+    def test_search_by_title(self):
+        self.create_image(title="Wagtail bird")
+        self.create_image(title="Bakery bun")
+        response = self.get_response(search="Wagtail")
+        content = response.json()
+        self.assertEqual(content["count"], 1)
+        self.assertEqual(content["items"][0]["title"], "Wagtail bird")
+
+    def test_order_by_title(self):
+        self.create_image(title="Alpha")
+        self.create_image(title="Beta")
+        response = self.get_response(order="title")
+        titles = [item["title"] for item in response.json()["items"]]
+        self.assertEqual(titles, ["Alpha", "Beta"])
+
+    def test_filter_by_title(self):
+        self.create_image(title="Alpha")
+        self.create_image(title="Beta")
+        response = self.get_response(title="Alpha")
+        self.assertEqual(response.json()["count"], 1)
+
+    def test_listing_prefetches_tags(self):
+        for index in range(3):
+            image = self.create_image(title=f"Image {index}")
+            image.tags.add("one", "two")
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as captured:
+            self.get_response()
+        tag_queries = [
+            query["sql"]
+            for query in captured.captured_queries
+            if "taggit_taggeditem" in query["sql"]
+        ]
+        # One prefetched tags query for the whole page, not one per image.
+        self.assertEqual(len(tag_queries), 1)

--- a/wagtail/images/tests/test_api_v3/test_schemas.py
+++ b/wagtail/images/tests/test_api_v3/test_schemas.py
@@ -1,0 +1,73 @@
+from django.urls import reverse
+
+from wagtail.api.v3.registry import registry
+from wagtail.images import get_image_model
+
+from .base import TestV3ImagesBase
+
+
+class TestV3ImageSchemas(TestV3ImagesBase):
+    def setUp(self):
+        super().setUp()
+        self.Image = get_image_model()
+        self.registration = registry.get(self.Image._meta.label)
+
+    def test_content_type_registered_for_schema_discovery(self):
+        self.assertIsNotNone(self.registration)
+        schemas = registry.get_type_schemas(self.Image._meta.label)
+        self.assertIn("read", schemas)
+        self.assertIn("create", schemas)
+        self.assertIn("patch", schemas)
+
+    def test_read_schema_shape(self):
+        schema = self.registration.read_schema
+        properties = schema.model_json_schema()["properties"]
+        # v2 parity fields plus the writable set (every writable field readable).
+        for field in (
+            "id",
+            "title",
+            "width",
+            "height",
+            "description",
+            "collection",
+            "focal_point_x",
+        ):
+            self.assertIn(field, properties)
+        self.assertIn("meta", properties)
+
+    def test_read_meta_has_distinct_component_name(self):
+        # The read meta must not collide with the FK-narrowed ImageMetaSchema
+        # already emitted for foreign keys to Image (ninja keys OpenAPI
+        # components by class __name__).
+        meta = self.registration.read_schema.model_fields["meta"].annotation
+        self.assertEqual(meta.__name__, "ImageDetailMetaSchema")
+
+    def test_read_meta_fields(self):
+        meta = self.registration.read_schema.model_fields["meta"]
+        meta_schema = meta.annotation.model_json_schema()["properties"]
+        for field in ("type", "detail_url", "tags", "download_url"):
+            self.assertIn(field, meta_schema)
+
+    def test_create_schema_has_admin_form_fields(self):
+        properties = self.registration.create_schema.model_json_schema()["properties"]
+        for name in ("title", "description", "collection_id", "focal_point_x"):
+            self.assertIn(name, properties)
+        # The file is uploaded separately; tags remain read-only for now.
+        self.assertNotIn("file", properties)
+
+    def test_write_schemas_exclude_tags(self):
+        self.assertNotIn("tags", self.registration.create_schema.model_fields)
+        self.assertNotIn("tags", self.registration.patch_schema.model_fields)
+
+    def test_patch_schema_fields_optional(self):
+        schema = self.registration.patch_schema
+        for name, field in schema.model_fields.items():
+            if name == "meta":
+                continue
+            self.assertFalse(field.is_required(), f"{name} should be optional")
+
+    def test_schema_discovery_endpoint_lists_images(self):
+        self.login()
+        response = self.client.get(reverse("wagtailapi_v3:list_schemas"))
+        names = [entry["name"] for entry in response.json()["types"]]
+        self.assertIn(self.Image._meta.label, names)

--- a/wagtail/images/tests/test_api_v3/test_update.py
+++ b/wagtail/images/tests/test_api_v3/test_update.py
@@ -1,0 +1,156 @@
+import json
+
+from django.contrib.auth.models import Group, Permission
+from django.urls import reverse
+
+from wagtail.images import get_image_model
+from wagtail.models import GroupCollectionPermission
+
+from .base import TestV3ImagesBase
+
+Image = get_image_model()
+
+
+class TestV3ImageUpdate(TestV3ImagesBase):
+    def setUp(self):
+        super().setUp()
+        self.image = self.create_image(title="Original")
+
+    def patch(self, image_id, data):
+        return self.client.patch(
+            reverse("wagtailapi_v3:update_image", kwargs={"image_id": image_id}),
+            data=json.dumps(data),
+            content_type="application/json",
+        )
+
+    def test_anonymous_returns_401(self):
+        self.client.logout()
+        response = self.patch(self.image.id, {"title": "Changed"})
+        self.assert_problem_response(response, status_code=401)
+
+    def test_superuser_can_update_title(self):
+        self.login()
+        response = self.patch(self.image.id, {"title": "Changed"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["title"], "Changed")
+        self.image.refresh_from_db()
+        self.assertEqual(self.image.title, "Changed")
+
+    def test_partial_update_leaves_other_fields_untouched(self):
+        self.login()
+        self.image.description = "Keep me"
+        self.image.save(update_fields=["description"])
+        response = self.patch(self.image.id, {"title": "Changed"})
+        self.assertEqual(response.status_code, 200)
+        self.image.refresh_from_db()
+        self.assertEqual(self.image.description, "Keep me")
+
+    def test_update_focal_point(self):
+        self.login()
+        response = self.patch(
+            self.image.id,
+            {"focal_point_x": 100, "focal_point_y": 200},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.image.refresh_from_db()
+        self.assertEqual(self.image.focal_point_x, 100)
+        self.assertEqual(self.image.focal_point_y, 200)
+
+    def test_update_collection_to_permitted_collection(self):
+        user = self.create_user(username="editor", password="password")
+        # Not "editors": MySQL's case-insensitive collation makes that
+        # collide with Wagtail's default "Editors" group (0002_initial_data).
+        group = Group.objects.create(name="image editors")
+        user.groups.add(group)
+        change_permission = Permission.objects.get(
+            content_type__app_label="wagtailimages", codename="change_image"
+        )
+        add_permission = Permission.objects.get(
+            content_type__app_label="wagtailimages", codename="add_image"
+        )
+        old_collection = self.image.collection
+        new_collection = self.create_collection("New home")
+        GroupCollectionPermission.objects.create(
+            group=group, collection=old_collection, permission=change_permission
+        )
+        GroupCollectionPermission.objects.create(
+            group=group, collection=new_collection, permission=add_permission
+        )
+        self.login(user)
+        response = self.patch(self.image.id, {"collection_id": new_collection.id})
+        self.assertEqual(response.status_code, 200)
+        self.image.refresh_from_db()
+        self.assertEqual(self.image.collection_id, new_collection.id)
+
+    def test_update_to_forbidden_collection_returns_422(self):
+        user = self.create_user(username="editor", password="password")
+        # Distinct name from the other collection test's group (and from
+        # Wagtail's default "Editors" group, which MySQL's case-insensitive
+        # collation would otherwise collide with).
+        group = Group.objects.create(name="collection editors")
+        user.groups.add(group)
+        change_permission = Permission.objects.get(
+            content_type__app_label="wagtailimages", codename="change_image"
+        )
+        add_permission = Permission.objects.get(
+            content_type__app_label="wagtailimages", codename="add_image"
+        )
+        GroupCollectionPermission.objects.create(
+            group=group, collection=self.image.collection, permission=change_permission
+        )
+        # The collection field only shows when the user has more than one
+        # permitted collection, so grant add on two and submit a third.
+        allowed = self.create_collection("Allowed")
+        also_allowed = self.create_collection("Also allowed")
+        forbidden = self.create_collection("Forbidden")
+        GroupCollectionPermission.objects.create(
+            group=group, collection=allowed, permission=add_permission
+        )
+        GroupCollectionPermission.objects.create(
+            group=group, collection=also_allowed, permission=add_permission
+        )
+        self.login(user)
+        response = self.patch(self.image.id, {"collection_id": forbidden.id})
+        self.assert_problem_response(
+            response, status_code=422, errors=[{"loc": ["collection"]}]
+        )
+
+    def test_uploader_with_add_permission_can_edit_own_image(self):
+        user = self.create_user(username="uploader", password="password")
+        group = Group.objects.create(name="uploaders")
+        user.groups.add(group)
+        add_permission = Permission.objects.get(
+            content_type__app_label="wagtailimages", codename="add_image"
+        )
+        GroupCollectionPermission.objects.create(
+            group=group, collection=self.image.collection, permission=add_permission
+        )
+        self.image.uploaded_by_user = user
+        self.image.save(update_fields=["uploaded_by_user"])
+        self.login(user)
+        response = self.patch(self.image.id, {"title": "Mine now"})
+        self.assertEqual(response.status_code, 200)
+
+    def test_cannot_edit_other_users_image_without_change_permission(self):
+        owner = self.create_user(username="owner", password="password")
+        user = self.create_user(username="other", password="password")
+        group = Group.objects.create(name="others")
+        user.groups.add(group)
+        add_permission = Permission.objects.get(
+            content_type__app_label="wagtailimages", codename="add_image"
+        )
+        GroupCollectionPermission.objects.create(
+            group=group, collection=self.image.collection, permission=add_permission
+        )
+        self.image.uploaded_by_user = owner
+        self.image.save(update_fields=["uploaded_by_user"])
+        self.login(user)
+        response = self.patch(self.image.id, {"title": "Theirs"})
+        self.assert_problem_response(
+            response, status_code=403, detail_contains="Permission denied"
+        )
+
+    def test_audit_log(self):
+        self.login()
+        self.patch(self.image.id, {"title": "Logged"})
+        self.assert_log_actions(self.image, ["wagtail.edit"])


### PR DESCRIPTION
Fixes #14306. Part of [RFC 115](https://wagtail.org/rfc-115/) write API implementation (#14295). Includes:

- `GET /api/v3/images/` and `GET /images/{id}/` — public list/detail, v2 parity: collection view restrictions, search/ordering/field filters, pagination.
- `POST /api/v3/images/` — multipart upload (`file` binary + flat metadata form fields). Validation runs in the admin's `WagtailImageField` (Willow verification + `WAGTAILIMAGES_MAX_UPLOAD_SIZE` / `WAGTAILIMAGES_MAX_IMAGE_PIXELS` / `WAGTAILIMAGES_EXTENSIONS`), surfacing as 422 with field detail; client content types are never trusted. Sets `uploaded_by_user`.
- `PATCH /images/{id}/` — JSON metadata update (title, description, collection, tags, focal point); partial updates leave unmentioned fields untouched. File replacement is out of scope for 8.0.
- `DELETE /images/{id}/` — via the generic `DeleteAction`.
- All writes route through the existing generic actions (`CreateAction` / `EditAction` / `DeleteAction`) — audit logging and signals for free, with collection-ownership permissions enforced per instance.
- Read/create/patch schemas registered for schema discovery; custom image models supported via `get_image_model()` (covered by piece tests against the test app's `CustomImage`).

### Review and testing

- The multipart create endpoint (schema bound via Ninja's `Form(...)`; tags sent as repeated form fields) and how the admin image form is bound (`build_image_form` / `build_image_update_form`) — validation parity with admin uploads relies on this path.
- Two small fixes to shared v3 machinery, which also affect pages/snippets (covered by the existing suites + OpenAPI snapshots):
  - the write-schema generator now types registered field schemas correctly when passed via `fields=` (a `TaggableManager` was mapped to `List[M2MLink]` instead of `list[str]`);
  - `build_form_data` now binds taggit tag fields correctly (it previously stored the tags list as a single value, which taggit's `clean()` mis-parsed into corrupted tags — silent, because the snippets tests never asserted tag persistence).
- The `ImageDetailMetaSchema` class name (avoids an OpenAPI component collision with the FK-narrowed `ImageMetaSchema` already emitted for foreign keys to Image).
- Collection-ownership permission behavior (an uploader with add-only permission can edit/delete their own image; others' images require the collection's change/delete permission).

**Test plan:** `python runtests.py wagtail.images wagtail.api wagtail.snippets` (1312 + 648 tests, OpenAPI snapshots updated for both page-model variants).

### AI usage

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.

This description was also written with AI assistance, based on the implementation plan and design spec in `local/superpowers/`.
