### PR TITLE
Hide chooser Edit link when user lacks edit permission

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Changelog
  * Fix: Prevent stale content types from breaking audit log message formatting (Thibaud Colas)
  * Fix: Ensure form field clean_name is consistently set on form pages if autosave runs prematurely (Joey Jurjens)
  * Fix: Enforce 'choose' permission on image chooser select-format view (Matt Westcott)
+ * Fix: Hide the "Edit" link on chooser widgets when the user does not have edit permission for the selected item (Saksham Chawla)
  * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
  * Docs: Fix panel classname and deprecated usage of `format_html` in `construct_homepage_panels` example (Andreas Nüßlein)
  * Docs: Add docs for `request.in_preview_panel` to explain its use (Raghad Dahi)

--- a/wagtail/admin/panels/field_panel.py
+++ b/wagtail/admin/panels/field_panel.py
@@ -306,6 +306,13 @@ class FieldPanel(Panel):
             if self.help_text:
                 widget_described_by_ids.append(help_text_id)
 
+            widget = self.bound_field.field.widget
+            if self.request and hasattr(widget, "user"):
+                # Pass the current user to the widget so that permission-aware widgets
+                # (e.g. chooser widgets) can withhold the edit link when the user does
+                # not have edit permission for the selected item.
+                widget.user = self.request.user
+
             if self.bound_field.errors:
                 widget = self.bound_field.field.widget
                 if hasattr(widget, "render_with_errors"):

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Mapping
 from datetime import date, datetime, timezone
 from functools import wraps
@@ -45,6 +46,7 @@ from wagtail.contrib.forms.models import FormSubmission
 from wagtail.contrib.forms.panels import FormSubmissionsPanel
 from wagtail.coreutils import get_dummy_request
 from wagtail.images import get_image_model
+from wagtail.images.tests.utils import get_test_image_file
 from wagtail.models import Comment, CommentReply, Site
 from wagtail.test.testapp.forms import ValidatedPageForm
 from wagtail.test.testapp.models import (
@@ -1016,6 +1018,50 @@ class TestFieldPanel(TestCase):
                 image,
             )
 
+    def test_request_user_is_passed_to_widget(self):
+        form = self._get_form(fields=["feed_image"])
+        bound_panel = self._get_bound_panel(FieldPanel("feed_image"), form)
+
+        bound_panel.render_html()
+
+        widget = bound_panel.bound_field.field.widget
+        self.assertIs(widget.user, self.request.user)
+
+    def test_chooser_edit_link_hidden_for_user_without_permission(self):
+        image = get_image_model().objects.create(
+            title="Test image", file=get_test_image_file()
+        )
+        self.event.feed_image = image
+
+        form = self._get_form(fields=["feed_image"])
+        bound_panel = self._get_bound_panel(FieldPanel("feed_image"), form)
+
+        result = bound_panel.render_html()
+
+        edit_link = re.search(r"<a data-chooser-edit-link[^>]*>", result)
+        self.assertIsNotNone(edit_link)
+        self.assertIn("hidden", edit_link.group(0))
+
+    def test_chooser_edit_link_shown_for_user_with_permission(self):
+        image = get_image_model().objects.create(
+            title="Test image", file=get_test_image_file()
+        )
+        self.event.feed_image = image
+        self.request.user = get_user_model().objects.create_superuser(
+            username="superuser_field_panel",
+            email="superuser_field_panel@example.com",
+            password="password",
+        )
+
+        form = self._get_form(fields=["feed_image"])
+        bound_panel = self._get_bound_panel(FieldPanel("feed_image"), form)
+
+        result = bound_panel.render_html()
+
+        edit_link = re.search(r"<a data-chooser-edit-link[^>]*>", result)
+        self.assertIsNotNone(edit_link)
+        self.assertNotIn("hidden", edit_link.group(0))
+
     def test_required_fields(self):
         result = self.end_date_panel.get_form_options()["fields"]
         self.assertEqual(result, ["date_to"])
@@ -1257,6 +1303,19 @@ class TestPageChooserPanel(PageFixturesMixin, TestCase):
             '<div class="chooser__title" data-chooser-title id="id_page-title">Christmas</div>',
             result,
         )
