### PR TITLE
Add revisions endpoints to pages and snippets

### DIFF
--- a/wagtail/api/v3/routers/pages.py
+++ b/wagtail/api/v3/routers/pages.py
@@ -29,6 +29,7 @@ from wagtail.api.v3.schemas.pages import BASE_PAGE_READ_FIELDS, PageTypeInjectin
 from wagtail.api.v3.schemas.params import (
     APIFieldFilterSchema,
     OrderingSchema,
+    RevisionFilterSchema,
     SearchSchema,
     locale_filter_q,
 )
@@ -347,10 +348,16 @@ def _check_can_view_revisions(request: HttpRequest, page: Page) -> None:
     operation_id="pages_revisions_list",
 )
 @paginate(WagtailLimitOffsetPagination)
-def list_page_revisions(request: HttpRequest, page_id: int, **kwargs):
+def list_page_revisions(
+    request: HttpRequest,
+    page_id: int,
+    filters: RevisionFilterSchema = Query(...),  # ty: ignore[call-non-callable]
+    **kwargs,
+):
     page = get_object_or_404(_public_pages_queryset(request), pk=page_id).specific
     _check_can_view_revisions(request, page)
-    return page.revisions.order_by("-created_at", "-id")
+    queryset = page.revisions.order_by("-created_at", "-id")
+    return filters.filter(queryset)
 
 
 @router.get(

--- a/wagtail/api/v3/routers/pages.py
+++ b/wagtail/api/v3/routers/pages.py
@@ -51,6 +51,10 @@ PageCreateSchema = _page_schemas.create
 PageUpdateSchema = _page_schemas.update
 
 
+class PageRevisionDetailSchema(RevisionDetailSchema):
+    content_object: PageDetailSchema
+
+
 def _public_pages_queryset(request: HttpRequest, model=Page):
     # Stable ordering so offset/limit pagination is deterministic (v2 parity).
     return get_pages_queryset(request, tier=AccessTier.PUBLIC, model=model).order_by(
@@ -362,7 +366,7 @@ def list_page_revisions(
 
 @router.get(
     "/{page_id}/revisions/{revision_id}/",
-    response=RevisionDetailSchema,
+    response=PageRevisionDetailSchema,
     url_name="detail_page_revision",
     summary="Page revision detail",
     operation_id="pages_revisions_detail",

--- a/wagtail/api/v3/routers/pages.py
+++ b/wagtail/api/v3/routers/pages.py
@@ -3,6 +3,7 @@ from typing import Literal, Optional, TypeAlias, cast
 import swapper
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import PermissionDenied
 from django.db.models import Model, Q
 from django.http import Http404, HttpRequest
 from django.shortcuts import get_object_or_404, redirect
@@ -31,6 +32,7 @@ from wagtail.api.v3.schemas.params import (
     SearchSchema,
     locale_filter_q,
 )
+from wagtail.api.v3.schemas.revisions import RevisionDetailSchema, RevisionSchema
 from wagtail.api.validators import SiteFilterValidator
 from wagtail.coreutils import find_available_slug, resolve_model_string
 from wagtail.models import Locale, Site, get_page_models
@@ -329,6 +331,40 @@ def update_page(
     )
     action.execute()
     return form.instance
+
+
+def _check_can_view_revisions(request: HttpRequest, page: Page) -> None:
+    perms = page.permissions_for_user(request.user)
+    if not (perms.can_publish() or perms.can_edit()):
+        raise PermissionDenied
+
+
+@router.get(
+    "/{page_id}/revisions/",
+    response=list[RevisionSchema],
+    url_name="list_page_revisions",
+    summary="List page revisions",
+    operation_id="pages_revisions_list",
+)
+@paginate(WagtailLimitOffsetPagination)
+def list_page_revisions(request: HttpRequest, page_id: int, **kwargs):
+    page = get_object_or_404(_public_pages_queryset(request), pk=page_id).specific
+    _check_can_view_revisions(request, page)
+    return page.revisions.order_by("-created_at", "-id")
+
+
+@router.get(
+    "/{page_id}/revisions/{revision_id}/",
+    response=RevisionDetailSchema,
+    url_name="detail_page_revision",
+    summary="Page revision detail",
+    operation_id="pages_revisions_detail",
+)
+def get_page_revision(request: HttpRequest, page_id: int, revision_id: PositiveInt):
+    page = get_object_or_404(_public_pages_queryset(request), pk=page_id).specific
+    _check_can_view_revisions(request, page)
+    revisions = page.revisions.select_related("content_type", "base_content_type")
+    return get_object_or_404(revisions, pk=revision_id)
 
 
 @actions_router.post(

--- a/wagtail/api/v3/schemas/params.py
+++ b/wagtail/api/v3/schemas/params.py
@@ -1,11 +1,13 @@
-from typing import ClassVar, Literal, Optional
+from datetime import datetime
+from typing import Annotated, ClassVar, Literal, Optional
 
 from django.conf import settings
 from django.db import models
 from django.db.models import Q, QuerySet
 from django.http import HttpRequest, QueryDict
 from django.shortcuts import get_object_or_404
-from ninja import NinjaAPI, Schema
+from ninja import FilterSchema, NinjaAPI, Schema
+from ninja.filter_schema import FilterLookup
 from ninja.params.models import Body, BodyModel
 from ninja.types import DictStrAny
 from pydantic import TypeAdapter, model_validator
@@ -268,3 +270,20 @@ class TranslationFilterSchema(Schema):
             queryset = queryset.filter(translation_of_q(instance))
 
         return queryset
+
+
+class RevisionFilterSchema(FilterSchema):
+    created_at_from: Annotated[Optional[datetime], FilterLookup("created_at__gte")] = (
+        None
+    )
+    created_at_to: Annotated[Optional[datetime], FilterLookup("created_at__lte")] = None
+    user_id: Optional[int | str] = None
+    approved_go_live_at_from: Annotated[
+        Optional[datetime],
+        FilterLookup("approved_go_live_at__gte"),
+    ] = None
+    approved_go_live_at_to: Annotated[
+        Optional[datetime],
+        FilterLookup("approved_go_live_at__lte"),
+    ] = None
+    object_str: Annotated[Optional[str], FilterLookup("object_str__icontains")] = None

--- a/wagtail/api/v3/schemas/revisions.py
+++ b/wagtail/api/v3/schemas/revisions.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Optional
+from uuid import UUID
 
 from django.contrib.contenttypes.models import ContentType
 from pydantic import PositiveInt
@@ -27,7 +28,7 @@ class RevisionSchema(BaseSchema):
     id: PositiveInt
     object_id: str
     created_at: datetime
-    user_id: Optional[int | str] = None
+    user_id: Optional[int | str | UUID] = None
     object_str: str
     approved_go_live_at: Optional[datetime] = None
 

--- a/wagtail/api/v3/schemas/revisions.py
+++ b/wagtail/api/v3/schemas/revisions.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Optional
+from typing import Optional
 
 from django.contrib.contenttypes.models import ContentType
 from pydantic import PositiveInt
@@ -35,4 +35,9 @@ class RevisionSchema(BaseSchema):
 class RevisionDetailSchema(RevisionSchema):
     content_type: ContentTypeSchema
     base_content_type: ContentTypeSchema
-    content: dict[str, Any]
+    # Subclasses must define the type of content_object, which is a schema of
+    # the model instance that the revision is for.
+
+    @staticmethod
+    def resolve_content_object(obj):
+        return obj.as_object()

--- a/wagtail/api/v3/schemas/revisions.py
+++ b/wagtail/api/v3/schemas/revisions.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from typing import Any, Optional
+
+from django.contrib.contenttypes.models import ContentType
+from pydantic import PositiveInt
+
+from .base import BaseSchema
+
+
+class ContentTypeSchema(BaseSchema):
+    id: int
+    name: str
+    label: str
+
+    @staticmethod
+    def resolve_name(obj: ContentType) -> str:
+        model = obj.model_class()
+        return model._meta.label if model else f"{obj.app_label}.{obj.model}"
+
+    @staticmethod
+    def resolve_label(obj: ContentType) -> str:
+        model = obj.model_class()
+        return str(model._meta.verbose_name) if model else obj.model
+
+
+class RevisionSchema(BaseSchema):
+    id: PositiveInt
+    object_id: str
+    created_at: datetime
+    user_id: Optional[int | str] = None
+    object_str: str
+    approved_go_live_at: Optional[datetime] = None
+
+
+class RevisionDetailSchema(RevisionSchema):
+    content_type: ContentTypeSchema
+    base_content_type: ContentTypeSchema
+    content: dict[str, Any]

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -22137,6 +22137,85 @@
         "title": "RevisionDetailSchema",
         "type": "object"
       },
+      "RevisionFilterSchema": {
+        "properties": {
+          "approved_go_live_at_from": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved Go Live At From"
+          },
+          "approved_go_live_at_to": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved Go Live At To"
+          },
+          "created_at_from": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At From"
+          },
+          "created_at_to": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At To"
+          },
+          "object_str": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Object Str"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "title": "RevisionFilterSchema",
+        "type": "object"
+      },
       "RevisionSchema": {
         "properties": {
           "approved_go_live_at": {
@@ -38260,6 +38339,109 @@
             "schema": {
               "title": "Page Id",
               "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at_from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created At From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at_to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created At To"
+            }
+          },
+          {
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "approved_go_live_at_from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Approved Go Live At From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "approved_go_live_at_to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Approved Go Live At To"
+            }
+          },
+          {
+            "in": "query",
+            "name": "object_str",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Object Str"
             }
           },
           {

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -19685,6 +19685,332 @@
         "title": "PageRevertSchema",
         "type": "object"
       },
+      "PageRevisionDetailSchema": {
+        "properties": {
+          "approved_go_live_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved Go Live At"
+          },
+          "base_content_type": {
+            "$ref": "#/components/schemas/ContentTypeSchema"
+          },
+          "content_object": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/PageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/EarlyPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SimplePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/NoPromotePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/MultiPreviewModesPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/CustomPreviewSizesPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/PageWithExcludedCopyFieldSchema"
+              },
+              {
+                "$ref": "#/components/schemas/PageWithGenericRelationSchema"
+              },
+              {
+                "$ref": "#/components/schemas/PageWithOldStyleRouteMethodSchema"
+              },
+              {
+                "$ref": "#/components/schemas/FilePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/abc__EventPageSchema__1"
+              },
+              {
+                "$ref": "#/components/schemas/FormClassAdditionalFieldPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SingleEventPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/EventIndexSchema"
+              },
+              {
+                "$ref": "#/components/schemas/abc__FormPageSchema__1"
+              },
+              {
+                "$ref": "#/components/schemas/JadeFormPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/FormPageWithRedirectSchema"
+              },
+              {
+                "$ref": "#/components/schemas/FormPageWithCustomSubmissionSchema"
+              },
+              {
+                "$ref": "#/components/schemas/FormPageWithCustomSubmissionListViewSchema"
+              },
+              {
+                "$ref": "#/components/schemas/FormPageWithCustomFormBuilderSchema"
+              },
+              {
+                "$ref": "#/components/schemas/StandardIndexSchema"
+              },
+              {
+                "$ref": "#/components/schemas/PromotionalPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/StandardChildSchema"
+              },
+              {
+                "$ref": "#/components/schemas/BusinessIndexSchema"
+              },
+              {
+                "$ref": "#/components/schemas/BusinessSubIndexSchema"
+              },
+              {
+                "$ref": "#/components/schemas/BusinessChildSchema"
+              },
+              {
+                "$ref": "#/components/schemas/BusinessNowherePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/CustomCopyFormPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/TaggedPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/TaggedChildPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/TaggedGrandchildPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SingletonPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SingletonPageViaMaxCountSchema"
+              },
+              {
+                "$ref": "#/components/schemas/StreamPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/DefaultStreamPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/ComplexDefaultStreamPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/MTIBasePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/MTIChildPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/NoCreatableSubpageTypesPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/NoSubpageTypesPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/ManyToManyBlogPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/OneToOnePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/GenericSnippetPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/CustomManagerPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/MyCustomPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/ValidatedPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/DefaultRichTextFieldPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/DefaultRichBlockFieldPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/CustomRichTextFieldPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/CustomRichBlockFieldPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/RichTextFieldWithFeaturesPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SectionedRichTextPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/InlineStreamPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/TableBlockStreamPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/AlwaysShowInMenusPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/AddedStreamFieldWithoutDefaultPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/AddedStreamFieldWithEmptyStringDefaultPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/AddedStreamFieldWithEmptyListDefaultPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SecretPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleParentPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleChildPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/abc__PersonPageSchema__1"
+              },
+              {
+                "$ref": "#/components/schemas/RestaurantPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/DeadlyStreamPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/GalleryPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/GenericSnippetNoIndexPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/GenericSnippetNoFieldIndexPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/CustomPermissionPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/RequiredDatePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/CommentableJSONPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/HomePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/StandardPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/StandardIndexPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/BlogEntryPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/BlogIndexPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/abc__EventPageSchema__2"
+              },
+              {
+                "$ref": "#/components/schemas/EventIndexPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/abc__PersonPageSchema__2"
+              },
+              {
+                "$ref": "#/components/schemas/ContactPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/abc__FormPageSchema__2"
+              },
+              {
+                "$ref": "#/components/schemas/RoutablePageTestSchema"
+              },
+              {
+                "$ref": "#/components/schemas/RoutablePageWithOverriddenIndexRouteTestSchema"
+              },
+              {
+                "$ref": "#/components/schemas/TestPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SamplePageSchema"
+              }
+            ],
+            "title": "Content Object"
+          },
+          "content_type": {
+            "$ref": "#/components/schemas/ContentTypeSchema"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "exclusiveMinimum": 0,
+            "title": "Id",
+            "type": "integer"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/BaseMetaSchema"
+          },
+          "object_id": {
+            "title": "Object Id",
+            "type": "string"
+          },
+          "object_str": {
+            "title": "Object Str",
+            "type": "string"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "meta",
+          "id",
+          "object_id",
+          "created_at",
+          "object_str",
+          "content_type",
+          "base_content_type",
+          "content_object"
+        ],
+        "title": "PageRevisionDetailSchema",
+        "type": "object"
+      },
       "PageSchema": {
         "properties": {
           "id": {
@@ -22061,80 +22387,6 @@
         },
         "required": ["meta", "id", "title"],
         "title": "RestaurantPageSchema",
-        "type": "object"
-      },
-      "RevisionDetailSchema": {
-        "properties": {
-          "approved_go_live_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Approved Go Live At"
-          },
-          "base_content_type": {
-            "$ref": "#/components/schemas/ContentTypeSchema"
-          },
-          "content": {
-            "additionalProperties": true,
-            "title": "Content",
-            "type": "object"
-          },
-          "content_type": {
-            "$ref": "#/components/schemas/ContentTypeSchema"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "id": {
-            "exclusiveMinimum": 0,
-            "title": "Id",
-            "type": "integer"
-          },
-          "meta": {
-            "$ref": "#/components/schemas/BaseMetaSchema"
-          },
-          "object_id": {
-            "title": "Object Id",
-            "type": "string"
-          },
-          "object_str": {
-            "title": "Object Str",
-            "type": "string"
-          },
-          "user_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User Id"
-          }
-        },
-        "required": [
-          "meta",
-          "id",
-          "object_id",
-          "created_at",
-          "object_str",
-          "content_type",
-          "base_content_type",
-          "content"
-        ],
-        "title": "RevisionDetailSchema",
         "type": "object"
       },
       "RevisionFilterSchema": {
@@ -26544,6 +26796,78 @@
         },
         "required": ["revision_id"],
         "title": "SnippetRevertSchema",
