### PR TITLE
Fix documentation and help text for wagtail_update_image_renditions command

### DIFF
--- a/docs/advanced_topics/images/renditions.md
+++ b/docs/advanced_topics/images/renditions.md
@@ -71,7 +71,7 @@ By default, Wagtail will try to use the cache called "renditions". If no such ca
 You can also directly use the image management command from the console to regenerate the renditions:
 
 ```sh
-./manage.py wagtail_update_image_renditions --purge
+./manage.py wagtail_update_image_renditions
 ```
 
 You can read more about this command from [](wagtail_update_image_renditions)

--- a/docs/reference/management_commands.md
+++ b/docs/reference/management_commands.md
@@ -168,9 +168,9 @@ Displays a summary of the contents of the references index. This shows the numbe
 ```
 
 This command provides the ability to regenerate image renditions.
-This is useful if you have deployed to a server where the image renditions have not yet been generated or you have changed the underlying image rendition behavior and need to ensure all renditions are created again.
+This is useful if you have changed the underlying image rendition behavior and need to ensure all existing renditions are created again.
 
-This does not remove unused rendition images, this can be done by clearing the folder using `rm -rf` or similar, once this is done you can then use the management command to generate the renditions.
+The command only operates on existing renditions; it will not create renditions that do not already exist. Deleting a rendition also removes its file from storage.
 
 Options:
 

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -512,7 +512,7 @@ Note that this won't affect any previously generated images so you may want to d
 You can also directly use the image management command from the console for regenerating the renditions:
 
 ```sh
-./manage.py wagtail_update_image_renditions --purge
+./manage.py wagtail_update_image_renditions
 ```
 
 You can read more about this command from [](wagtail_update_image_renditions)

--- a/wagtail/images/management/commands/wagtail_update_image_renditions.py
+++ b/wagtail/images/management/commands/wagtail_update_image_renditions.py
@@ -20,9 +20,9 @@ def progress_bar(current, total, bar_length=50):
 
 
 class Command(BaseCommand):
-    """Command to create missing image renditions with the option to remove (purge) any existing ones."""
+    """Command to delete and regenerate existing image renditions, with the option to purge them without regenerating."""
 
-    help = "This command will generate all image renditions, with an option to purge existing renditions first."
+    help = "This command will delete all image renditions and regenerate them by default; use --purge-only to delete them without regenerating."
 
     def add_arguments(self, parser):
         parser.add_argument(


### PR DESCRIPTION
Fixes #14493

### Description

The documentation for the `wagtail_update_image_renditions` management command was inaccurate:

- It claimed the command could generate renditions that had not yet been created, but the command only iterates over existing renditions and exits early with "No image renditions found." when there are none.
- It claimed the command does not remove unused rendition images, but `rendition.delete()` triggers the `post_delete_file_cleanup` signal handler (`wagtail/images/signal_handlers.py`), which deletes the file from storage.

This PR corrects:

- The docs section in `docs/reference/management_commands.md`.
- The command's docstring and help text in `wagtail_update_image_renditions.py`.
- The non-existent `--purge` flag used in `docs/topics/images.md` and `docs/advanced_topics/images/renditions.md`. The actual argument is `--purge-only`; since both pages describe regenerating renditions, the default mode (no flag) is the correct invocation.

Areas to review:
- The rewording of the docs section and the command's docstring/help text, to make sure the behaviour is described accurately.

### AI usage

The changes were drafted with the assistance of AI. I reviewed every claim against the source (`wagtail/images/management/commands/wagtail_update_image_renditions.py`, `wagtail/images/signal_handlers.py`) and verified the documented flag names, and I take final accountability for the result, as required by Wagtail's guidelines on use of generative AI.
