### PR TITLE
Implement read and write support for RichTextBlocks

### DIFF
--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -261,9 +261,7 @@ class TestOverriddenDefaultRichText(WagtailTestUtils, BaseRichTextEditHandlerTes
 
 @override_settings(
     WAGTAILADMIN_RICH_TEXT_EDITORS={
-        "default": {
-            "WIDGET": "wagtail.admin.tests.test_rich_text.TestCustomDefaultRichText"
-        },
+        "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
         "custom": {"WIDGET": "wagtail.test.testapp.rich_text.CustomRichTextArea"},
     }
 )

--- a/wagtail/api/v3/form_data.py
+++ b/wagtail/api/v3/form_data.py
@@ -17,6 +17,7 @@ from wagtail.api.rich_text import APIRichText
 from wagtail.api.v3.registry import ContentTypeRegistration, registry
 from wagtail.api.v3.schemas import create_generator
 from wagtail.blocks.base import BlockField
+from wagtail.blocks.field_block import RichTextBlock
 from wagtail.blocks.list_block import ListBlock
 from wagtail.blocks.stream_block import BaseStreamBlock
 from wagtail.blocks.struct_block import BaseStructBlock
@@ -297,6 +298,10 @@ def flatten_block_value(block, value: Any, prefix: str, data: MultiValueDict) ->
         value = value or {}
         for name, child_block in block.child_blocks.items():
             flatten_block_value(child_block, value.get(name), f"{prefix}-{name}", data)
+    elif isinstance(block, RichTextBlock):
+        if value is not None:
+            value, _ = APIRichText.convert_input(value, features=block.features)
+        data[prefix] = block.field.widget.format_value(value)
     else:
         # A leaf field block (CharBlock, BooleanBlock, ChooserBlock, ...):
         # its own form field's widget reads a single key via plain `.get()`,

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -7019,6 +7019,12 @@
       },
       "CustomRichBlockFieldPageCreateSchema": {
         "properties": {
+          "body": {
+            "default": [],
+            "items": {},
+            "title": "Body",
+            "type": "array"
+          },
           "meta": {
             "$ref": "#/components/schemas/CustomRichBlockFieldPageCreateMetaSchema"
           },
@@ -7231,6 +7237,12 @@
       },
       "CustomRichBlockFieldPagePatchSchema": {
         "properties": {
+          "body": {
+            "default": [],
+            "items": {},
+            "title": "Body",
+            "type": "array"
+          },
           "meta": {
             "anyOf": [
               {
@@ -7311,6 +7323,12 @@
       },
       "CustomRichBlockFieldPageSchema": {
         "properties": {
+          "body": {
+            "default": [],
+            "items": {},
+            "title": "Body",
+            "type": "array"
+          },
           "id": {
             "title": "Id",
             "type": "integer"
@@ -8033,6 +8051,12 @@
       },
       "DefaultRichBlockFieldPageCreateSchema": {
         "properties": {
+          "body": {
+            "default": [],
+            "items": {},
+            "title": "Body",
+            "type": "array"
+          },
           "meta": {
             "$ref": "#/components/schemas/DefaultRichBlockFieldPageCreateMetaSchema"
           },
@@ -8245,6 +8269,12 @@
       },
       "DefaultRichBlockFieldPagePatchSchema": {
         "properties": {
+          "body": {
+            "default": [],
+            "items": {},
+            "title": "Body",
+            "type": "array"
+          },
           "meta": {
             "anyOf": [
               {
@@ -8325,6 +8355,12 @@
       },
       "DefaultRichBlockFieldPageSchema": {
         "properties": {
+          "body": {
+            "default": [],
+            "items": {},
+            "title": "Body",
+            "type": "array"
+          },
           "id": {
             "title": "Id",
             "type": "integer"

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -5324,6 +5324,12 @@
       },
       "CustomRichBlockFieldPageCreateSchema": {
         "properties": {
+          "body": {
+            "default": [],
+            "items": {},
+            "title": "Body",
+            "type": "array"
+          },
           "meta": {
             "$ref": "#/components/schemas/CustomRichBlockFieldPageCreateMetaSchema"
           },
@@ -5465,6 +5471,12 @@
       },
       "CustomRichBlockFieldPagePatchSchema": {
         "properties": {
+          "body": {
+            "default": [],
+            "items": {},
+            "title": "Body",
+            "type": "array"
+          },
           "meta": {
             "anyOf": [
               {
@@ -5507,6 +5519,12 @@
       },
       "CustomRichBlockFieldPageSchema": {
         "properties": {
+          "body": {
+            "default": [],
+            "items": {},
+            "title": "Body",
+            "type": "array"
+          },
           "id": {
             "title": "Id",
             "type": "integer"
@@ -6011,6 +6029,12 @@
       },
       "DefaultRichBlockFieldPageCreateSchema": {
         "properties": {
+          "body": {
+            "default": [],
+            "items": {},
+            "title": "Body",
+            "type": "array"
+          },
           "meta": {
             "$ref": "#/components/schemas/DefaultRichBlockFieldPageCreateMetaSchema"
           },
@@ -6152,6 +6176,12 @@
       },
       "DefaultRichBlockFieldPagePatchSchema": {
         "properties": {
+          "body": {
+            "default": [],
+            "items": {},
+            "title": "Body",
+            "type": "array"
+          },
           "meta": {
             "anyOf": [
               {
@@ -6194,6 +6224,12 @@
       },
       "DefaultRichBlockFieldPageSchema": {
         "properties": {
+          "body": {
+            "default": [],
+            "items": {},
+            "title": "Body",
+            "type": "array"
+          },
           "id": {
             "title": "Id",
             "type": "integer"

--- a/wagtail/api/v3/tests/test_page_create.py
+++ b/wagtail/api/v3/tests/test_page_create.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 
 import swapper
 from django.contrib.auth.models import Group, Permission
@@ -617,18 +616,7 @@ class TestV3PageCreate(TestV3Base, WagtailTestUtils, TestCase):
             [{"message": "body: unrecognised block type 'not_a_real_block'"}],
         )
 
-    @unittest.expectedFailure
     def test_create_streamfield_page_with_rich_text_block(self):
-        """
-        RichTextBlock isn't yet run through APIRichText.convert_input like a
-        top-level RichTextField is (see convert_rich_text_payload). Its form
-        widget is Draftail, which expects a contentstate JSON string, not
-        source HTML - so posting the plain HTML string that every other
-        rich text input on this API accepts currently crashes the request
-        with a JSONDecodeError instead of saving the block or returning a
-        422. Marked as an expected failure until RichTextBlock values are
-        run through the same conversion as RichTextField.
-        """
         response = self.post(
             {
                 "meta": {"parent_id": self.root_page.pk, "type": "tests.StreamPage"},
@@ -640,7 +628,7 @@ class TestV3PageCreate(TestV3Base, WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 201)
         page = StreamPage.objects.get(slug="stream-page-rich-text")
         self.assertEqual(page.body[0].block_type, "rich_text")
-        self.assertEqual(str(page.body[0].value), "<p>hello <b>world</b></p>")
+        self.assertIn("hello <b>world</b>", str(page.body[0].value))
 
     def test_create_streamfield_page_with_various_block_types(self):
         image = Image.objects.create(title="Test image", file=get_test_image_file())
@@ -789,12 +777,7 @@ class TestV3PageCreate(TestV3Base, WagtailTestUtils, TestCase):
         self.assertEqual(block["type"], "image")
         self.assertEqual(block["value"], {"id": image.pk, "title": image.title})
 
-    @unittest.expectedFailure
     def test_create_streamfield_page_with_multiple_blocks(self):
-        """
-        Includes a rich_text block, which currently crashes the request -
-        see test_create_streamfield_page_with_rich_text_block.
-        """
         image = Image.objects.create(title="Test image", file=get_test_image_file())
         response = self.post(
             {

--- a/wagtail/api/v3/tests/test_page_create.py
+++ b/wagtail/api/v3/tests/test_page_create.py
@@ -1,4 +1,5 @@
 import json
+import unittest
 
 import swapper
 from django.contrib.auth.models import Group, Permission
@@ -614,6 +615,235 @@ class TestV3PageCreate(TestV3Base, WagtailTestUtils, TestCase):
         self.assertEqual(
             content["errors"],
             [{"message": "body: unrecognised block type 'not_a_real_block'"}],
+        )
+
+    @unittest.expectedFailure
+    def test_create_streamfield_page_with_rich_text_block(self):
+        """
+        RichTextBlock isn't yet run through APIRichText.convert_input like a
+        top-level RichTextField is (see convert_rich_text_payload). Its form
+        widget is Draftail, which expects a contentstate JSON string, not
+        source HTML - so posting the plain HTML string that every other
+        rich text input on this API accepts currently crashes the request
+        with a JSONDecodeError instead of saving the block or returning a
+        422. Marked as an expected failure until RichTextBlock values are
+        run through the same conversion as RichTextField.
+        """
+        response = self.post(
+            {
+                "meta": {"parent_id": self.root_page.pk, "type": "tests.StreamPage"},
+                "title": "Stream page",
+                "slug": "stream-page-rich-text",
+                "body": [{"type": "rich_text", "value": "<p>hello <b>world</b></p>"}],
+            }
+        )
+        self.assertEqual(response.status_code, 201)
+        page = StreamPage.objects.get(slug="stream-page-rich-text")
+        self.assertEqual(page.body[0].block_type, "rich_text")
+        self.assertEqual(str(page.body[0].value), "<p>hello <b>world</b></p>")
+
+    def test_create_streamfield_page_with_various_block_types(self):
+        image = Image.objects.create(title="Test image", file=get_test_image_file())
+        cases = [
+            (
+                "text",
+                "hello streamfield",
+                lambda value: self.assertEqual(value, "hello streamfield"),
+                lambda value: self.assertEqual(value, "hello streamfield"),
+            ),
+            (
+                "product",
+                {"name": "Widget", "price": "9.99"},
+                lambda value: (
+                    self.assertEqual(value["name"], "Widget"),
+                    self.assertEqual(value["price"], "9.99"),
+                ),
+                lambda value: self.assertEqual(
+                    value, {"name": "Widget", "price": "9.99"}
+                ),
+            ),
+            (
+                "raw_html",
+                "<div>raw</div>",
+                lambda value: self.assertEqual(str(value), "<div>raw</div>"),
+                lambda value: self.assertEqual(value, "<div>raw</div>"),
+            ),
+            (
+                "books",
+                [
+                    {"type": "title", "value": "Dune"},
+                    {"type": "author", "value": "Frank Herbert"},
+                ],
+                lambda value: (
+                    self.assertEqual(value[0].block_type, "title"),
+                    self.assertEqual(value[0].value, "Dune"),
+                    self.assertEqual(value[1].block_type, "author"),
+                    self.assertEqual(value[1].value, "Frank Herbert"),
+                ),
+                # Each child gets its own server-generated "id" - assert one
+                # is present, then compare the rest.
+                lambda value: (
+                    self.assertTrue(all(item["id"] for item in value)),
+                    self.assertEqual(
+                        [
+                            {k: v for k, v in item.items() if k != "id"}
+                            for item in value
+                        ],
+                        [
+                            {"type": "title", "value": "Dune"},
+                            {"type": "author", "value": "Frank Herbert"},
+                        ],
+                    ),
+                ),
+            ),
+            (
+                "title_list",
+                ["First", "Second", "Third"],
+                lambda value: self.assertEqual(
+                    list(value), ["First", "Second", "Third"]
+                ),
+                lambda value: self.assertEqual(value, ["First", "Second", "Third"]),
+            ),
+            (
+                "image",
+                image.pk,
+                lambda value: self.assertEqual(value.pk, image.pk),
+                lambda value: self.assertEqual(value, image.pk),
+            ),
+            (
+                "image_with_alt",
+                {
+                    "image": image.pk,
+                    "decorative": False,
+                    "alt_text": "A test image",
+                },
+                lambda value: (
+                    self.assertEqual(value.pk, image.pk),
+                    self.assertEqual(value.contextual_alt_text, "A test image"),
+                ),
+                lambda value: self.assertEqual(
+                    value,
+                    {
+                        "image": image.pk,
+                        "decorative": False,
+                        "alt_text": "A test image",
+                    },
+                ),
+            ),
+        ]
+        for (
+            block_type,
+            input_value,
+            assert_db_value,
+            assert_api_value,
+        ) in cases:
+            with self.subTest(block_type=block_type):
+                slug = f"stream-page-{block_type}"
+                response = self.post(
+                    {
+                        "meta": {
+                            "parent_id": self.root_page.pk,
+                            "type": "tests.StreamPage",
+                        },
+                        "title": "Stream page",
+                        "slug": slug,
+                        "body": [{"type": block_type, "value": input_value}],
+                    }
+                )
+                self.assertEqual(response.status_code, 201)
+
+                page = StreamPage.objects.get(slug=slug)
+                self.assertEqual(page.body[0].block_type, block_type)
+                assert_db_value(page.body[0].value)
+
+                [block] = response.json()["body"]
+                self.assertEqual(block["type"], block_type)
+                self.assertTrue(block["id"])
+                assert_api_value(block["value"])
+
+    def test_create_streamfield_page_with_image_chooser_block_extended(self):
+        """
+        With an ?extended= query param, ExtendedImageChooserBlock's
+        get_api_representation returns a dict of id/title instead of a bare
+        pk. Ensure this is respected in the create response body.
+        """
+        image = Image.objects.create(title="Test image", file=get_test_image_file())
+        response = self.client.post(
+            reverse("wagtailapi_v3:create_page") + "?extended=true",
+            data=json.dumps(
+                {
+                    "meta": {
+                        "parent_id": self.root_page.pk,
+                        "type": "tests.StreamPage",
+                    },
+                    "title": "Stream page",
+                    "slug": "stream-page-image-extended",
+                    "body": [{"type": "image", "value": image.pk}],
+                }
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+        content = response.json()
+        [block] = content["body"]
+        self.assertEqual(block["type"], "image")
+        self.assertEqual(block["value"], {"id": image.pk, "title": image.title})
+
+    @unittest.expectedFailure
+    def test_create_streamfield_page_with_multiple_blocks(self):
+        """
+        Includes a rich_text block, which currently crashes the request -
+        see test_create_streamfield_page_with_rich_text_block.
+        """
+        image = Image.objects.create(title="Test image", file=get_test_image_file())
+        response = self.post(
+            {
+                "meta": {"parent_id": self.root_page.pk, "type": "tests.StreamPage"},
+                "title": "Stream page",
+                "slug": "stream-page-multiple",
+                "body": [
+                    {"type": "text", "value": "hello"},
+                    {"type": "rich_text", "value": "<p>hi</p>"},
+                    {"type": "image", "value": image.pk},
+                    {
+                        "type": "product",
+                        "value": {"name": "Widget", "price": "9.99"},
+                    },
+                    {"type": "raw_html", "value": "<hr>"},
+                    {
+                        "type": "books",
+                        "value": [
+                            {"type": "title", "value": "Dune"},
+                            {"type": "author", "value": "Frank Herbert"},
+                        ],
+                    },
+                    {"type": "title_list", "value": ["First", "Second"]},
+                    {
+                        "type": "image_with_alt",
+                        "value": {
+                            "image": image.pk,
+                            "decorative": False,
+                            "alt_text": "A test image",
+                        },
+                    },
+                ],
+            }
+        )
+        self.assertEqual(response.status_code, 201)
+        page = StreamPage.objects.get(slug="stream-page-multiple")
+        self.assertEqual(len(page.body), 8)
+        self.assertEqual(
+            [block.block_type for block in page.body],
+            [
+                "text",
+                "rich_text",
+                "image",
+                "product",
+                "raw_html",
+                "books",
+                "title_list",
+                "image_with_alt",
+            ],
         )
 
     def test_create_page_with_rich_text_field(self):

--- a/wagtail/api/v3/tests/test_page_update.py
+++ b/wagtail/api/v3/tests/test_page_update.py
@@ -1,4 +1,5 @@
 import json
+import unittest
 
 from django.contrib.auth.models import Group, Permission
 from django.test import TestCase
@@ -226,6 +227,245 @@ class TestV3PageUpdate(TestV3Base, WagtailTestUtils, TestCase):
         self.assertEqual(page.body[0].value, "updated")
         # title wasn't sent, so it must be untouched.
         self.assertEqual(page.title, "Stream page")
+
+    def test_update_page_without_block_id_regenerates_it(self):
+        page = self.root_page.add_child(
+            instance=StreamPage(
+                title="Stream page",
+                slug="stream-page",
+                body=[{"type": "text", "value": "original"}],
+                live=False,
+            )
+        )
+        original_id = page.body[0].id
+        response = self.patch(
+            page,
+            {
+                "meta": {"type": "tests.StreamPage"},
+                "body": [{"type": "text", "value": "updated"}],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        page.refresh_from_db()
+        self.assertEqual(page.body[0].value, "updated")
+        self.assertNotEqual(page.body[0].id, original_id)
+
+    def test_update_page_with_block_id_preserves_it(self):
+        page = self.root_page.add_child(
+            instance=StreamPage(
+                title="Stream page",
+                slug="stream-page",
+                body=[{"type": "text", "value": "original"}],
+                live=False,
+            )
+        )
+        original_id = page.body[0].id
+        response = self.patch(
+            page,
+            {
+                "meta": {"type": "tests.StreamPage"},
+                "body": [{"type": "text", "value": "updated", "id": original_id}],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        page.refresh_from_db()
+        self.assertEqual(page.body[0].value, "updated")
+        self.assertEqual(page.body[0].id, original_id)
+
+    def test_update_page_with_streamfield_diffing(self):
+        page = self.root_page.add_child(
+            instance=StreamPage(
+                title="Stream page",
+                slug="stream-page",
+                body=[
+                    {"type": "text", "value": "first"},
+                    {"type": "text", "value": "second"},
+                    {"type": "text", "value": "third"},
+                ],
+                live=False,
+            )
+        )
+        first_id, second_id, third_id = (block.id for block in page.body)
+
+        response = self.patch(
+            page,
+            {
+                "meta": {"type": "tests.StreamPage"},
+                "body": [
+                    {"type": "text", "value": "third updated", "id": third_id},
+                    {"type": "text", "value": "first updated", "id": first_id},
+                    {"type": "text", "value": "new block"},
+                ],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        page.refresh_from_db()
+        self.assertEqual(len(page.body), 3)
+        self.assertEqual(page.body[0].value, "third updated")
+        self.assertEqual(page.body[0].id, third_id)
+        self.assertEqual(page.body[1].value, "first updated")
+        self.assertEqual(page.body[1].id, first_id)
+        self.assertEqual(page.body[2].value, "new block")
+        self.assertNotIn(page.body[2].id, {first_id, second_id, third_id})
+
+    @unittest.expectedFailure
+    def test_update_page_with_rich_text_block(self):
+        """
+        RichTextBlock isn't yet run through APIRichText.convert_input like a
+        top-level RichTextField is (see convert_rich_text_payload). Its form
+        widget is Draftail, which expects a contentstate JSON string, not
+        source HTML - so posting the plain HTML string that every other rich
+        text input on this API accepts currently crashes the request with a
+        JSONDecodeError instead of saving the block or returning a 200.
+        Marked as an expected failure until RichTextBlock values are run
+        through the same conversion as RichTextField.
+        """
+        page = self.root_page.add_child(
+            instance=StreamPage(
+                title="Stream page",
+                slug="stream-page",
+                body=[{"type": "rich_text", "value": "<p>original</p>"}],
+                live=False,
+            )
+        )
+        response = self.patch(
+            page,
+            {
+                "meta": {"type": "tests.StreamPage"},
+                "body": [{"type": "rich_text", "value": "<p>updated <b>text</b></p>"}],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        page.refresh_from_db()
+        self.assertEqual(page.body[0].block_type, "rich_text")
+        self.assertEqual(str(page.body[0].value), "<p>updated <b>text</b></p>")
+
+    def test_update_page_with_various_block_types(self):
+        original_image = Image.objects.create(
+            title="Original image", file=get_test_image_file()
+        )
+        new_image = Image.objects.create(title="New image", file=get_test_image_file())
+        cases = [
+            (
+                "product",
+                {"name": "Original", "price": "1.00"},
+                {"name": "Widget", "price": "9.99"},
+                lambda value: (
+                    self.assertEqual(value["name"], "Widget"),
+                    self.assertEqual(value["price"], "9.99"),
+                ),
+                lambda value: self.assertEqual(
+                    value, {"name": "Widget", "price": "9.99"}
+                ),
+            ),
+            (
+                "raw_html",
+                "<div>original</div>",
+                "<div>updated</div>",
+                lambda value: self.assertEqual(str(value), "<div>updated</div>"),
+                lambda value: self.assertEqual(value, "<div>updated</div>"),
+            ),
+            (
+                "books",
+                [{"type": "title", "value": "Original"}],
+                [
+                    {"type": "title", "value": "Dune"},
+                    {"type": "author", "value": "Frank Herbert"},
+                ],
+                lambda value: (
+                    self.assertEqual(value[0].value, "Dune"),
+                    self.assertEqual(value[1].value, "Frank Herbert"),
+                ),
+                # Each child gets its own server-generated "id" - assert one
+                # is present, then compare the rest.
+                lambda value: (
+                    self.assertTrue(all(item["id"] for item in value)),
+                    self.assertEqual(
+                        [
+                            {k: v for k, v in item.items() if k != "id"}
+                            for item in value
+                        ],
+                        [
+                            {"type": "title", "value": "Dune"},
+                            {"type": "author", "value": "Frank Herbert"},
+                        ],
+                    ),
+                ),
+            ),
+            (
+                "title_list",
+                ["Original"],
+                ["First", "Second", "Third"],
+                lambda value: self.assertEqual(
+                    list(value), ["First", "Second", "Third"]
+                ),
+                lambda value: self.assertEqual(value, ["First", "Second", "Third"]),
+            ),
+            (
+                "image",
+                original_image.pk,
+                new_image.pk,
+                lambda value: self.assertEqual(value.pk, new_image.pk),
+                lambda value: self.assertEqual(value, new_image.pk),
+            ),
+            (
+                "image_with_alt",
+                {
+                    "image": original_image.pk,
+                    "decorative": False,
+                    "alt_text": "Original alt",
+                },
+                {
+                    "image": original_image.pk,
+                    "decorative": False,
+                    "alt_text": "Updated alt",
+                },
+                lambda value: self.assertEqual(
+                    value.contextual_alt_text, "Updated alt"
+                ),
+                lambda value: self.assertEqual(
+                    value,
+                    {
+                        "image": original_image.pk,
+                        "decorative": False,
+                        "alt_text": "Updated alt",
+                    },
+                ),
+            ),
+        ]
+        for (
+            block_type,
+            original_value,
+            updated_value,
+            assert_db_value,
+            assert_api_value,
+        ) in cases:
+            with self.subTest(block_type=block_type):
+                page = self.root_page.add_child(
+                    instance=StreamPage(
+                        title="Stream page",
+                        slug=f"stream-page-{block_type}",
+                        body=[{"type": block_type, "value": original_value}],
+                        live=False,
+                    )
+                )
+                response = self.patch(
+                    page,
+                    {
+                        "meta": {"type": "tests.StreamPage"},
+                        "body": [{"type": block_type, "value": updated_value}],
+                    },
+                )
+                self.assertEqual(response.status_code, 200)
+
+                page.refresh_from_db()
+                self.assertEqual(page.body[0].block_type, block_type)
+                assert_db_value(page.body[0].value)
+
+                [block] = response.json()["body"]
+                self.assertEqual(block["type"], block_type)
+                self.assertTrue(block["id"])
+                assert_api_value(block["value"])
 
     def test_update_page_with_non_writable_api_field_ignores_it(self):
         page = self.root_page.add_child(

--- a/wagtail/api/v3/tests/test_page_update.py
+++ b/wagtail/api/v3/tests/test_page_update.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 
 from django.contrib.auth.models import Group, Permission
 from django.test import TestCase
@@ -308,18 +307,7 @@ class TestV3PageUpdate(TestV3Base, WagtailTestUtils, TestCase):
         self.assertEqual(page.body[2].value, "new block")
         self.assertNotIn(page.body[2].id, {first_id, second_id, third_id})
 
-    @unittest.expectedFailure
     def test_update_page_with_rich_text_block(self):
-        """
-        RichTextBlock isn't yet run through APIRichText.convert_input like a
-        top-level RichTextField is (see convert_rich_text_payload). Its form
-        widget is Draftail, which expects a contentstate JSON string, not
-        source HTML - so posting the plain HTML string that every other rich
-        text input on this API accepts currently crashes the request with a
-        JSONDecodeError instead of saving the block or returning a 200.
-        Marked as an expected failure until RichTextBlock values are run
-        through the same conversion as RichTextField.
-        """
         page = self.root_page.add_child(
             instance=StreamPage(
                 title="Stream page",
@@ -338,7 +326,7 @@ class TestV3PageUpdate(TestV3Base, WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
         page.refresh_from_db()
         self.assertEqual(page.body[0].block_type, "rich_text")
-        self.assertEqual(str(page.body[0].value), "<p>updated <b>text</b></p>")
+        self.assertIn("updated <b>text</b>", str(page.body[0].value))
 
     def test_update_page_with_various_block_types(self):
         original_image = Image.objects.create(

--- a/wagtail/api/v3/tests/test_rich_text.py
+++ b/wagtail/api/v3/tests/test_rich_text.py
@@ -1,10 +1,13 @@
 import json
+import unittest
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from wagtail.api.v3.tests.base import TestV3Base
 from wagtail.test.testapp.models import (
+    CustomRichBlockFieldPage,
+    DefaultRichBlockFieldPage,
     DefaultRichTextFieldPage,
     RichTextFieldWithFeaturesPage,
 )
@@ -12,10 +15,14 @@ from wagtail.test.utils import Page, WagtailTestUtils
 
 
 class TestV3RichTextWrite(TestV3Base, WagtailTestUtils, TestCase):
+    model = DefaultRichTextFieldPage
+    unknown_format_status = 422
+
     def setUp(self):
         super().setUp()
         self.root_page = Page.objects.get(depth=1)
         self.user = self.login()
+        self.type_name = self.model._meta.label
 
     def post(self, data):
         return self.client.post(
@@ -24,46 +31,57 @@ class TestV3RichTextWrite(TestV3Base, WagtailTestUtils, TestCase):
             content_type="application/json",
         )
 
-    def create_page(self, body, model="tests.DefaultRichTextFieldPage", title="Rich"):
+    def build_body(self, value):
+        return value
+
+    def body_value(self, page):
+        return page.body
+
+    def create_page(self, value, model=None, title="Rich"):
         return self.post(
             {
-                "meta": {"parent_id": self.root_page.pk, "type": model},
+                "meta": {
+                    "parent_id": self.root_page.pk,
+                    "type": model or self.type_name,
+                },
                 "title": title,
                 "slug": "rich",
-                "body": body,
+                "body": self.build_body(value),
             }
         )
 
     def test_plain_string_stored_sanitised(self):
         response = self.create_page("<p><b>x</b></p><script>alert(1)</script>")
         self.assertEqual(response.status_code, 201)
-        page = DefaultRichTextFieldPage.objects.get(slug="rich")
-        self.assertNotIn("<script", page.body)
-        self.assertIn("<b>x</b>", page.body)
+        page = self.model.objects.get(slug="rich")
+        value = self.body_value(page)
+        self.assertNotIn("<script", value)
+        self.assertIn("<b>x</b>", value)
 
     def test_envelope_stored_sanitised(self):
         response = self.create_page(
             {"format": "db_html", "content": "<p>hi <script>alert(1)</script></p>"}
         )
         self.assertEqual(response.status_code, 201)
-        page = DefaultRichTextFieldPage.objects.get(slug="rich")
-        self.assertNotIn("<script", page.body)
+        page = self.model.objects.get(slug="rich")
+        self.assertNotIn("<script", self.body_value(page))
 
     def test_entity_references_survive(self):
         response = self.create_page('<p><a linktype="page" id="2">home</a></p>')
         self.assertEqual(response.status_code, 201)
-        page = DefaultRichTextFieldPage.objects.get(slug="rich")
-        self.assertIn('linktype="page"', page.body)
-        self.assertIn('id="2"', page.body)
+        page = self.model.objects.get(slug="rich")
+        value = self.body_value(page)
+        self.assertIn('linktype="page"', value)
+        self.assertIn('id="2"', value)
 
-    def test_unknown_format_rejected_with_422(self):
+    def test_unknown_format_rejected(self):
         response = self.create_page({"format": "markdown", "content": "# Hi"})
-        self.assert_problem_response(response, status_code=422)
+        self.assert_problem_response(response, status_code=self.unknown_format_status)
 
-    def create_page_without_body(self, action=None):
+    def create_page_without_body(self, action=None, **data):
         meta = {
             "parent_id": self.root_page.pk,
-            "type": "tests.DefaultRichTextFieldPage",
+            "type": self.type_name,
         }
         if action:
             meta["action"] = action
@@ -72,6 +90,7 @@ class TestV3RichTextWrite(TestV3Base, WagtailTestUtils, TestCase):
                 "meta": meta,
                 "title": "No body",
                 "slug": "no-body",
+                **data,
             }
         )
 
@@ -83,8 +102,11 @@ class TestV3RichTextWrite(TestV3Base, WagtailTestUtils, TestCase):
         # paragraph, so what gets stored is not "".
         response = self.create_page_without_body()
         self.assertEqual(response.status_code, 201)
-        page = DefaultRichTextFieldPage.objects.get(slug="no-body")
-        self.assertRegex(page.body, r"^<p data-block-key=\"[a-z0-9]+\"></p>$")
+        page = self.model.objects.get(slug="no-body")
+        self.assertRegex(
+            self.body_value(page),
+            r"^<p data-block-key=\"[a-z0-9]+\"></p>$",
+        )
 
     def test_omitted_required_body_allowed_on_publish(self):
         # Publish runs full form validation, but the widget round-trip's
@@ -94,7 +116,7 @@ class TestV3RichTextWrite(TestV3Base, WagtailTestUtils, TestCase):
         # strictness; see the plan's Task 3 ruling.)
         response = self.create_page_without_body(action="publish")
         self.assertEqual(response.status_code, 201)
-        page = DefaultRichTextFieldPage.objects.get(slug="no-body")
+        page = self.model.objects.get(slug="no-body")
         self.assertTrue(page.live)
 
     def test_feature_restricted_field_strips_out_of_features(self):
@@ -111,21 +133,97 @@ class TestV3RichTextWrite(TestV3Base, WagtailTestUtils, TestCase):
         self.assertNotIn("<b>", page.body)
 
 
+class TestV3RichTextBlockWrite(TestV3RichTextWrite):
+    """RichTextBlock counterpart of TestV3RichTextWrite."""
+
+    model = DefaultRichBlockFieldPage
+    type_name = "tests.DefaultRichBlockFieldPage"
+    unknown_format_status = 400
+
+    def build_body(self, value):
+        return [{"type": "rich_text", "value": value}]
+
+    def body_value(self, page):
+        return page.body[0].value.source
+
+    def create_page_without_body(self, action=None, **data):
+        # Rather than an empty StreamField body, add a single rich_text block
+        # with an empty value for testing empty input.
+        return super().create_page_without_body(
+            action,
+            body=[{"type": "rich_text", "value": ""}],
+        )
+
+    def create_page_with_block(self, block_type, value, model, title):
+        return self.post(
+            {
+                "meta": {"parent_id": self.root_page.pk, "type": model},
+                "title": title,
+                "slug": "rich",
+                "body": [{"type": block_type, "value": value}],
+            }
+        )
+
+    def test_feature_restricted_field_strips_out_of_features(self):
+        # CustomRichBlockFieldPage.rich_text_limited block: features=
+        # ["quotation", "embed"] - bold/h2 are not enabled.
+        response = self.create_page_with_block(
+            "rich_text_limited",
+            "<h2>T</h2><p><b>x</b></p>",
+            model="tests.CustomRichBlockFieldPage",
+            title="Restricted",
+        )
+        self.assertEqual(response.status_code, 201)
+        page = CustomRichBlockFieldPage.objects.get(slug="rich")
+        value = page.body[0].value.source
+        self.assertNotIn("<h2>", value)
+        self.assertNotIn("<b>", value)
+
+    def test_unrestricted_block_on_same_page_keeps_its_own_features(self):
+        # The plain "rich_text" block on CustomRichBlockFieldPage has no
+        # features restriction, unlike its sibling "rich_text_limited" block.
+        response = self.create_page_with_block(
+            "rich_text",
+            "<h2>T</h2><p><b>x</b></p>",
+            model="tests.CustomRichBlockFieldPage",
+            title="Unrestricted",
+        )
+        self.assertEqual(response.status_code, 201)
+        page = CustomRichBlockFieldPage.objects.get(slug="rich")
+        value = page.body[0].value.source
+        self.assertIn("<h2>", value)
+        self.assertIn("<b>", value)
+
+
 class TestV3RichTextRead(TestV3Base, WagtailTestUtils, TestCase):
+    model = DefaultRichTextFieldPage
+    type_name = "tests.DefaultRichTextFieldPage"
+
     def setUp(self):
         super().setUp()
         self.root_page = Page.objects.get(depth=1)
         self.user = self.login()
         self.home_page = Page.objects.get(depth=2)
-        self.page = DefaultRichTextFieldPage(
+        self.page = self.model(
             title="Rich",
             slug="rich",
-            body=f'<p><a linktype="page" id="{self.home_page.pk}">home</a></p>',
+            body=self.build_body(
+                f'<p><a linktype="page" id="{self.home_page.pk}">home</a></p>'
+            ),
         )
         # The detail endpoint serves the public queryset: live pages under
         # the default site's root (the depth-2 home page).
         self.home_page.add_child(instance=self.page)
         self.page.save_revision().publish()
+
+    def build_body(self, html):
+        """The api_fields "body" payload/model value for a given rich text
+        HTML string - a plain string for RichTextField."""
+        return html
+
+    def body_value(self, response):
+        """Extract the rich text HTML from a response's "body" value."""
+        return response.json()["body"]
 
     def get_detail(self, **params):
         return self.client.get(
@@ -137,14 +235,14 @@ class TestV3RichTextRead(TestV3Base, WagtailTestUtils, TestCase):
         response = self.get_detail()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.json()["body"],
+            self.body_value(response),
             f'<p><a linktype="page" id="{self.home_page.pk}">home</a></p>',
         )
 
     def test_html_output_expands_references(self):
         response = self.get_detail(rich_text_format="html")
         self.assertEqual(response.status_code, 200)
-        body = response.json()["body"]
+        body = self.body_value(response)
         self.assertIn("<a href=", body)
         self.assertNotIn("linktype", body)
 
@@ -173,28 +271,30 @@ class TestV3RichTextRead(TestV3Base, WagtailTestUtils, TestCase):
                 {
                     "meta": {
                         "parent_id": self.root_page.pk,
-                        "type": "tests.DefaultRichTextFieldPage",
+                        "type": self.type_name,
                     },
                     "title": "Rich html",
                     "slug": "rich-html",
-                    "body": f'<p><a linktype="page" id="{self.home_page.pk}">home</a></p>',
+                    "body": self.build_body(
+                        f'<p><a linktype="page" id="{self.home_page.pk}">home</a></p>'
+                    ),
                 }
             ),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 201)
-        self.assertIn("<a href=", response.json()["body"])
+        self.assertIn("<a href=", self.body_value(response))
 
     @override_settings(WAGTAILAPI_RICH_TEXT_FORMAT="html")
     def test_project_wide_default_setting(self):
         response = self.get_detail()
-        self.assertIn("<a href=", response.json()["body"])
+        self.assertIn("<a href=", self.body_value(response))
 
     def test_features_in_schema_discovery(self):
         response = self.client.get(
             reverse(
                 "wagtailapi_v3:get_schema_for_type",
-                kwargs={"type_name": "tests.DefaultRichTextFieldPage"},
+                kwargs={"type_name": self.type_name},
             )
         )
         self.assertEqual(response.status_code, 200)
@@ -202,3 +302,35 @@ class TestV3RichTextRead(TestV3Base, WagtailTestUtils, TestCase):
         body_schema = read_schema["properties"]["body"]
         self.assertIn("features", body_schema)
         self.assertIn("bold", body_schema["features"])
+
+
+class TestV3RichTextBlockRead(TestV3RichTextRead):
+    """RichTextBlock counterpart of TestV3RichTextRead."""
+
+    model = DefaultRichBlockFieldPage
+    type_name = "tests.DefaultRichBlockFieldPage"
+
+    def build_body(self, html):
+        return [{"type": "rich_text", "value": html}]
+
+    def body_value(self, response):
+        [block] = response.json()["body"]
+        return block["value"]
+
+    def test_features_in_schema_discovery(self):
+        self.skipTest("StreamField body has no per-block schema to carry features")
+
+    @unittest.expectedFailure
+    def test_html_output_expands_references(self):
+        "RichTextBlock does not respect rich_text_format query param"
+        super().test_html_output_expands_references()
+
+    @unittest.expectedFailure
+    def test_write_response_honours_format(self):
+        "RichTextBlock does not respect rich_text_format query param"
+        super().test_write_response_honours_format()
+
+    @unittest.expectedFailure
+    def test_project_wide_default_setting(self):
+        "RichTextBlock does not respect WAGTAILAPI_RICH_TEXT_FORMAT"
+        super().test_project_wide_default_setting()

--- a/wagtail/api/v3/tests/test_rich_text.py
+++ b/wagtail/api/v3/tests/test_rich_text.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -319,18 +318,3 @@ class TestV3RichTextBlockRead(TestV3RichTextRead):
 
     def test_features_in_schema_discovery(self):
         self.skipTest("StreamField body has no per-block schema to carry features")
-
-    @unittest.expectedFailure
-    def test_html_output_expands_references(self):
-        "RichTextBlock does not respect rich_text_format query param"
-        super().test_html_output_expands_references()
-
-    @unittest.expectedFailure
-    def test_write_response_honours_format(self):
-        "RichTextBlock does not respect rich_text_format query param"
-        super().test_write_response_honours_format()
-
-    @unittest.expectedFailure
-    def test_project_wide_default_setting(self):
-        "RichTextBlock does not respect WAGTAILAPI_RICH_TEXT_FORMAT"
-        super().test_project_wide_default_setting()

--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -16,6 +16,7 @@ from django.utils.translation import gettext as _
 
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.telepath import Adapter, register
+from wagtail.api.rich_text import APIRichText
 from wagtail.compat import URLField
 from wagtail.coreutils import camelcase_to_underscore, resolve_model_string
 from wagtail.rich_text import (
@@ -784,6 +785,13 @@ class RichTextBlock(FieldBlock):
         # convert a RichText object back to a source-HTML string to go into
         # the JSONish representation
         return value.source
+
+    def get_api_representation(self, value, context=None):
+        rich_text_format = None
+        if request := (context and context.get("request")):
+            rich_text_format = request.GET.get("rich_text_format")
+        rich_text_format = APIRichText.resolve_format(rich_text_format)
+        return APIRichText.serialize(value.source, format=rich_text_format)
 
     def normalize(self, value):
         if isinstance(value, RichText):

--- a/wagtail/snippets/tests/test_api_v3/test_create.py
+++ b/wagtail/snippets/tests/test_api_v3/test_create.py
@@ -1,4 +1,5 @@
 import json
+import unittest
 
 from django.contrib.auth.models import Permission
 from django.test import TestCase
@@ -217,6 +218,129 @@ class TestV3SnippetCreateWithRelations(TestV3SnippetCreateBase):
         self.assertEqual(len(snippet.body), 1)
         self.assertEqual(snippet.body[0].block_type, "text")
         self.assertEqual(snippet.body[0].value, "hello world")
+
+    def test_create_with_various_streamfield_block_types(self):
+        image = Image.objects.create(title="Test image", file=get_test_image_file())
+        cases = [
+            (
+                "text",
+                "hello streamfield",
+                lambda value: self.assertEqual(value, "hello streamfield"),
+                lambda value: self.assertEqual(value, "hello streamfield"),
+            ),
+            (
+                "product",
+                {"name": "Widget", "price": "9.99"},
+                lambda value: (
+                    self.assertEqual(value["name"], "Widget"),
+                    self.assertEqual(value["price"], "9.99"),
+                ),
+                lambda value: self.assertEqual(
+                    value, {"name": "Widget", "price": "9.99"}
+                ),
+            ),
+            (
+                "raw_html",
+                "<div>raw</div>",
+                lambda value: self.assertEqual(str(value), "<div>raw</div>"),
+                lambda value: self.assertEqual(value, "<div>raw</div>"),
+            ),
+            (
+                "books",
+                [
+                    {"type": "title", "value": "Dune"},
+                    {"type": "author", "value": "Frank Herbert"},
+                ],
+                lambda value: (
+                    self.assertEqual(value[0].block_type, "title"),
+                    self.assertEqual(value[0].value, "Dune"),
+                    self.assertEqual(value[1].block_type, "author"),
+                    self.assertEqual(value[1].value, "Frank Herbert"),
+                ),
+                lambda value: (
+                    self.assertTrue(all(item["id"] for item in value)),
+                    self.assertEqual(
+                        [
+                            {k: v for k, v in item.items() if k != "id"}
+                            for item in value
+                        ],
+                        [
+                            {"type": "title", "value": "Dune"},
+                            {"type": "author", "value": "Frank Herbert"},
+                        ],
+                    ),
+                ),
+            ),
+            (
+                "title_list",
+                ["First", "Second", "Third"],
+                lambda value: self.assertEqual(
+                    list(value), ["First", "Second", "Third"]
+                ),
+                lambda value: self.assertEqual(value, ["First", "Second", "Third"]),
+            ),
+            (
+                "image",
+                image.pk,
+                lambda value: self.assertEqual(value.pk, image.pk),
+                lambda value: self.assertEqual(value, image.pk),
+            ),
+            (
+                "image_with_alt",
+                {
+                    "image": image.pk,
+                    "decorative": False,
+                    "alt_text": "A test image",
+                },
+                lambda value: (
+                    self.assertEqual(value.pk, image.pk),
+                    self.assertEqual(value.contextual_alt_text, "A test image"),
+                ),
+                lambda value: self.assertEqual(
+                    value,
+                    {
+                        "image": image.pk,
+                        "decorative": False,
+                        "alt_text": "A test image",
+                    },
+                ),
+            ),
+        ]
+        for block_type, input_value, assert_db_value, assert_api_value in cases:
+            with self.subTest(block_type=block_type):
+                text = f"Hello {block_type}"
+                response = self.post(
+                    {
+                        "text": text,
+                        # UUIDSnippetWithRelationsAPIForm.clean() requires
+                        # feed_image whenever body is given.
+                        "feed_image_id": image.pk,
+                        "body": [{"type": block_type, "value": input_value}],
+                    }
+                )
+                self.assertEqual(response.status_code, 201)
+
+                snippet = UUIDSnippetWithRelations.objects.get(text=text)
+                self.assertEqual(snippet.body[0].block_type, block_type)
+                assert_db_value(snippet.body[0].value)
+
+                [block] = response.json()["body"]
+                self.assertEqual(block["type"], block_type)
+                self.assertTrue(block["id"])
+                assert_api_value(block["value"])
+
+    @unittest.expectedFailure
+    def test_create_with_rich_text_block(self):
+        response = self.post(
+            {
+                "text": "Hello",
+                "body": [{"type": "rich_text", "value": "<p>hello <b>world</b></p>"}],
+            }
+        )
+        self.assertEqual(response.status_code, 201)
+        snippet = UUIDSnippetWithRelations.objects.get(text="Hello")
+        self.assertEqual(snippet.body[0].block_type, "rich_text")
+        self.assertEqual(str(snippet.body[0].value), "<p>hello <b>world</b></p>")
 
     def test_create_with_invalid_streamfield_block_type_returns_422(self):
         response = self.post(

--- a/wagtail/snippets/tests/test_api_v3/test_create.py
+++ b/wagtail/snippets/tests/test_api_v3/test_create.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 
 from django.contrib.auth.models import Permission
 from django.test import TestCase
@@ -329,18 +328,19 @@ class TestV3SnippetCreateWithRelations(TestV3SnippetCreateBase):
                 self.assertTrue(block["id"])
                 assert_api_value(block["value"])
 
-    @unittest.expectedFailure
     def test_create_with_rich_text_block(self):
+        image = Image.objects.create(title="Test image", file=get_test_image_file())
         response = self.post(
             {
                 "text": "Hello",
+                "feed_image_id": image.pk,
                 "body": [{"type": "rich_text", "value": "<p>hello <b>world</b></p>"}],
             }
         )
         self.assertEqual(response.status_code, 201)
         snippet = UUIDSnippetWithRelations.objects.get(text="Hello")
         self.assertEqual(snippet.body[0].block_type, "rich_text")
-        self.assertEqual(str(snippet.body[0].value), "<p>hello <b>world</b></p>")
+        self.assertIn("hello <b>world</b>", str(snippet.body[0].value))
 
     def test_create_with_invalid_streamfield_block_type_returns_422(self):
         response = self.post(

--- a/wagtail/snippets/tests/test_api_v3/test_update.py
+++ b/wagtail/snippets/tests/test_api_v3/test_update.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 
 from django.contrib.auth.models import Permission
 from django.test import TestCase
@@ -316,7 +315,6 @@ class TestV3SnippetUpdateWithRelations(TestV3SnippetUpdateBase):
         self.assertEqual(snippet.body[2].value, "new block")
         self.assertNotIn(snippet.body[2].id, {first_id, second_id, third_id})
 
-    @unittest.expectedFailure
     def test_update_with_rich_text_block(self):
         image = Image.objects.create(title="Test image", file=get_test_image_file())
         snippet = UUIDSnippetWithRelations.objects.create(
@@ -333,7 +331,7 @@ class TestV3SnippetUpdateWithRelations(TestV3SnippetUpdateBase):
         )
         self.assertEqual(response.status_code, 200)
         snippet.refresh_from_db()
-        self.assertEqual(str(snippet.body[0].value), "<p>updated <b>text</b></p>")
+        self.assertIn("updated <b>text</b>", str(snippet.body[0].value))
 
     def test_update_with_various_streamfield_block_types(self):
         original_image = Image.objects.create(

--- a/wagtail/snippets/tests/test_api_v3/test_update.py
+++ b/wagtail/snippets/tests/test_api_v3/test_update.py
@@ -1,4 +1,5 @@
 import json
+import unittest
 
 from django.contrib.auth.models import Permission
 from django.test import TestCase
@@ -222,6 +223,235 @@ class TestV3SnippetUpdateWithRelations(TestV3SnippetUpdateBase):
         self.assertEqual(response.status_code, 200)
         snippet.refresh_from_db()
         self.assertIsNone(snippet.feed_image_id)
+
+    def test_update_with_streamfield(self):
+        image = Image.objects.create(title="Test image", file=get_test_image_file())
+        snippet = UUIDSnippetWithRelations.objects.create(
+            text="Hello",
+            feed_image=image,
+            body=[{"type": "text", "value": "hello world"}],
+        )
+        response = self.patch(
+            snippet.pk,
+            {
+                "feed_image_id": image.pk,
+                "body": [{"type": "text", "value": "updated"}],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        snippet.refresh_from_db()
+        self.assertEqual(snippet.body[0].value, "updated")
+
+    def test_update_without_block_id_regenerates_it(self):
+        image = Image.objects.create(title="Test image", file=get_test_image_file())
+        snippet = UUIDSnippetWithRelations.objects.create(
+            text="Hello",
+            feed_image=image,
+            body=[{"type": "text", "value": "original"}],
+        )
+        original_id = snippet.body[0].id
+        response = self.patch(
+            snippet.pk,
+            {
+                "feed_image_id": image.pk,
+                "body": [{"type": "text", "value": "updated"}],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        snippet.refresh_from_db()
+        self.assertEqual(snippet.body[0].value, "updated")
+        self.assertNotEqual(snippet.body[0].id, original_id)
+
+    def test_update_with_block_id_preserves_it(self):
+        image = Image.objects.create(title="Test image", file=get_test_image_file())
+        snippet = UUIDSnippetWithRelations.objects.create(
+            text="Hello",
+            feed_image=image,
+            body=[{"type": "text", "value": "original"}],
+        )
+        original_id = snippet.body[0].id
+        response = self.patch(
+            snippet.pk,
+            {
+                "feed_image_id": image.pk,
+                "body": [{"type": "text", "value": "updated", "id": original_id}],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        snippet.refresh_from_db()
+        self.assertEqual(snippet.body[0].value, "updated")
+        self.assertEqual(snippet.body[0].id, original_id)
+
+    def test_update_with_streamfield_diffing(self):
+        image = Image.objects.create(title="Test image", file=get_test_image_file())
+        snippet = UUIDSnippetWithRelations.objects.create(
+            text="Hello",
+            feed_image=image,
+            body=[
+                {"type": "text", "value": "first"},
+                {"type": "text", "value": "second"},
+                {"type": "text", "value": "third"},
+            ],
+        )
+        first_id, second_id, third_id = (block.id for block in snippet.body)
+
+        response = self.patch(
+            snippet.pk,
+            {
+                "feed_image_id": image.pk,
+                "body": [
+                    {"type": "text", "value": "third updated", "id": third_id},
+                    {"type": "text", "value": "first updated", "id": first_id},
+                    {"type": "text", "value": "new block"},
+                ],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        snippet.refresh_from_db()
+        self.assertEqual(len(snippet.body), 3)
+        self.assertEqual(snippet.body[0].value, "third updated")
+        self.assertEqual(snippet.body[0].id, third_id)
+        self.assertEqual(snippet.body[1].value, "first updated")
+        self.assertEqual(snippet.body[1].id, first_id)
+        self.assertEqual(snippet.body[2].value, "new block")
+        self.assertNotIn(snippet.body[2].id, {first_id, second_id, third_id})
+
+    @unittest.expectedFailure
+    def test_update_with_rich_text_block(self):
+        image = Image.objects.create(title="Test image", file=get_test_image_file())
+        snippet = UUIDSnippetWithRelations.objects.create(
+            text="Hello",
+            feed_image=image,
+            body=[{"type": "rich_text", "value": "<p>original</p>"}],
+        )
+        response = self.patch(
+            snippet.pk,
+            {
+                "feed_image_id": image.pk,
+                "body": [{"type": "rich_text", "value": "<p>updated <b>text</b></p>"}],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        snippet.refresh_from_db()
+        self.assertEqual(str(snippet.body[0].value), "<p>updated <b>text</b></p>")
+
+    def test_update_with_various_streamfield_block_types(self):
+        original_image = Image.objects.create(
+            title="Original image", file=get_test_image_file()
+        )
+        new_image = Image.objects.create(title="New image", file=get_test_image_file())
+        cases = [
+            (
+                "product",
+                {"name": "Original", "price": "1.00"},
+                {"name": "Widget", "price": "9.99"},
+                lambda value: (
+                    self.assertEqual(value["name"], "Widget"),
+                    self.assertEqual(value["price"], "9.99"),
+                ),
+                lambda value: self.assertEqual(
+                    value, {"name": "Widget", "price": "9.99"}
+                ),
+            ),
+            (
+                "raw_html",
+                "<div>original</div>",
+                "<div>updated</div>",
+                lambda value: self.assertEqual(str(value), "<div>updated</div>"),
+                lambda value: self.assertEqual(value, "<div>updated</div>"),
+            ),
+            (
+                "books",
+                [{"type": "title", "value": "Original"}],
+                [
+                    {"type": "title", "value": "Dune"},
+                    {"type": "author", "value": "Frank Herbert"},
+                ],
+                lambda value: (
+                    self.assertEqual(value[0].value, "Dune"),
+                    self.assertEqual(value[1].value, "Frank Herbert"),
+                ),
+                lambda value: (
+                    self.assertTrue(all(item["id"] for item in value)),
+                    self.assertEqual(
+                        [
+                            {k: v for k, v in item.items() if k != "id"}
+                            for item in value
+                        ],
+                        [
+                            {"type": "title", "value": "Dune"},
+                            {"type": "author", "value": "Frank Herbert"},
+                        ],
+                    ),
+                ),
+            ),
+            (
+                "title_list",
+                ["Original"],
+                ["First", "Second", "Third"],
+                lambda value: self.assertEqual(
+                    list(value), ["First", "Second", "Third"]
+                ),
+                lambda value: self.assertEqual(value, ["First", "Second", "Third"]),
+            ),
+            (
+                "image",
+                original_image.pk,
+                new_image.pk,
+                lambda value: self.assertEqual(value.pk, new_image.pk),
+                lambda value: self.assertEqual(value, new_image.pk),
+            ),
+            (
+                "image_with_alt",
+                {
+                    "image": original_image.pk,
+                    "decorative": False,
+                    "alt_text": "Original alt",
+                },
+                {
+                    "image": original_image.pk,
+                    "decorative": False,
+                    "alt_text": "Updated alt",
+                },
+                lambda value: self.assertEqual(
+                    value.contextual_alt_text, "Updated alt"
+                ),
+                lambda value: self.assertEqual(
+                    value,
+                    {
+                        "image": original_image.pk,
+                        "decorative": False,
+                        "alt_text": "Updated alt",
+                    },
+                ),
+            ),
+        ]
+        for (
+            block_type,
+            original_value,
+            updated_value,
+            assert_db_value,
+            assert_api_value,
+        ) in cases:
+            with self.subTest(block_type=block_type):
+                snippet = UUIDSnippetWithRelations.objects.create(
+                    text=f"Hello {block_type}",
+                    feed_image=original_image,
+                    body=[{"type": block_type, "value": original_value}],
+                )
+                response = self.patch(
+                    snippet.pk,
+                    {"body": [{"type": block_type, "value": updated_value}]},
+                )
+                self.assertEqual(response.status_code, 200)
+
+                snippet.refresh_from_db()
+                self.assertEqual(snippet.body[0].block_type, block_type)
+                assert_db_value(snippet.body[0].value)
+
+                [block] = response.json()["body"]
+                self.assertEqual(block["type"], block_type)
+                assert_api_value(block["value"])
 
     def test_update_with_child_relations_replaces_them(self):
         snippet = UUIDSnippetWithRelations.objects.create(text="Hello")

--- a/wagtail/test/testapp/forms.py
+++ b/wagtail/test/testapp/forms.py
@@ -53,6 +53,10 @@ class FavouriteColourForm(forms.ModelForm):
 class UUIDSnippetWithRelationsAPIForm(WagtailAdminModelForm):
     def clean(self):
         cleaned_data = super().clean()
-        if cleaned_data.get("body") and not cleaned_data.get("feed_image"):
+        if (
+            "feed_image" in self.fields
+            and cleaned_data.get("body")
+            and not cleaned_data.get("feed_image")
+        ):
             self.add_error("feed_image", "This field is required when body is given.")
         return cleaned_data

--- a/wagtail/test/testapp/migrations/0021_remove_non_json_field_streamfields.py
+++ b/wagtail/test/testapp/migrations/0021_remove_non_json_field_streamfields.py
@@ -49,7 +49,15 @@ class Migration(migrations.Migration):
             model_name="customrichblockfieldpage",
             name="body",
             field=wagtail.fields.StreamField(
-                [("rich_text", wagtail.blocks.RichTextBlock(editor="custom"))],
+                [
+                    ("rich_text", wagtail.blocks.RichTextBlock(editor="custom")),
+                    (
+                        "rich_text_limited",
+                        wagtail.blocks.RichTextBlock(
+                            features=["quotation", "embed"]
+                        ),
+                    ),
+                ],
                 use_json_field=True,
             ),
         ),

--- a/wagtail/test/testapp/migrations/0062_uuidsnippetwithrelations_and_more.py
+++ b/wagtail/test/testapp/migrations/0062_uuidsnippetwithrelations_and_more.py
@@ -38,11 +38,34 @@ class Migration(migrations.Migration):
                 (
                     "body",
                     wagtail.fields.StreamField(
-                        [("text", 0), ("image", 1)],
+                        [
+                            ("text", 0),
+                            ("rich_text", 1),
+                            ("image", 2),
+                            ("product", 3),
+                            ("raw_html", 4),
+                            ("books", 5),
+                            ("title_list", 6),
+                            ("image_with_alt", 7),
+                        ],
                         blank=True,
                         block_lookup={
                             0: ("wagtail.blocks.CharBlock", (), {}),
-                            1: ("wagtail.images.blocks.ImageChooserBlock", (), {}),
+                            1: ("wagtail.blocks.RichTextBlock", (), {}),
+                            2: ("wagtail.images.blocks.ImageChooserBlock", (), {}),
+                            3: (
+                                "wagtail.blocks.StructBlock",
+                                [[("name", 0), ("price", 0)]],
+                                {},
+                            ),
+                            4: ("wagtail.blocks.RawHTMLBlock", (), {}),
+                            5: (
+                                "wagtail.blocks.StreamBlock",
+                                [[("title", 0), ("author", 0)]],
+                                {},
+                            ),
+                            6: ("wagtail.blocks.ListBlock", (0,), {}),
+                            7: ("wagtail.images.blocks.ImageBlock", [], {}),
                         },
                     ),
                 ),

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -1919,8 +1919,10 @@ class ExtendedImageChooserBlock(ImageChooserBlock):
 
     def get_api_representation(self, value, context=None):
         image_id = super().get_api_representation(value, context=context)
-        if "request" in context and context["request"].query_params.get(
-            "extended", False
+        if (
+            context
+            and context.get("request")
+            and context["request"].GET.get("extended", False)
         ):
             return {"id": image_id, "title": value.title}
         return image_id

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -2360,6 +2360,8 @@ class DefaultRichBlockFieldPage(Page):
 
     content_panels = Page.content_panels + [FieldPanel("body")]
 
+    api_fields = (APIField("body", writable=True),)
+
 
 class CustomRichTextFieldPage(Page):
     body = RichTextField(editor="custom")
@@ -2374,6 +2376,10 @@ class CustomRichBlockFieldPage(Page):
     body = StreamField(
         [
             ("rich_text", RichTextBlock(editor="custom")),
+            (
+                "rich_text_limited",
+                RichTextBlock(features=["quotation", "embed"]),
+            ),
         ],
     )
 
@@ -2381,6 +2387,8 @@ class CustomRichBlockFieldPage(Page):
         TitleFieldPanel("title", classname="title"),
         FieldPanel("body"),
     ]
+
+    api_fields = (APIField("body", writable=True),)
 
 
 class RichTextFieldWithFeaturesPage(Page):

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -1203,7 +1203,32 @@ class UUIDSnippetWithRelations(index.Indexed, ClusterableModel):
     body = StreamField(
         [
             ("text", CharBlock()),
+            ("rich_text", RichTextBlock()),
             ("image", ImageChooserBlock()),
+            (
+                "product",
+                StructBlock(
+                    [
+                        ("name", CharBlock()),
+                        ("price", CharBlock()),
+                    ]
+                ),
+            ),
+            ("raw_html", RawHTMLBlock()),
+            (
+                "books",
+                StreamBlock(
+                    [
+                        ("title", CharBlock()),
+                        ("author", CharBlock()),
+                    ]
+                ),
+            ),
+            (
+                "title_list",
+                ListBlock(CharBlock()),
+            ),
+            ("image_with_alt", ImageBlock()),
         ],
         blank=True,
     )

--- a/wagtail/users/tests/test_api_tokens_admin.py
+++ b/wagtail/users/tests/test_api_tokens_admin.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.test import SimpleTestCase, TestCase
 from django.urls import reverse
 from django.utils import timezone
+from freezegun import freeze_time
 
 from wagtail.log_actions import registry as log_registry
 from wagtail.models import APIToken
@@ -230,6 +231,7 @@ class TestAPITokenAdmin(TestCase):
         self.assertContains(response, "plain token")
         self.assertNotContains(response, "other token")
 
+    @freeze_time("2024-06-15 12:00:00")
     def test_filter_created_range(self):
         token, _ = APIToken.create_token(user=self.root, name="dated token")
         APIToken.objects.filter(pk=token.pk).update(
@@ -254,6 +256,7 @@ class TestAPITokenAdmin(TestCase):
         )
         self.assertNotContains(response, "dated token")
 
+    @freeze_time("2024-06-15 12:00:00")
     def test_filter_last_used_at_range(self):
         token, _ = APIToken.create_token(user=self.root, name="used token")
         used_at = timezone.now() - timezone.timedelta(days=3)


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
It turns out StreamField write already works 🤷 

### Description

<!-- Please describe the problem you're fixing. -->
Added some tests to verify StreamField behaviour, and added implementation for RichTextBlock support based on #14483.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Claude Code with Sonnet 5 in VSCode was used to write the code, with me reviewing and refining along the way.