+        "type": "object"
+      },
+      "SnippetRevisionDetailSchema": {
+        "properties": {
+          "approved_go_live_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved Go Live At"
+          },
+          "base_content_type": {
+            "$ref": "#/components/schemas/ContentTypeSchema"
+          },
+          "content_object": {
+            "$ref": "#/components/schemas/FullFeaturedSnippetSchema"
+          },
+          "content_type": {
+            "$ref": "#/components/schemas/ContentTypeSchema"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "exclusiveMinimum": 0,
+            "title": "Id",
+            "type": "integer"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/BaseMetaSchema"
+          },
+          "object_id": {
+            "title": "Object Id",
+            "type": "string"
+          },
+          "object_str": {
+            "title": "Object Str",
+            "type": "string"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "meta",
+          "id",
+          "object_id",
+          "created_at",
+          "object_str",
+          "content_type",
+          "base_content_type",
+          "content_object"
+        ],
+        "title": "SnippetRevisionDetailSchema",
         "type": "object"
       },
       "StandardChildCreateMetaSchema": {
@@ -38512,7 +38836,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RevisionDetailSchema"
+                  "$ref": "#/components/schemas/PageRevisionDetailSchema"
                 }
               }
             },
@@ -39686,7 +40010,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RevisionDetailSchema"
+                  "$ref": "#/components/schemas/SnippetRevisionDetailSchema"
                 }
               }
             },

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -5481,6 +5481,28 @@
         "title": "ContentTypeListSchema",
         "type": "object"
       },
