### PR TITLE
Fix Vector and Rect repr for float coordinates

### DIFF
--- a/wagtail/images/rect.py
+++ b/wagtail/images/rect.py
@@ -16,7 +16,7 @@ class Vector:
         return tuple(self) == tuple(other)
 
     def __repr__(self):
-        return "Vector(x: %d, y: %d)" % (self.x, self.y)
+        return f"Vector(x:{self.x} y:{self.y})"
 
 
 class Rect:
@@ -185,13 +185,7 @@ class Rect:
         return tuple(self) == tuple(other)
 
     def __repr__(self):
-        return "Rect(left: %d, top: %d, right: %d, bottom: %d)" % (
-            self.left,
-            self.top,
-            self.right,
-            self.bottom,
-        )
-
+        return f"Rect(left: {self.left}, top: {self.top}, right: {self.right}, bottom: {self.bottom})"
     @classmethod
     def from_point(cls, x, y, width, height):
         return cls(

--- a/wagtail/images/rect.py
+++ b/wagtail/images/rect.py
@@ -16,7 +16,7 @@ class Vector:
         return tuple(self) == tuple(other)
 
     def __repr__(self):
-        return f"Vector(x:{self.x} y:{self.y})"
+        return f"Vector(x: {self.x}, y: {self.y})"
 
 
 class Rect:


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #...

### Description

<!--## What this PR does

Fixes `Vector.__repr__` and `Rect.__repr__` silently truncating
float coordinates by replacing `%d` integer formatting with f-strings.

## Testing

Verified that float coordinates are preserved in the string
representation of `Vector` and `Rect`.

Fixes #14382. -->


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
