### PR TITLE
Apply permission check on image chooser select format view

### DIFF
--- a/docs/advanced_topics/privacy.md
+++ b/docs/advanced_topics/privacy.md
@@ -48,6 +48,10 @@ for collection in Collection.objects.all():
     collection.get_view_restrictions().filter(restriction_type="password").delete()
 ```
 
+```{note}
+Privacy settings on collections only apply to documents, not images. See [](documents_security_considerations) for directions for securing documents at the server level to prevent access checks from being bypassed.
+```
+
 (login_page)=
 
 ## Setting up a login page

--- a/docs/topics/permissions.md
+++ b/docs/topics/permissions.md
@@ -48,6 +48,10 @@ Access to specific sets of images and documents can be controlled by setting up 
 
 The 'choose' permission for images and documents determines which collections are visible within the chooser interface used to select images and document links for insertion into pages (and other models, such as snippets). Typically, all users are granted choose permission for all collections, allowing them to use any uploaded image or document on pages they create, but this permission can be limited to allow creating collections that are only visible to specific groups.
 
+```{note}
+The 'choose' permission is a UI-level affordance to guide users in selecting suitable images and documents, and is not intended to be a robust mechanism to hide sensitive documents or images from being seen by low-privilege editors. Editors can bypass the chooser interface to insert references to arbitrary documents and images, and access metadata such as document titles and image renditions. [Private collections](private_collections) can be used to prevent unauthorised users from reading document contents, provided these have been properly secured at the server level (see [](documents_security_considerations)); note that this does not apply to images.
+```
+
 (collection_management_permissions)=
 
 ## Collection management permissions

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -2394,7 +2394,7 @@ class TestImageChooserViewSearch(
         self.assertEqual(response.context["results"][0], image)
 
 
-class TestImageChooserChosenMixin:
+class TestImageChooserLimitedPermissionsMixin:
     @classmethod
     def setUpTestData(cls):
         cls.superuser = cls.create_test_user()
@@ -2423,7 +2423,7 @@ class TestImageChooserChosenMixin:
 
 
 class TestImageChooserChosenView(
-    TestImageChooserChosenMixin, WagtailTestUtils, TestCase
+    TestImageChooserLimitedPermissionsMixin, WagtailTestUtils, TestCase
 ):
     @classmethod
     def setUpTestData(cls):
@@ -2496,7 +2496,7 @@ class TestImageChooserChosenView(
 
 
 class TestImageChooserChosenMultipleView(
-    TestImageChooserChosenMixin, WagtailTestUtils, TestCase
+    TestImageChooserLimitedPermissionsMixin, WagtailTestUtils, TestCase
 ):
     @classmethod
     def setUpTestData(cls):
@@ -2553,37 +2553,44 @@ class TestImageChooserChosenMultipleView(
         self.assertEqual(item["default_alt_text"], "Another test description")
 
 
-class TestImageChooserSelectFormatView(WagtailTestUtils, TestCase):
-    def setUp(self):
-        self.login()
+class TestImageChooserSelectFormatView(
+    TestImageChooserLimitedPermissionsMixin, WagtailTestUtils, TestCase
+):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
 
         # Create an image to edit
-        self.image = Image.objects.create(
+        cls.image = Image.objects.create(
             title="Test image",
             file=get_test_image_file(),
         )
 
-    def get(self, params=None):
+    def get(self, image_id, params=None):
         return self.client.get(
-            reverse("wagtailimages_chooser:select_format", args=(self.image.id,)),
+            reverse("wagtailimages_chooser:select_format", args=(image_id,)),
             params,
         )
 
-    def post(self, post_data=None):
+    def post(self, image_id, post_data=None):
         return self.client.post(
-            reverse("wagtailimages_chooser:select_format", args=(self.image.id,)),
+            reverse("wagtailimages_chooser:select_format", args=(image_id,)),
             post_data,
         )
 
     def test_simple(self):
-        response = self.get()
+        self.client.force_login(self.superuser)
+        response = self.get(self.image.id)
         self.assertEqual(response.status_code, 200)
         response_json = json.loads(response.content.decode())
         self.assertEqual(response_json["step"], "select_format")
         self.assertTemplateUsed(response, "wagtailimages/chooser/select_format.html")
 
     def test_with_edit_params(self):
-        response = self.get(params={"alt_text": "some previous alt text"})
+        self.client.force_login(self.superuser)
+        response = self.get(
+            self.image.id, params={"alt_text": "some previous alt text"}
+        )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'value=\\"some previous alt text\\"')
         self.assertNotContains(
@@ -2591,19 +2598,22 @@ class TestImageChooserSelectFormatView(WagtailTestUtils, TestCase):
         )
 
     def test_with_edit_params_no_alt_text_marks_as_decorative(self):
-        response = self.get(params={"alt_text": ""})
+        self.client.force_login(self.superuser)
+        response = self.get(self.image.id, params={"alt_text": ""})
         self.assertEqual(response.status_code, 200)
         self.assertContains(
             response, 'id=\\"id_image-chooser-insertion-image_is_decorative\\" checked'
         )
 
     def test_post_response(self):
+        self.client.force_login(self.superuser)
         response = self.post(
+            self.image.id,
             {
                 "image-chooser-insertion-format": "left",
                 "image-chooser-insertion-image_is_decorative": False,
                 "image-chooser-insertion-alt_text": 'Arthur "two sheds" Jackson',
-            }
+            },
         )
 
         self.assertEqual(response.status_code, 200)
@@ -2620,12 +2630,14 @@ class TestImageChooserSelectFormatView(WagtailTestUtils, TestCase):
         self.assertIn('alt="Arthur &quot;two sheds&quot; Jackson"', result["html"])
 
     def test_post_response_image_is_decorative_discards_alt_text(self):
+        self.client.force_login(self.superuser)
         response = self.post(
+            self.image.id,
             {
                 "image-chooser-insertion-format": "left",
                 "image-chooser-insertion-alt_text": 'Arthur "two sheds" Jackson',
                 "image-chooser-insertion-image_is_decorative": True,
-            }
+            },
         )
         response_json = json.loads(response.content.decode())
         result = response_json["result"]
@@ -2634,18 +2646,74 @@ class TestImageChooserSelectFormatView(WagtailTestUtils, TestCase):
         self.assertIn('alt=""', result["html"])
 
     def test_post_response_image_is_not_decorative_missing_alt_text(self):
+        self.client.force_login(self.superuser)
         response = self.post(
+            self.image.id,
             {
                 "image-chooser-insertion-format": "left",
                 "image-chooser-insertion-alt_text": "",
                 "image-chooser-insertion-image_is_decorative": False,
-            }
+            },
         )
         response_json = json.loads(response.content.decode())
         self.assertIn(
             "Please add some alt text for your image or mark it as decorative",
             response_json["html"],
         )
+
+    def test_get_with_limited_collection_access(self):
+        self.client.force_login(self.limited_user)
+        accessible_image = Image.objects.create(
+            title="Accessible image",
+            file=get_test_image_file(),
+            description="Test description",
+            collection=self.limited_collection,
+        )
+
+        # should not have access to images outside their allowed collection
+        response = self.get(self.image.pk)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.assertEqual(
+            response.context["message"],
+            "Sorry, you do not have permission to access this area.",
+        )
+
+        response = self.get(accessible_image.pk)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response["Content-Type"], "application/json")
+
+    def test_post_with_limited_collection_access(self):
+        self.client.force_login(self.limited_user)
+        accessible_image = Image.objects.create(
+            title="Accessible image",
+            file=get_test_image_file(),
+            description="Test description",
+            collection=self.limited_collection,
+        )
+
+        response = self.post(
+            self.image.id,
+            {
+                "image-chooser-insertion-format": "left",
+                "image-chooser-insertion-image_is_decorative": False,
+                "image-chooser-insertion-alt_text": 'Arthur "two sheds" Jackson',
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.assertEqual(
+            response.context["message"],
+            "Sorry, you do not have permission to access this area.",
+        )
+        response = self.post(
+            accessible_image.id,
+            {
+                "image-chooser-insertion-format": "left",
+                "image-chooser-insertion-image_is_decorative": False,
+                "image-chooser-insertion-alt_text": 'Arthur "two sheds" Jackson',
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response["Content-Type"], "application/json")
 
 
 class TestImageChooserUploadView(WagtailTestUtils, TestCase):

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -344,8 +344,18 @@ class ImageUploadView(
 class ImageSelectFormatView(SelectFormatResponseMixin, ImageChosenResponseMixin, View):
     model = None
 
+    def get_object(self, pk):
+        image = get_object_or_404(self.model, id=pk)
+        permission_policy = policy_registry.get_by_type(self.model)
+        if not permission_policy.user_has_permission_for_instance(
+            self.request.user, "choose", image
+        ):
+            raise PermissionDenied
+
+        return image
+
     def get(self, request, image_id):
-        image = get_object_or_404(self.model, id=image_id)
+        image = self.get_object(image_id)
         initial = {"alt_text": image.default_alt_text}
         initial.update(request.GET.dict())
         # If you edit an existing image, and there is no alt text, ensure that
@@ -371,7 +381,7 @@ class ImageSelectFormatView(SelectFormatResponseMixin, ImageChosenResponseMixin,
         return response_data
 
     def post(self, request, image_id):
-        image = get_object_or_404(get_image_model(), id=image_id)
+        image = self.get_object(image_id)
 
         self.form = ImageInsertionForm(
             request.POST,


### PR DESCRIPTION
### Description

Several security reporters noted that the fix for [CVE-2026-54259](https://github.com/wagtail/wagtail/security/advisories/GHSA-h54r-xq46-qwqm) did not apply the permission check to the `﻿﻿/admin/images/chooser/{id}/select_format/` endpoint. However, on further consideration the security team has elected not to handle this through the security advisory process, as it does not provide access to any information that was not already available to editors by bypassing the chooser and inserting an arbitrary image ID onto a page being edited.

This PR applies the permission check and adds additional notes to the permission and privacy docs, clarifying that the collection 'choose' permission should not be relied upon as a means to hide the metadata of images and documents from lower-privilege editors.

### AI usage

Github Copilot for code completion