+      "ContentTypeSchema": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/BaseMetaSchema"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": ["meta", "id", "name", "label"],
+        "title": "ContentTypeSchema",
+        "type": "object"
+      },
       "ContentTypeSummarySchema": {
         "properties": {
           "label": {
@@ -20795,6 +20817,24 @@
         "title": "PagedRedirectSchema",
         "type": "object"
       },
+      "PagedRevisionSchema": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RevisionSchema"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": ["items", "count"],
+        "title": "PagedRevisionSchema",
+        "type": "object"
+      },
       "PagedSiteSchema": {
         "properties": {
           "count": {
@@ -22021,6 +22061,134 @@
         },
         "required": ["meta", "id", "title"],
         "title": "RestaurantPageSchema",
+        "type": "object"
+      },
+      "RevisionDetailSchema": {
+        "properties": {
+          "approved_go_live_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved Go Live At"
+          },
+          "base_content_type": {
+            "$ref": "#/components/schemas/ContentTypeSchema"
+          },
+          "content": {
+            "additionalProperties": true,
+            "title": "Content",
+            "type": "object"
+          },
+          "content_type": {
+            "$ref": "#/components/schemas/ContentTypeSchema"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "exclusiveMinimum": 0,
+            "title": "Id",
+            "type": "integer"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/BaseMetaSchema"
+          },
+          "object_id": {
+            "title": "Object Id",
+            "type": "string"
+          },
+          "object_str": {
+            "title": "Object Str",
+            "type": "string"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "meta",
+          "id",
+          "object_id",
+          "created_at",
+          "object_str",
+          "content_type",
+          "base_content_type",
+          "content"
+        ],
+        "title": "RevisionDetailSchema",
+        "type": "object"
+      },
+      "RevisionSchema": {
+        "properties": {
+          "approved_go_live_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved Go Live At"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "exclusiveMinimum": 0,
+            "title": "Id",
+            "type": "integer"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/BaseMetaSchema"
+          },
+          "object_id": {
+            "title": "Object Id",
+            "type": "string"
+          },
+          "object_str": {
+            "title": "Object Str",
+            "type": "string"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": ["meta", "id", "object_id", "created_at", "object_str"],
+        "title": "RevisionSchema",
         "type": "object"
       },
       "RichTextFieldWithFeaturesPageCreateMetaSchema": {
@@ -38078,6 +38246,98 @@
           }
         },
         "summary": "Unpublish page",
+        "tags": ["pages"]
+      }
+    },
+    "/api/v3/pages/{page_id}/revisions/": {
+      "get": {
+        "operationId": "pages_revisions_list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "page_id",
+            "required": true,
+            "schema": {
+              "title": "Page Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedRevisionSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List page revisions",
+        "tags": ["pages"]
+      }
+    },
+    "/api/v3/pages/{page_id}/revisions/{revision_id}/": {
+      "get": {
+        "operationId": "pages_revisions_detail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "page_id",
+            "required": true,
+            "schema": {
+              "title": "Page Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": 0,
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevisionDetailSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Page revision detail",
         "tags": ["pages"]
       }
     },

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -39481,6 +39481,221 @@
         "summary": "Unpublish snippet",
         "tags": ["snippets"]
       }
+    },
+    "/api/v3/snippets/{type}/{pk}/revisions/": {
+      "get": {
+        "operationId": "snippets_revisions_list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "const": "tests.FullFeaturedSnippet",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "title": "Pk",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at_from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created At From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at_to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created At To"
+            }
+          },
+          {
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "approved_go_live_at_from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Approved Go Live At From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "approved_go_live_at_to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Approved Go Live At To"
+            }
+          },
+          {
+            "in": "query",
+            "name": "object_str",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Object Str"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedRevisionSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List snippet revisions",
+        "tags": ["snippets"]
+      }
+    },
+    "/api/v3/snippets/{type}/{pk}/revisions/{revision_id}/": {
+      "get": {
+        "operationId": "snippets_revisions_detail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "const": "tests.FullFeaturedSnippet",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "title": "Pk",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": 0,
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevisionDetailSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Snippet revision detail",
+        "tags": ["snippets"]
+      }
     }
   },
   "servers": []

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -19992,6 +19992,10 @@
                 "type": "string"
               },
               {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -22509,6 +22513,10 @@
                 "type": "integer"
               },
               {
+                "type": "string"
+              },
+              {
+                "format": "uuid",
                 "type": "string"
               },
               {
@@ -26848,6 +26856,10 @@
                 "type": "integer"
               },
               {
+                "type": "string"
+              },
+              {
+                "format": "uuid",
                 "type": "string"
               },
               {

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -30307,6 +30307,221 @@
         "summary": "Unpublish snippet",
         "tags": ["snippets"]
       }
+    },
+    "/api/v3/snippets/{type}/{pk}/revisions/": {
+      "get": {
+        "operationId": "snippets_revisions_list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "const": "tests.FullFeaturedSnippet",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "title": "Pk",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at_from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created At From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at_to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created At To"
+            }
+          },
+          {
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "approved_go_live_at_from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Approved Go Live At From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "approved_go_live_at_to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Approved Go Live At To"
+            }
+          },
+          {
+            "in": "query",
+            "name": "object_str",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Object Str"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedRevisionSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List snippet revisions",
+        "tags": ["snippets"]
+      }
+    },
+    "/api/v3/snippets/{type}/{pk}/revisions/{revision_id}/": {
+      "get": {
+        "operationId": "snippets_revisions_detail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "const": "tests.FullFeaturedSnippet",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "title": "Pk",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": 0,
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevisionDetailSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Snippet revision detail",
+        "tags": ["snippets"]
+      }
     }
   },
   "servers": []

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -4222,6 +4222,28 @@
         "title": "ContentTypeListSchema",
         "type": "object"
       },
