### PR TITLE
Use Ubuntu 26.04 ARM runner

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ jobs:
       security-events: write # to upload SARIF results (github/codeql-action/analyze)
 
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04-arm
     timeout-minutes: 15
 
     strategy:

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -24,7 +24,7 @@ jobs:
     # Don't run scheduled workflows on forks
     if: ${{ github.repository == 'wagtail/wagtail' }}
     name: Latest dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04-arm
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ permissions:
 
 jobs:
   test-sqlite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04-arm
     timeout-minutes: 60
     strategy:
       matrix:
@@ -93,7 +93,7 @@ jobs:
           include-hidden-files: true
 
   test-postgres:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04-arm
     timeout-minutes: 60
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -141,6 +141,8 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
+      - name: Install libpq-dev
+        run: sudo apt-get install -y libpq-dev
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install dependencies
@@ -189,7 +191,7 @@ jobs:
           python manage.py check --fail-level WARNING
 
   test-mysql:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04-arm
     timeout-minutes: 60
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -261,7 +263,7 @@ jobs:
           include-hidden-files: true
 
   test-sqlite-elasticsearch8:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04-arm
     timeout-minutes: 60
     strategy:
       matrix:
@@ -316,7 +318,7 @@ jobs:
           include-hidden-files: true
 
   test-postgres-elasticsearch7:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04-arm
     timeout-minutes: 60
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -355,6 +357,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python }}
+      - name: Install libpq-dev
+        run: sudo apt-get install -y libpq-dev
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install dependencies
@@ -384,7 +388,7 @@ jobs:
           include-hidden-files: true
 
   test-sqlite-opensearch2:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04-arm
     timeout-minutes: 60
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -443,7 +447,7 @@ jobs:
       - test-sqlite-elasticsearch8
       - test-postgres-elasticsearch7
       - test-sqlite-opensearch2
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04-arm
     timeout-minutes: 10
     steps:
       - name: Check out the repo

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   zizmor:
     name: Run zizmor 🌈
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04-arm
     permissions:
       security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
       contents: read # Only needed for private repos. Needed to clone the repo.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -50,6 +50,7 @@ Changelog
  * Maintenance: Add support for latest Azure SDK for frontend cache invalidation (Sage Abdullah)
  * Maintenance: Update guide.wagtail.org links to new versioning scheme (Raghad Dahi)
  * Maintenance: Format Python code in documentation using ruff (Thibaud Colas)
+ * Maintenance: Use Ubuntu 26.04 ARM runner for GitHub Actions workflows (Storm Heg)
 
 
 7.4.3 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -83,6 +83,7 @@ For more details, refer to the [](permissions_reference) reference documentation
  * Add support for latest Azure SDK for frontend cache invalidation (Sage Abdullah, Tomasz Knapik)
  * Update guide.wagtail.org links to new versioning scheme (Raghad Dahi)
  * Format Python code in documentation using ruff (Thibaud Colas)
+ * Use Ubuntu 26.04 ARM runner for GitHub Actions workflows (Storm Heg)
 
 ## Upgrade considerations - removal of deprecated features from Wagtail 6.4 - 7.3
 


### PR DESCRIPTION
### Description

Mentioned on core team channel as something we should try. ARM runners are more energy efficient (`Arm-based servers in the cloud have been shown to use 30-40% less power output for some of the most widely deployed workloads`)[^1]

There isn't a `ubuntu-latest-arm` tag or similar, so have to pin this to a specific Ubuntu version. 26.04 is currently still in preview but seems to be stable enough.

I've switched over a few projects now and I noticed test suite running faster. Maybe this benefit will compound for Wagtail.

### AI usage

None

[^1]: https://github.blog/news-insights/product-news/arm64-on-github-actions-powering-faster-more-efficient-build-systems/#sustainability-on-github-actions