+        # the request user is anonymous, so the edit link is hidden
+        self.assertIn(
+            '<a data-chooser-edit-link href="" aria-describedby="id_page-title" hidden',
+            result,
+        )
+
+    def test_render_html_with_edit_permission(self):
+        self.request.user = get_user_model().objects.create_superuser(
+            username="superuser_page_chooser",
+            email="superuser_page_chooser@example.com",
+            password="password",
+        )
+        result = self.page_chooser_panel.render_html()
         self.assertIn(
             '<a data-chooser-edit-link href="/admin/pages/%d/edit/" aria-describedby="id_page-title"'
             % self.christmas_page.id,

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -40,7 +40,8 @@ class BaseChooser(widgets.Input):
     input_type = "hidden"
     is_hidden = False
 
-    def __init__(self, **kwargs):
+    def __init__(self, user=None, **kwargs):
+        self.user = user
         # allow attributes to be overridden by kwargs
         for var in [
             "choose_one_text",
@@ -95,7 +96,7 @@ class BaseChooser(widgets.Input):
             "value": bool(
                 value_data
             ),  # only used by chooser.html to identify blank values
-            "edit_url": value_data.get("edit_url", ""),
+            "edit_url": value_data.get("edit_url") or "",
             "display_title": value_data.get(self.display_title_key, ""),
             "chooser_url": self.get_chooser_modal_url(),
             "icon": self.icon,
@@ -137,7 +138,7 @@ class BaseChooser(widgets.Input):
         """
         return {
             "id": instance.pk,
-            "edit_url": AdminURLFinder().get_edit_url(instance),
+            "edit_url": AdminURLFinder(user=self.user).get_edit_url(instance),
             self.display_title_key: self.get_display_title(instance),
         }
 

--- a/wagtail/snippets/tests/test_chooser_widget.py
+++ b/wagtail/snippets/tests/test_chooser_widget.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.urls import reverse
 
 from wagtail.snippets.widgets import (
     AdminSnippetChooser,
@@ -9,6 +10,9 @@ from wagtail.test.utils import WagtailTestUtils
 
 
 class TestAdminSnippetChooserWidget(WagtailTestUtils, TestCase):
+    def setUp(self):
+        self.advert = Advert.objects.create(text="test advert")
+
     def test_adapt(self):
         widget = AdminSnippetChooser(Advert)
 
@@ -20,3 +24,22 @@ class TestAdminSnippetChooserWidget(WagtailTestUtils, TestCase):
         )
         self.assertIn("Choose advert", js_args[0])
         self.assertEqual(js_args[1], "__ID__")
+
+    def test_edit_url_hidden_for_user_without_edit_permission(self):
+        user = self.create_user("editor-without-advert-permissions")
+        widget = AdminSnippetChooser(Advert, user=user)
+
+        value_data = widget.get_value_data_from_instance(self.advert)
+
+        self.assertIsNone(value_data["edit_url"])
+
+    def test_edit_url_shown_for_user_with_edit_permission(self):
+        user = self.create_user("editor", permissions=["change_advert"])
+        widget = AdminSnippetChooser(Advert, user=user)
+
+        value_data = widget.get_value_data_from_instance(self.advert)
+
+        self.assertEqual(
+            value_data["edit_url"],
+            reverse("wagtailsnippets_tests_advert:edit", args=[self.advert.pk]),
+        )


### PR DESCRIPTION
Fixes #12801

### Description

Chooser widgets (e.g. snippet, image, document and page choosers) rendered an "Edit" link on the initial form render even when the current user does not have edit permission for the selected item. The link was only correctly hidden after an item had been re-chosen through the chooser workflow.

The root cause is an oversight in the two code paths that compute the edit URL:

- The chooser workflow (`ChosenView`) already passes the request user to `AdminURLFinder`, which filters out URLs the user cannot access.
- The widget's initial render path (`BaseChooser.get_value_data_from_instance`) called `AdminURLFinder()` *without* a user, so the permission check in `AdminURLFinder.get_edit_url()` was skipped and the edit URL was always returned.

This PR makes the widget's render path permission-aware:

- `BaseChooser` now accepts a `user` kwarg and passes it to `AdminURLFinder`, so the edit URL is only included in the value data when the user has `change` permission for the item.
- `FieldPanel.BoundField.get_editable_context_data()` passes the request user to the widget before rendering it, since widgets do not otherwise have access to the request.
- `BaseChooser.get_context` normalises a `None` edit URL to an empty string, so the rendered `href` is empty (rather than `"None"`) when the link is hidden.

For models without a registered permission policy, `AdminURLFinder` still returns the edit URL unconditionally, so behaviour is unchanged in those cases.

### Testing

Added unit tests covering:

- `wagtail.snippets.tests.test_chooser_widget` — the edit URL is hidden for a user without `change_advert` permission and shown for a user with it.
- `wagtail.admin.tests.test_edit_handlers` — `FieldPanel` passes the request user to the widget, and the rendered chooser edit link is hidden for an anonymous user and shown for a superuser (for both image and page choosers).

### AI usage

This pull request includes code written with the assistance of AI. I have reviewed and tested the code, understand it, and take final accountability for it.