+      "ContentTypeSchema": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/BaseMetaSchema"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": ["meta", "id", "name", "label"],
+        "title": "ContentTypeSchema",
+        "type": "object"
+      },
       "ContentTypeSummarySchema": {
         "properties": {
           "label": {
@@ -15142,6 +15164,24 @@
         "title": "PagedRedirectSchema",
         "type": "object"
       },
+      "PagedRevisionSchema": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RevisionSchema"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": ["items", "count"],
+        "title": "PagedRevisionSchema",
+        "type": "object"
+      },
       "PagedSiteSchema": {
         "properties": {
           "count": {
@@ -16041,6 +16081,134 @@
         },
         "required": ["meta", "id", "title"],
         "title": "RestaurantPageSchema",
+        "type": "object"
+      },
+      "RevisionDetailSchema": {
+        "properties": {
+          "approved_go_live_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved Go Live At"
+          },
+          "base_content_type": {
+            "$ref": "#/components/schemas/ContentTypeSchema"
+          },
+          "content": {
+            "additionalProperties": true,
+            "title": "Content",
+            "type": "object"
+          },
+          "content_type": {
+            "$ref": "#/components/schemas/ContentTypeSchema"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "exclusiveMinimum": 0,
+            "title": "Id",
+            "type": "integer"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/BaseMetaSchema"
+          },
+          "object_id": {
+            "title": "Object Id",
+            "type": "string"
+          },
+          "object_str": {
+            "title": "Object Str",
+            "type": "string"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "meta",
+          "id",
+          "object_id",
+          "created_at",
+          "object_str",
+          "content_type",
+          "base_content_type",
+          "content"
+        ],
+        "title": "RevisionDetailSchema",
+        "type": "object"
+      },
+      "RevisionSchema": {
+        "properties": {
+          "approved_go_live_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved Go Live At"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "exclusiveMinimum": 0,
+            "title": "Id",
+            "type": "integer"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/BaseMetaSchema"
+          },
+          "object_id": {
+            "title": "Object Id",
+            "type": "string"
+          },
+          "object_str": {
+            "title": "Object Str",
+            "type": "string"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": ["meta", "id", "object_id", "created_at", "object_str"],
+        "title": "RevisionSchema",
         "type": "object"
       },
       "RichTextFieldWithFeaturesPageCreateMetaSchema": {
@@ -28904,6 +29072,98 @@
           }
         },
         "summary": "Unpublish page",
+        "tags": ["pages"]
+      }
+    },
+    "/api/v3/pages/{page_id}/revisions/": {
+      "get": {
+        "operationId": "pages_revisions_list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "page_id",
+            "required": true,
+            "schema": {
+              "title": "Page Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedRevisionSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List page revisions",
+        "tags": ["pages"]
+      }
+    },
+    "/api/v3/pages/{page_id}/revisions/{revision_id}/": {
+      "get": {
+        "operationId": "pages_revisions_detail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "page_id",
+            "required": true,
+            "schema": {
+              "title": "Page Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": 0,
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevisionDetailSchema"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Page revision detail",
         "tags": ["pages"]
       }
     },

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -14384,6 +14384,332 @@
         "title": "PageRevertSchema",
         "type": "object"
       },
+      "PageRevisionDetailSchema": {
+        "properties": {
+          "approved_go_live_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved Go Live At"
+          },
+          "base_content_type": {
+            "$ref": "#/components/schemas/ContentTypeSchema"
+          },
+          "content_object": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/BasePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/EarlyPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SimplePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/NoPromotePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/MultiPreviewModesPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/CustomPreviewSizesPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/PageWithExcludedCopyFieldSchema"
+              },
+              {
+                "$ref": "#/components/schemas/PageWithGenericRelationSchema"
+              },
+              {
+                "$ref": "#/components/schemas/PageWithOldStyleRouteMethodSchema"
+              },
+              {
+                "$ref": "#/components/schemas/FilePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/abc__EventPageSchema__1"
+              },
+              {
+                "$ref": "#/components/schemas/FormClassAdditionalFieldPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SingleEventPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/EventIndexSchema"
+              },
+              {
+                "$ref": "#/components/schemas/abc__FormPageSchema__1"
+              },
+              {
+                "$ref": "#/components/schemas/JadeFormPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/FormPageWithRedirectSchema"
+              },
+              {
+                "$ref": "#/components/schemas/FormPageWithCustomSubmissionSchema"
+              },
+              {
+                "$ref": "#/components/schemas/FormPageWithCustomSubmissionListViewSchema"
+              },
+              {
+                "$ref": "#/components/schemas/FormPageWithCustomFormBuilderSchema"
+              },
+              {
+                "$ref": "#/components/schemas/StandardIndexSchema"
+              },
+              {
+                "$ref": "#/components/schemas/PromotionalPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/StandardChildSchema"
+              },
+              {
+                "$ref": "#/components/schemas/BusinessIndexSchema"
+              },
+              {
+                "$ref": "#/components/schemas/BusinessSubIndexSchema"
+              },
+              {
+                "$ref": "#/components/schemas/BusinessChildSchema"
+              },
+              {
+                "$ref": "#/components/schemas/BusinessNowherePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/CustomCopyFormPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/TaggedPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/TaggedChildPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/TaggedGrandchildPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SingletonPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SingletonPageViaMaxCountSchema"
+              },
+              {
+                "$ref": "#/components/schemas/StreamPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/DefaultStreamPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/ComplexDefaultStreamPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/MTIBasePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/MTIChildPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/NoCreatableSubpageTypesPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/NoSubpageTypesPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/ManyToManyBlogPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/OneToOnePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/GenericSnippetPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/CustomManagerPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/MyCustomPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/ValidatedPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/DefaultRichTextFieldPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/DefaultRichBlockFieldPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/CustomRichTextFieldPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/CustomRichBlockFieldPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/RichTextFieldWithFeaturesPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SectionedRichTextPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/InlineStreamPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/TableBlockStreamPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/AlwaysShowInMenusPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/AddedStreamFieldWithoutDefaultPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/AddedStreamFieldWithEmptyStringDefaultPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/AddedStreamFieldWithEmptyListDefaultPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SecretPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleParentPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleChildPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/abc__PersonPageSchema__1"
+              },
+              {
+                "$ref": "#/components/schemas/RestaurantPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/DeadlyStreamPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/GalleryPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/GenericSnippetNoIndexPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/GenericSnippetNoFieldIndexPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/CustomPermissionPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/RequiredDatePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/CommentableJSONPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/HomePageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/StandardPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/StandardIndexPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/BlogEntryPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/BlogIndexPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/abc__EventPageSchema__2"
+              },
+              {
+                "$ref": "#/components/schemas/EventIndexPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/abc__PersonPageSchema__2"
+              },
+              {
+                "$ref": "#/components/schemas/ContactPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/abc__FormPageSchema__2"
+              },
+              {
+                "$ref": "#/components/schemas/RoutablePageTestSchema"
+              },
+              {
+                "$ref": "#/components/schemas/RoutablePageWithOverriddenIndexRouteTestSchema"
+              },
+              {
+                "$ref": "#/components/schemas/TestPageSchema"
+              },
+              {
+                "$ref": "#/components/schemas/SamplePageSchema"
+              }
+            ],
+            "title": "Content Object"
+          },
+          "content_type": {
+            "$ref": "#/components/schemas/ContentTypeSchema"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "exclusiveMinimum": 0,
+            "title": "Id",
+            "type": "integer"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/BaseMetaSchema"
+          },
+          "object_id": {
+            "title": "Object Id",
+            "type": "string"
+          },
+          "object_str": {
+            "title": "Object Str",
+            "type": "string"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "meta",
+          "id",
+          "object_id",
+          "created_at",
+          "object_str",
+          "content_type",
+          "base_content_type",
+          "content_object"
+        ],
+        "title": "PageRevisionDetailSchema",
+        "type": "object"
+      },
       "PageUnpublishSchema": {
         "properties": {
           "recursive": {
@@ -16081,80 +16407,6 @@
         },
         "required": ["meta", "id", "title"],
         "title": "RestaurantPageSchema",
-        "type": "object"
-      },
-      "RevisionDetailSchema": {
-        "properties": {
-          "approved_go_live_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Approved Go Live At"
-          },
-          "base_content_type": {
-            "$ref": "#/components/schemas/ContentTypeSchema"
-          },
-          "content": {
-            "additionalProperties": true,
-            "title": "Content",
-            "type": "object"
-          },
-          "content_type": {
-            "$ref": "#/components/schemas/ContentTypeSchema"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "id": {
-            "exclusiveMinimum": 0,
-            "title": "Id",
-            "type": "integer"
-          },
-          "meta": {
-            "$ref": "#/components/schemas/BaseMetaSchema"
-          },
-          "object_id": {
-            "title": "Object Id",
-            "type": "string"
-          },
-          "object_str": {
-            "title": "Object Str",
-            "type": "string"
-          },
-          "user_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User Id"
-          }
-        },
-        "required": [
-          "meta",
-          "id",
-          "object_id",
-          "created_at",
-          "object_str",
-          "content_type",
-          "base_content_type",
-          "content"
-        ],
-        "title": "RevisionDetailSchema",
         "type": "object"
       },
       "RevisionFilterSchema": {
@@ -19256,6 +19508,78 @@
         },
         "required": ["revision_id"],
         "title": "SnippetRevertSchema",
