### PR TITLE
Fix form submissions listing recipe: remove stale get_csv_filename override, add missing imports

### DIFF
--- a/docs/reference/contrib/forms/customization.md
+++ b/docs/reference/contrib/forms/customization.md
@@ -631,16 +631,12 @@ class CustomSubmissionsListView(SubmissionsListView):
     ordering_csv = (
         "-submit_time",
     )  # order csv export by newest first, normally oldest first
-
-    # override the method to generate csv filename
-    def get_csv_filename(self):
-        """Returns the filename for CSV file with page slug at start"""
-        filename = super().get_csv_filename()
-        return self.form_page.slug + "-" + filename
 ```
 
 ```python
 # myapp/models.py
+from modelcluster.fields import ParentalKey
+from wagtail.fields import RichTextField
 from wagtail.contrib.forms.models import AbstractEmailForm, AbstractFormField
 
 

--- a/wagtail/test/testapp/views.py
+++ b/wagtail/test/testapp/views.py
@@ -62,11 +62,6 @@ class CustomSubmissionsListView(SubmissionsListView):
     default_ordering = ("submit_time",)
     ordering_csv = ("-submit_time",)
 
-    def get_csv_filename(self):
-        """Returns the filename for CSV file with page title at start"""
-        filename = super().get_csv_filename()
-        return self.form_page.slug + "-" + filename
-
 
 class TestIndexView(IndexView):
     model = ModelWithStringTypePrimaryKey


### PR DESCRIPTION
AI-generated to follow-up to review of #14368. Two small correctness fixes to the "Customise form submissions listing in Wagtail Admin" recipe in `docs/reference/contrib/forms/customization.md`.

### Description

**1. Remove the stale `get_csv_filename` override (docs + testapp)**

The recipe's `CustomSubmissionsListView` overrides `get_csv_filename`, but `SubmissionsListView` / `SpreadsheetExportMixin` have no such method. It was renamed to `get_filename()` in 1d107abc7d, and the export path calls `get_filename()` (`wagtail/admin/views/mixins.py`), not `get_csv_filename`. As written, the override is dead code that would raise `AttributeError` if it were ever invoked. The stated behavior is also redundant, because the base `get_filename()` already prepends `form_page.slug` (`wagtail/contrib/forms/views.py`). I removed the override from the docs example and from the test fixture it was copied into (`wagtail/test/testapp/views.py`).

**2. Add missing imports to the docs example**

The `models.py` block used `ParentalKey` without importing it, unlike every other example in this file. I added `from modelcluster.fields import ParentalKey`. I also added `from wagtail.fields import RichTextField` since the same block references `RichTextField` — feel free to drop that second import if you'd rather keep this strictly to `ParentalKey`.

I confirmed the affected code blocks still compile and pass `ruff format`/`ruff check`, and the `wagtail.contrib.forms` test suite (130 tests) is green.

### AI usage

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.
