### PR TITLE
Fix documentation and help text for wagtail_update_image_renditions command

### DIFF
--- a/docs/advanced_topics/images/renditions.md
+++ b/docs/advanced_topics/images/renditions.md
@@ -71,7 +71,7 @@ By default, Wagtail will try to use the cache called "renditions". If no such ca
 You can also directly use the image management command from the console to regenerate the renditions:
 
 ```sh
-./manage.py wagtail_update_image_renditions --purge
+./manage.py wagtail_update_image_renditions
 ```
 
 You can read more about this command from [](wagtail_update_image_renditions)

--- a/docs/reference/management_commands.md
+++ b/docs/reference/management_commands.md
@@ -168,9 +168,9 @@ Displays a summary of the contents of the references index. This shows the numbe
 ```
 
 This command provides the ability to regenerate image renditions.
-This is useful if you have deployed to a server where the image renditions have not yet been generated or you have changed the underlying image rendition behavior and need to ensure all renditions are created again.
+This is useful if you have changed the underlying image rendition behavior and need to ensure all existing renditions are created again.
 
-This does not remove unused rendition images, this can be done by clearing the folder using `rm -rf` or similar, once this is done you can then use the management command to generate the renditions.
+The command only operates on existing renditions; it will not create renditions that do not already exist. Deleting a rendition also removes its file from storage.
 
 Options:
 

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -512,7 +512,7 @@ Note that this won't affect any previously generated images so you may want to d
 You can also directly use the image management command from the console for regenerating the renditions:
 
 ```sh
-./manage.py wagtail_update_image_renditions --purge
+./manage.py wagtail_update_image_renditions
 ```
 
 You can read more about this command from [](wagtail_update_image_renditions)

--- a/wagtail/images/management/commands/wagtail_update_image_renditions.py
+++ b/wagtail/images/management/commands/wagtail_update_image_renditions.py
@@ -20,9 +20,9 @@ def progress_bar(current, total, bar_length=50):
 
 
 class Command(BaseCommand):
-    """Command to create missing image renditions with the option to remove (purge) any existing ones."""
+    """Command to delete and regenerate existing image renditions, with the option to purge them without regenerating."""
 
-    help = "This command will generate all image renditions, with an option to purge existing renditions first."
+    help = "This command will delete all image renditions and regenerate them by default; use --purge-only to delete them without regenerating."
 
     def add_arguments(self, parser):
         parser.add_argument(


### PR DESCRIPTION
Fixes #14493

### Description

The `wagtail_update_image_renditions` command's documentation and help text were inaccurate about how it handles image renditions:

- The example invocations in `docs/topics/images.md` and `docs/advanced_topics/images/renditions.md` included `--purge`, implying a purge is expected before regenerating. The command regenerates existing renditions by default, so the flag is dropped from the examples.
- `docs/reference/management_commands.md` implied the command also generates renditions that were never created and suggested manual `rm -rf` cleanup of the files. It now states that the command only operates on existing renditions, does not create missing ones, and that deleting a rendition also removes its file from storage.
- The command's own `--help` text and docstring described a `--purge` option and the wrong default behaviour; the actual option is `--purge-only`, and the default (delete + regenerate existing renditions) is now described correctly.

Verified against `wagtail/images/management/commands/wagtail_update_image_renditions.py` and the rendition deletion signal handlers.

This is a resubmission of #14505, which was closed because the AI disclosure did not meet Wagtail's generative-AI guidelines. I have reviewed and tested the changes, and take final accountability for them.

### AI usage

OpenCode (a local AI coding assistant) was used to draft this change and this description. Per Wagtail's [guidelines on use of generative AI](https://docs.wagtail.org/en/latest/contributing/general_guidelines.html#use-of-generative-ai), I have reviewed and tested the code, understand it, and take final accountability for it.