+        "type": "object"
+      },
+      "SnippetRevisionDetailSchema": {
+        "properties": {
+          "approved_go_live_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved Go Live At"
+          },
+          "base_content_type": {
+            "$ref": "#/components/schemas/ContentTypeSchema"
+          },
+          "content_object": {
+            "$ref": "#/components/schemas/FullFeaturedSnippetSchema"
+          },
+          "content_type": {
+            "$ref": "#/components/schemas/ContentTypeSchema"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "exclusiveMinimum": 0,
+            "title": "Id",
+            "type": "integer"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/BaseMetaSchema"
+          },
+          "object_id": {
+            "title": "Object Id",
+            "type": "string"
+          },
+          "object_str": {
+            "title": "Object Str",
+            "type": "string"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "meta",
+          "id",
+          "object_id",
+          "created_at",
+          "object_str",
+          "content_type",
+          "base_content_type",
+          "content_object"
+        ],
+        "title": "SnippetRevisionDetailSchema",
         "type": "object"
       },
       "StandardChildCreateMetaSchema": {
@@ -29338,7 +29662,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RevisionDetailSchema"
+                  "$ref": "#/components/schemas/PageRevisionDetailSchema"
                 }
               }
             },
@@ -30512,7 +30836,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RevisionDetailSchema"
+                  "$ref": "#/components/schemas/SnippetRevisionDetailSchema"
                 }
               }
             },

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -16157,6 +16157,85 @@
         "title": "RevisionDetailSchema",
         "type": "object"
       },
+      "RevisionFilterSchema": {
+        "properties": {
+          "approved_go_live_at_from": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved Go Live At From"
+          },
+          "approved_go_live_at_to": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approved Go Live At To"
+          },
+          "created_at_from": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At From"
+          },
+          "created_at_to": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At To"
+          },
+          "object_str": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Object Str"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "title": "RevisionFilterSchema",
+        "type": "object"
+      },
       "RevisionSchema": {
         "properties": {
           "approved_go_live_at": {
@@ -29086,6 +29165,109 @@
             "schema": {
               "title": "Page Id",
               "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at_from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created At From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at_to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created At To"
+            }
+          },
+          {
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "approved_go_live_at_from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Approved Go Live At From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "approved_go_live_at_to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Approved Go Live At To"
+            }
+          },
+          {
+            "in": "query",
+            "name": "object_str",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Object Str"
             }
           },
           {

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -14691,6 +14691,10 @@
                 "type": "string"
               },
               {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -16529,6 +16533,10 @@
                 "type": "integer"
               },
               {
+                "type": "string"
+              },
+              {
+                "format": "uuid",
                 "type": "string"
               },
               {
@@ -19560,6 +19568,10 @@
                 "type": "integer"
               },
               {
+                "type": "string"
+              },
+              {
+                "format": "uuid",
                 "type": "string"
               },
               {

--- a/wagtail/api/v3/tests/test_page_revisions.py
+++ b/wagtail/api/v3/tests/test_page_revisions.py
@@ -119,6 +119,69 @@ class TestV3PageRevisionsList(TestV3PageRevisionsBase):
         self.assert_problem_response(response, status_code=404)
 
 
+class TestV3PageRevisionsListFilters(TestV3PageRevisionsBase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.login()
+        self.other_user = self.create_superuser(username="other")
+
+        self.old_revision = self.home_page.save_revision(user=self.user)
+        self.old_revision.created_at = "2020-01-01T00:00:00Z"
+        self.old_revision.object_str = "Old title"
+        self.old_revision.save()
+
+        self.new_revision = self.home_page.save_revision(user=self.other_user)
+        self.new_revision.created_at = "2024-06-01T00:00:00Z"
+        self.new_revision.object_str = "New Title"
+        self.new_revision.approved_go_live_at = "2024-06-02T00:00:00Z"
+        self.new_revision.save()
+
+    def get_ids(self, **params):
+        response = self.client.get(self.list_url(self.home_page), params)
+        self.assertEqual(response.status_code, 200)
+        return {item["id"] for item in response.json()["items"]}
+
+    def test_filter_created_at_from(self):
+        self.assertEqual(
+            self.get_ids(created_at_from="2022-01-01T00:00:00Z"),
+            {self.new_revision.pk},
+        )
+
+    def test_filter_created_at_to(self):
+        self.assertEqual(
+            self.get_ids(created_at_to="2022-01-01T00:00:00Z"),
+            {self.old_revision.pk},
+        )
+
+    def test_filter_user_id(self):
+        self.assertEqual(
+            self.get_ids(user_id=self.other_user.pk),
+            {self.new_revision.pk},
+        )
+
+    def test_filter_approved_go_live_at_from(self):
+        self.assertEqual(
+            self.get_ids(approved_go_live_at_from="2024-01-01T00:00:00Z"),
+            {self.new_revision.pk},
+        )
+
+    def test_filter_approved_go_live_at_to(self):
+        self.assertEqual(
+            self.get_ids(approved_go_live_at_to="2024-12-31T00:00:00Z"),
+            {self.new_revision.pk},
+        )
+
+    def test_filter_object_str_icontains(self):
+        self.assertEqual(
+            self.get_ids(object_str="title"),
+            {self.old_revision.pk, self.new_revision.pk},
+        )
+        self.assertEqual(
+            self.get_ids(object_str="New"),
+            {self.new_revision.pk},
+        )
+
+
 class TestV3PageRevisionsDetail(TestV3PageRevisionsBase):
     # Viewing a revision requires "publish" or "change" and nothing less.
     permission_matrix = [

--- a/wagtail/api/v3/tests/test_page_revisions.py
+++ b/wagtail/api/v3/tests/test_page_revisions.py
@@ -224,7 +224,7 @@ class TestV3PageRevisionsDetail(TestV3PageRevisionsBase):
                 "approved_go_live_at",
                 "content_type",
                 "base_content_type",
-                "content",
+                "content_object",
             },
         )
         self.assertEqual(content["meta"]["type"], "wagtailcore.Revision")
@@ -247,7 +247,8 @@ class TestV3PageRevisionsDetail(TestV3PageRevisionsBase):
                 "label": "page",
             },
         )
-        self.assertEqual(content["content"], revision.content)
+        self.assertEqual(content["content_object"]["id"], self.home_page.pk)
+        self.assertEqual(content["content_object"]["title"], self.home_page.title)
 
     def test_unknown_page_returns_404(self):
         revision = self.home_page.save_revision()

