### PR TITLE
Autocreate redirects only for live pages when WAGTAILREDIRECTS_AUTO_CREATE = True

### DIFF
--- a/docs/reference/contrib/redirects.md
+++ b/docs/reference/contrib/redirects.md
@@ -52,11 +52,20 @@ Overrides to the following `Page` methods are respected when generating redirect
 -   {meth}`~wagtail.models.AbstractPage.get_url_parts()`
 -   {meth}`~wagtail.models.AbstractPage.get_route_paths()`
 
-If you find the feature is not a good fit for your project, you can disable it by adding the following to your project settings:
+The `WAGTAILREDIRECTS_AUTO_CREATE` setting controls when automatic redirects are created:
 
-```python
-WAGTAILREDIRECTS_AUTO_CREATE = False
-```
+-   `True` (the default): redirects are only created for published (live) pages.
+-   `False`: automatic redirects are never created. If you find the feature is not a good fit for your project, you can disable it by adding the following to your project settings:
+
+    ```python
+    WAGTAILREDIRECTS_AUTO_CREATE = False
+    ```
+
+-   `"always"`: redirects are created whenever a page (or a descendant of a page) is moved or its slug is changed, regardless of whether the page is live.
+
+    ```python
+    WAGTAILREDIRECTS_AUTO_CREATE = "always"
+    ```
 
 ## Management commands
 

--- a/wagtail/contrib/redirects/signal_handlers.py
+++ b/wagtail/contrib/redirects/signal_handlers.py
@@ -45,13 +45,23 @@ class BatchRedirectCreator(BatchCreator):
         batch.purge()
 
 
+def should_autocreate_redirects(page: Page) -> bool:
+    match getattr(settings, "WAGTAILREDIRECTS_AUTO_CREATE", True):
+        case "always":
+            return True
+        case False:
+            return False
+        case _:
+            return page.live
+
+
 def autocreate_redirects_on_slug_change(
     instance_before: Page, instance: Page, **kwargs
 ):
     # NB: `page_slug_changed` provides specific page instances,
     # so we do not need to 'upcast' them for create_redirects here
 
-    if not getattr(settings, "WAGTAILREDIRECTS_AUTO_CREATE", True):
+    if not should_autocreate_redirects(instance_before):
         return None
 
     # Determine sites to create redirects for
@@ -71,7 +81,7 @@ def autocreate_redirects_on_page_move(
     url_path_before: str,
     **kwargs,
 ) -> None:
-    if not getattr(settings, "WAGTAILREDIRECTS_AUTO_CREATE", True):
+    if not should_autocreate_redirects(instance):
         return None
 
     if url_path_after == url_path_before:

--- a/wagtail/contrib/redirects/tests/test_signal_handlers.py
+++ b/wagtail/contrib/redirects/tests/test_signal_handlers.py
@@ -40,6 +40,20 @@ class TestAutocreateRedirects(PageFixturesMixin, WagtailTestUtils, TestCase):
         with self.captureOnCommitCallbacks(execute=True):
             page.save(log_action="wagtail.publish", user=self.user, clean=False)
 
+    def new_page(self, *, live=False):
+        page = EventIndex(title="Test Page", slug="test-page", live=live)
+        self.home_page.add_child(instance=page)
+        return page
+
+    def page_path(self, page):
+        return page.get_url(get_dummy_request()).rstrip("/")
+
+    def automatic_redirect_exists(self, old_path, page=None):
+        qs = Redirect.objects.filter(old_path=old_path, automatically_created=True)
+        if page is not None:
+            qs = qs.filter(redirect_page=page)
+        return qs.exists()
+
     def test_golden_path(self):
         with self.captureOnCommitCallbacks(execute=True):
             # the page we'll be triggering the change for here is...
@@ -239,3 +253,50 @@ class TestAutocreateRedirects(PageFixturesMixin, WagtailTestUtils, TestCase):
             self.trigger_page_slug_changed_signal(self.event_index)
         self.assertFalse(Redirect.objects.exists())
         self.assertEqual(len(PURGED_URLS), 0)
+
+    def test_no_redirects_created_for_draft_page_slug_change(self):
+        draft = self.new_page(live=False)
+        old_url_path = self.page_path(draft)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self.trigger_page_slug_changed_signal(draft)
+
+        self.assertFalse(self.automatic_redirect_exists(old_url_path))
+
+    def test_redirects_created_for_live_page_move(self):
+        event_index_path = self.page_path(self.event_index)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self.event_index.move(self.other_page, pos="last-child")
+
+        exists = self.automatic_redirect_exists(event_index_path, page=self.event_index)
+        self.assertTrue(exists)
+
+    def test_no_redirects_created_for_draft_page_move(self):
+        draft = self.new_page(live=False)
+        draft_url_path = self.page_path(draft)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            draft.move(self.other_page, pos="last-child")
+
+        self.assertFalse(self.automatic_redirect_exists(draft_url_path))
+
+    @override_settings(WAGTAILREDIRECTS_AUTO_CREATE="always")
+    def test_redirects_created_for_draft_page_slug_change_when_always(self):
+        draft = self.new_page(live=False)
+        old_url_path = self.page_path(draft)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self.trigger_page_slug_changed_signal(draft)
+
+        self.assertTrue(self.automatic_redirect_exists(old_url_path))
+
+    @override_settings(WAGTAILREDIRECTS_AUTO_CREATE="always")
+    def test_redirects_created_for_draft_page_move_when_always(self):
+        draft = self.new_page(live=False)
+        draft_url_path = self.page_path(draft)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            draft.move(self.other_page, pos="last-child")
+
+        self.assertTrue(self.automatic_redirect_exists(draft_url_path))


### PR DESCRIPTION



<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #12582

### Description

<!-- Please describe the problem you're fixing. -->
Following the discussion in the issue, this PR reverts the behaviour of `WAGTAILREDIRECTS_AUTO_CREATE = True` to only autocreate redirects for live pages (similar to Wagtail < 6.0).

Introduce the `always` value to retain the behavior of Wagtail 6.0–8.0 where redirects were also created for draft pages.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
DeepSeek Flash v4 0731 was used to write the initial code, but it has since been rewritten by me, as the initial code was rather sloppy and touched more areas than necessary.