--- a/wagtail/api/v3/tests/test_page_revisions.py
+++ b/wagtail/api/v3/tests/test_page_revisions.py
@@ -1,0 +1,217 @@
+from django.contrib.auth.models import Group, Permission
+from django.test import TestCase
+from django.urls import reverse
+
+from wagtail.api.v3.tests.base import TestV3Base
+from wagtail.models import GroupPagePermission
+from wagtail.test.utils import Page, WagtailTestUtils
+
+
+class TestV3PageRevisionsBase(TestV3Base, WagtailTestUtils, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.root_page = Page.objects.get(depth=1)
+        self.home_page = Page.objects.get(depth=2)
+
+    def list_url(self, page):
+        return reverse("wagtailapi_v3:list_page_revisions", kwargs={"page_id": page.pk})
+
+    def detail_url(self, page, revision):
+        return reverse(
+            "wagtailapi_v3:detail_page_revision",
+            kwargs={"page_id": page.pk, "revision_id": revision.pk},
+        )
+
+    def login_with_permissions(self, *codenames, index=0, scope=None):
+        """
+        Log in as a fresh non-superuser with exactly the given
+        GroupPagePermission codenames granted on ``scope`` (default:
+        ``self.root_page``, i.e. the whole tree). Passing no codenames logs
+        in a user with no page permissions at all. ``index`` (e.g. the row
+        number in a permission_matrix loop) keeps usernames unique within a
+        single test method.
+        """
+        scope = scope or self.root_page
+        username = f"user-{index}"
+        user = self.create_user(username=username, password="password")
+        if codenames:
+            group = Group.objects.create(name=f"Test group ({username})")
+            user.groups.add(group)
+            for codename in codenames:
+                GroupPagePermission.objects.create(
+                    group=group,
+                    page=scope,
+                    permission=Permission.objects.get(
+                        content_type__app_label=Page._meta.app_label, codename=codename
+                    ),
+                )
+        self.login(username=getattr(user, user.USERNAME_FIELD), password="password")
+        return user
+
+
+class TestV3PageRevisionsList(TestV3PageRevisionsBase):
+    # Viewing revisions requires "publish" or "change" and nothing less.
+    permission_matrix = [
+        (None, 401),
+        ([], 403),
+        ([Page.PERMISSION_CODENAMES.ADD], 403),
+        ([Page.PERMISSION_CODENAMES.CHANGE], 200),
+        ([Page.PERMISSION_CODENAMES.PUBLISH], 200),
+    ]
+
+    def test_permission_matrix(self):
+        for i, (codenames, expected_status) in enumerate(self.permission_matrix):
+            with self.subTest(codenames=codenames):
+                if codenames is None:
+                    self.client.logout()
+                else:
+                    self.login_with_permissions(*codenames, index=i)
+
+                response = self.client.get(self.list_url(self.home_page))
+                self.assertEqual(response.status_code, expected_status)
+
+    def test_list_revisions(self):
+        user = self.login()
+        first_revision = self.home_page.save_revision(user=user)
+        second_revision = self.home_page.save_revision(user=user)
+
+        response = self.client.get(self.list_url(self.home_page))
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+
+        self.assertEqual(content["count"], 2)
+        ids = [item["id"] for item in content["items"]]
+        # Most recent revision first.
+        self.assertEqual(ids, [second_revision.pk, first_revision.pk])
+
+        item = content["items"][0]
+        self.assertEqual(
+            set(item.keys()),
+            {
+                "meta",
+                "id",
+                "object_id",
+                "created_at",
+                "user_id",
+                "object_str",
+                "approved_go_live_at",
+            },
+        )
+        self.assertEqual(item["meta"]["type"], "wagtailcore.Revision")
+        self.assertEqual(item["id"], second_revision.pk)
+        self.assertEqual(item["object_id"], str(self.home_page.pk))
+        self.assertEqual(str(item["user_id"]), str(user.pk))
+        self.assertEqual(item["object_str"], str(self.home_page))
+        self.assertIsNone(item["approved_go_live_at"])
+
+    def test_list_revisions_empty(self):
+        self.login()
+        response = self.client.get(self.list_url(self.home_page))
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertEqual(content["count"], 0)
+        self.assertEqual(content["items"], [])
+
+    def test_unknown_page_returns_404(self):
+        response = self.client.get(
+            reverse("wagtailapi_v3:list_page_revisions", kwargs={"page_id": 999999})
+        )
+        self.assert_problem_response(response, status_code=404)
+
+
+class TestV3PageRevisionsDetail(TestV3PageRevisionsBase):
+    # Viewing a revision requires "publish" or "change" and nothing less.
+    permission_matrix = [
+        (None, 401),
+        ([], 403),
+        ([Page.PERMISSION_CODENAMES.ADD], 403),
+        ([Page.PERMISSION_CODENAMES.CHANGE], 200),
+        ([Page.PERMISSION_CODENAMES.PUBLISH], 200),
+    ]
+
+    def test_permission_matrix(self):
+        revision = self.home_page.save_revision()
+        for i, (codenames, expected_status) in enumerate(self.permission_matrix):
+            with self.subTest(codenames=codenames):
+                if codenames is None:
+                    self.client.logout()
+                else:
+                    self.login_with_permissions(*codenames, index=i)
+
+                response = self.client.get(self.detail_url(self.home_page, revision))
+                self.assertEqual(response.status_code, expected_status)
+
+    def test_detail(self):
+        user = self.login()
+        revision = self.home_page.save_revision(user=user)
+
+        response = self.client.get(self.detail_url(self.home_page, revision))
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+
+        self.assertEqual(
+            set(content.keys()),
+            {
+                "meta",
+                "id",
+                "object_id",
+                "created_at",
+                "user_id",
+                "object_str",
+                "approved_go_live_at",
+                "content_type",
+                "base_content_type",
+                "content",
+            },
+        )
+        self.assertEqual(content["meta"]["type"], "wagtailcore.Revision")
+        self.assertEqual(content["id"], revision.pk)
+        self.assertEqual(
+            content["content_type"],
+            {
+                "meta": {"type": "contenttypes.ContentType"},
+                "id": revision.content_type_id,
+                "name": Page._meta.label,
+                "label": "page",
+            },
+        )
+        self.assertEqual(
+            content["base_content_type"],
+            {
+                "meta": {"type": "contenttypes.ContentType"},
+                "id": revision.base_content_type_id,
+                "name": Page._meta.label,
+                "label": "page",
+            },
+        )
+        self.assertEqual(content["content"], revision.content)
+
+    def test_unknown_page_returns_404(self):
+        revision = self.home_page.save_revision()
+        response = self.client.get(
+            reverse(
+                "wagtailapi_v3:detail_page_revision",
+                kwargs={"page_id": 999999, "revision_id": revision.pk},
+            )
+        )
+        self.assert_problem_response(response, status_code=404)
+
+    def test_unknown_revision_returns_404(self):
+        self.login()
+        response = self.client.get(
+            reverse(
+                "wagtailapi_v3:detail_page_revision",
+                kwargs={"page_id": self.home_page.pk, "revision_id": 999999},
+            )
+        )
+        self.assert_problem_response(response, status_code=404)
+
+    def test_revision_belonging_to_another_page_returns_404(self):
+        self.login()
+        other_page = self.home_page.add_child(
+            instance=Page(title="Other", slug="other")
+        )
+        other_revision = other_page.save_revision()
+
+        response = self.client.get(self.detail_url(self.home_page, other_revision))
+        self.assert_problem_response(response, status_code=404)

--- a/wagtail/snippets/api/router.py
+++ b/wagtail/snippets/api/router.py
@@ -1,6 +1,7 @@
 from typing import Any, Literal, cast
 
 from django.conf import settings
+from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpRequest
 from django.shortcuts import get_object_or_404
 from ninja import Body, Query, Router, Schema, Status
@@ -17,9 +18,11 @@ from wagtail.api.v3.schemas.base import build_discriminated_union, build_union_s
 from wagtail.api.v3.schemas.params import (
     APIFieldFilterSchema,
     OrderingSchema,
+    RevisionFilterSchema,
     SearchSchema,
     TranslationFilterSchema,
 )
+from wagtail.api.v3.schemas.revisions import RevisionDetailSchema, RevisionSchema
 from wagtail.coreutils import resolve_model_string
 from wagtail.models import DraftStateMixin, Locale, RevisionMixin, TranslatableMixin
 from wagtail.permissions import policy_registry
@@ -81,6 +84,14 @@ for mixin in mixins:
 
 def get_model_from_params(request, *args, type: SnippetTypeLiteral, **kwargs):
     return resolve_model_string(type)
+
+
+def _check_can_view_revisions(request: HttpRequest, instance) -> None:
+    permission_policy = policy_registry.get(instance)
+    if not permission_policy.user_has_permission_for_instance(
+        request.user, "change", instance
+    ):
+        raise PermissionDenied
 
 
 @router.get(
@@ -213,6 +224,47 @@ def delete_snippet(request: HttpRequest, type: SnippetTypeLiteral, pk: str):
     action = action_class(instance, user=request.user)
     action.execute()
     return Status(204, None)
+
+
+@router.get(
+    "/{type}/{pk}/revisions/",
+    response=list[RevisionSchema],
+    url_name="list_snippet_revisions",
+    summary="List snippet revisions",
+    operation_id="snippets_revisions_list",
+)
+@paginate(WagtailLimitOffsetPagination)
+def list_snippet_revisions(
+    request: HttpRequest,
+    type: literals_by_mixin[RevisionMixin],
+    pk: str,
+    filters: RevisionFilterSchema = Query(...),  # ty: ignore[call-non-callable]
+):
+    model = resolve_model_string(type)
+    instance = get_object_or_404(model, pk=pk)
+    _check_can_view_revisions(request, instance)
+    queryset = instance.revisions.order_by("-created_at", "-id")
+    return filters.filter(queryset)
+
+
+@router.get(
+    "/{type}/{pk}/revisions/{revision_id}/",
+    response=RevisionDetailSchema,
+    url_name="detail_snippet_revision",
+    summary="Snippet revision detail",
+    operation_id="snippets_revisions_detail",
+)
+def get_snippet_revision(
+    request: HttpRequest,
+    type: literals_by_mixin[RevisionMixin],
+    pk: str,
+    revision_id: PositiveInt,
+):
+    model = resolve_model_string(type)
+    instance = get_object_or_404(model, pk=pk)
+    _check_can_view_revisions(request, instance)
+    revisions = instance.revisions.select_related("content_type", "base_content_type")
+    return get_object_or_404(revisions, pk=revision_id)
 
 
 @actions_router.post(

--- a/wagtail/snippets/api/router.py
+++ b/wagtail/snippets/api/router.py
@@ -94,6 +94,14 @@ def _check_can_view_revisions(request: HttpRequest, instance) -> None:
         raise PermissionDenied
 
 
+class SnippetRevisionDetailSchema(RevisionDetailSchema):
+    content_object: schemas_by_mixin[RevisionMixin]
+
+    @staticmethod
+    def resolve_content_object(obj):
+        return obj.as_object()
+
+
 @router.get(
     "/{type}/",
     response=list[SnippetDetailSchema],
@@ -249,7 +257,7 @@ def list_snippet_revisions(
 
 @router.get(
     "/{type}/{pk}/revisions/{revision_id}/",
-    response=RevisionDetailSchema,
+    response=SnippetRevisionDetailSchema,
     url_name="detail_snippet_revision",
     summary="Snippet revision detail",
     operation_id="snippets_revisions_detail",

--- a/wagtail/snippets/tests/test_api_v3/test_revisions.py
+++ b/wagtail/snippets/tests/test_api_v3/test_revisions.py
@@ -1,0 +1,321 @@
+from django.contrib.auth.models import Permission
+from django.test import TestCase
+from django.urls import reverse
+
+from wagtail.api.v3.tests.base import TestV3Base
+from wagtail.test.testapp.models import Advert, FullFeaturedSnippet
+from wagtail.test.utils import WagtailTestUtils
+
+
+class TestV3SnippetRevisionsBase(TestV3Base, WagtailTestUtils, TestCase):
+    model = FullFeaturedSnippet
+
+    def setUp(self):
+        super().setUp()
+        self.snippet = FullFeaturedSnippet.objects.create(text="Original")
+
+    def list_url(self, snippet):
+        return reverse(
+            "wagtailapi_v3:list_snippet_revisions",
+            kwargs={"type": self.model._meta.label, "pk": snippet.pk},
+        )
+
+    def detail_url(self, snippet, revision):
+        return reverse(
+            "wagtailapi_v3:detail_snippet_revision",
+            kwargs={
+                "type": self.model._meta.label,
+                "pk": snippet.pk,
+                "revision_id": revision.pk,
+            },
+        )
+
+    def login_with_permissions(self, *codenames, index=0):
+        """
+        Log in as a fresh non-superuser with exactly the given permission
+        codenames on ``self.model``. Passing no codenames logs in a user with
+        no permissions on the model at all. ``index`` keeps usernames unique
+        within a single test method (e.g. across a permission_matrix loop).
+        """
+        username = f"user-{index}"
+        user = self.create_user(username=username, password="password")
+        for codename in codenames:
+            user.user_permissions.add(
+                Permission.objects.get(
+                    content_type__app_label=self.model._meta.app_label,
+                    codename=codename,
+                )
+            )
+        self.login(username=username, password="password")
+        return user
+
+
+class TestV3SnippetRevisionsList(TestV3SnippetRevisionsBase):
+    permission_matrix = [
+        (None, 401),
+        ([], 403),
+        (["add_fullfeaturedsnippet"], 403),
+        (["change_fullfeaturedsnippet"], 200),
+    ]
+
+    def test_permission_matrix(self):
+        for i, (codenames, expected_status) in enumerate(self.permission_matrix):
+            with self.subTest(codenames=codenames):
+                if codenames is None:
+                    self.client.logout()
+                else:
+                    self.login_with_permissions(*codenames, index=i)
+
+                response = self.client.get(self.list_url(self.snippet))
+                self.assertEqual(response.status_code, expected_status)
+
+    def test_list_revisions(self):
+        user = self.login()
+        first_revision = self.snippet.save_revision(user=user)
+        second_revision = self.snippet.save_revision(user=user)
+
+        response = self.client.get(self.list_url(self.snippet))
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+
+        self.assertEqual(content["count"], 2)
+        ids = [item["id"] for item in content["items"]]
+        # Most recent revision first.
+        self.assertEqual(ids, [second_revision.pk, first_revision.pk])
+
+        item = content["items"][0]
+        self.assertEqual(
+            set(item.keys()),
+            {
+                "meta",
+                "id",
+                "object_id",
+                "created_at",
+                "user_id",
+                "object_str",
+                "approved_go_live_at",
+            },
+        )
+        self.assertEqual(item["meta"], {"type": "wagtailcore.Revision"})
+        self.assertEqual(item["id"], second_revision.pk)
+        self.assertEqual(item["object_id"], str(self.snippet.pk))
+        self.assertEqual(str(item["user_id"]), str(user.pk))
+        self.assertEqual(item["object_str"], str(self.snippet))
+        self.assertIsNone(item["approved_go_live_at"])
+
+    def test_list_revisions_empty(self):
+        self.login()
+        response = self.client.get(self.list_url(self.snippet))
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertEqual(content["count"], 0)
+        self.assertEqual(content["items"], [])
+
+    def test_unknown_snippet_returns_404(self):
+        self.login()
+        response = self.client.get(
+            reverse(
+                "wagtailapi_v3:list_snippet_revisions",
+                kwargs={"type": self.model._meta.label, "pk": 999999},
+            )
+        )
+        self.assert_problem_response(response, status_code=404)
+
+    def test_non_revisable_type_is_rejected(self):
+        self.login()
+        advert = Advert.objects.create(text="Hi")
+        response = self.client.get(
+            reverse(
+                "wagtailapi_v3:list_snippet_revisions",
+                kwargs={"type": "tests.Advert", "pk": advert.pk},
+            )
+        )
+        self.assert_problem_response(
+            response,
+            status_code=422,
+            detail_contains="Validation failed",
+            errors=[{"type": "literal_error", "loc": ["path", "type"]}],
+        )
+
+
+class TestV3SnippetRevisionsListFilters(TestV3SnippetRevisionsBase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.login()
+        self.other_user = self.create_superuser(username="other")
+
+        self.old_revision = self.snippet.save_revision(user=self.user)
+        self.old_revision.created_at = "2020-01-01T00:00:00Z"
+        self.old_revision.object_str = "Old title"
+        self.old_revision.save()
+
+        self.new_revision = self.snippet.save_revision(user=self.other_user)
+        self.new_revision.created_at = "2024-06-01T00:00:00Z"
+        self.new_revision.object_str = "New Title"
+        self.new_revision.approved_go_live_at = "2024-06-02T00:00:00Z"
+        self.new_revision.save()
+
+    def get_ids(self, **params):
+        response = self.client.get(self.list_url(self.snippet), params)
+        self.assertEqual(response.status_code, 200)
+        return {item["id"] for item in response.json()["items"]}
+
+    def test_filter_created_at_from(self):
+        self.assertEqual(
+            self.get_ids(created_at_from="2022-01-01T00:00:00Z"),
+            {self.new_revision.pk},
+        )
+
+    def test_filter_created_at_to(self):
+        self.assertEqual(
+            self.get_ids(created_at_to="2022-01-01T00:00:00Z"),
+            {self.old_revision.pk},
+        )
+
+    def test_filter_user_id(self):
+        self.assertEqual(
+            self.get_ids(user_id=self.other_user.pk),
+            {self.new_revision.pk},
+        )
+
+    def test_filter_approved_go_live_at_from(self):
+        self.assertEqual(
+            self.get_ids(approved_go_live_at_from="2024-01-01T00:00:00Z"),
+            {self.new_revision.pk},
+        )
+
+    def test_filter_approved_go_live_at_to(self):
+        self.assertEqual(
+            self.get_ids(approved_go_live_at_to="2024-12-31T00:00:00Z"),
+            {self.new_revision.pk},
+        )
+
+    def test_filter_object_str_icontains(self):
+        self.assertEqual(
+            self.get_ids(object_str="title"),
+            {self.old_revision.pk, self.new_revision.pk},
+        )
+        self.assertEqual(
+            self.get_ids(object_str="New"),
+            {self.new_revision.pk},
+        )
+
+
+class TestV3SnippetRevisionsDetail(TestV3SnippetRevisionsBase):
+    permission_matrix = [
+        (None, 401),
+        ([], 403),
+        (["add_fullfeaturedsnippet"], 403),
+        (["change_fullfeaturedsnippet"], 200),
+    ]
+
+    def test_permission_matrix(self):
+        revision = self.snippet.save_revision()
+        for i, (codenames, expected_status) in enumerate(self.permission_matrix):
+            with self.subTest(codenames=codenames):
+                if codenames is None:
+                    self.client.logout()
+                else:
+                    self.login_with_permissions(*codenames, index=i)
+
+                response = self.client.get(self.detail_url(self.snippet, revision))
+                self.assertEqual(response.status_code, expected_status)
+
+    def test_detail(self):
+        user = self.login()
+        revision = self.snippet.save_revision(user=user)
+        revision.refresh_from_db()
+
+        response = self.client.get(self.detail_url(self.snippet, revision))
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+
+        self.assertEqual(
+            set(content.keys()),
+            {
+                "meta",
+                "id",
+                "object_id",
+                "created_at",
+                "user_id",
+                "object_str",
+                "approved_go_live_at",
+                "content_type",
+                "base_content_type",
+                "content",
+            },
+        )
+        self.assertEqual(content["meta"], {"type": "wagtailcore.Revision"})
+        self.assertEqual(content["id"], revision.pk)
+        self.assertEqual(
+            content["content_type"],
+            {
+                "meta": {"type": "contenttypes.ContentType"},
+                "id": revision.content_type_id,
+                "name": "tests.FullFeaturedSnippet",
+                "label": "full-featured snippet",
+            },
+        )
+        self.assertEqual(
+            content["base_content_type"],
+            {
+                "meta": {"type": "contenttypes.ContentType"},
+                "id": revision.base_content_type_id,
+                "name": "tests.FullFeaturedSnippet",
+                "label": "full-featured snippet",
+            },
+        )
+        self.assertEqual(content["content"], revision.content)
+
+    def test_unknown_snippet_returns_404(self):
+        self.login()
+        revision = self.snippet.save_revision()
+        response = self.client.get(
+            reverse(
+                "wagtailapi_v3:detail_snippet_revision",
+                kwargs={
+                    "type": self.model._meta.label,
+                    "pk": 999999,
+                    "revision_id": revision.pk,
+                },
+            )
+        )
+        self.assert_problem_response(response, status_code=404)
+
+    def test_unknown_revision_returns_404(self):
+        self.login()
+        response = self.client.get(
+            reverse(
+                "wagtailapi_v3:detail_snippet_revision",
+                kwargs={
+                    "type": self.model._meta.label,
+                    "pk": self.snippet.pk,
+                    "revision_id": 999999,
+                },
+            )
+        )
+        self.assert_problem_response(response, status_code=404)
+
+    def test_revision_belonging_to_another_snippet_returns_404(self):
+        self.login()
+        other_snippet = FullFeaturedSnippet.objects.create(text="Other")
+        other_revision = other_snippet.save_revision()
+
+        response = self.client.get(self.detail_url(self.snippet, other_revision))
+        self.assert_problem_response(response, status_code=404)
+
+    def test_non_revisable_type_is_rejected(self):
+        self.login()
+        advert = Advert.objects.create(text="Hi")
+        response = self.client.get(
+            reverse(
+                "wagtailapi_v3:detail_snippet_revision",
+                kwargs={"type": "tests.Advert", "pk": advert.pk, "revision_id": 1},
+            )
+        )
+        self.assert_problem_response(
+            response,
+            status_code=422,
+            detail_contains="Validation failed",
+            errors=[{"type": "literal_error", "loc": ["path", "type"]}],
+        )

--- a/wagtail/snippets/tests/test_api_v3/test_revisions.py
+++ b/wagtail/snippets/tests/test_api_v3/test_revisions.py
@@ -242,7 +242,7 @@ class TestV3SnippetRevisionsDetail(TestV3SnippetRevisionsBase):
                 "approved_go_live_at",
                 "content_type",
                 "base_content_type",
-                "content",
+                "content_object",
             },
         )
         self.assertEqual(content["meta"], {"type": "wagtailcore.Revision"})
@@ -265,7 +265,8 @@ class TestV3SnippetRevisionsDetail(TestV3SnippetRevisionsBase):
                 "label": "full-featured snippet",
             },
         )
-        self.assertEqual(content["content"], revision.content)
+        self.assertEqual(content["content_object"]["id"], self.snippet.pk)
+        self.assertEqual(content["content_object"]["text"], self.snippet.text)
 
     def test_unknown_snippet_returns_404(self):
         self.login()


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Ref: #14304 and #14312

### Description

<!-- Please describe the problem you're fixing. -->
This adds `{id}/revisions/` and `{id}/revisions/{revision_id}/` GET endpoints to the pages and snippets API.

For the revision's content, we utilise Revision.as_object() and then use the underlying object's registered detail schema to match the detail API. This ensures we don't expose more data than what's configured via api_fields. In addition, it also ensures nested JSON (e.g. StreamField) are not doubly-serialised like they do right now inside the raw content.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->

Claude Code with Sonnet 5 in VSCode was used to write the code, with me reviewing and refining the code along the way. I've reviewed the implementation, but I have only briefly reviewed the tests.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>