### PR TITLE
Expand collapsed panels when navigating via contentpath links

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Changelog
  * Fix: Prevent stale content types from breaking audit log message formatting (Thibaud Colas)
  * Fix: Ensure form field clean_name is consistently set on form pages if autosave runs prematurely (Joey Jurjens)
  * Fix: Enforce 'choose' permission on image chooser select-format view (Matt Westcott)
+ * Fix: Expand collapsed sections when navigating to a field via a contentpath link (Saksham Chawla)
  * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
  * Docs: Fix panel classname and deprecated usage of `format_html` in `construct_homepage_panels` example (Andreas Nüßlein)
  * Docs: Add docs for `request.in_preview_panel` to explain its use (Raghad Dahi)

--- a/client/src/includes/panels.test.js
+++ b/client/src/includes/panels.test.js
@@ -1,0 +1,114 @@
+import { initAnchoredPanels, initCollapsiblePanels } from './panels';
+
+describe('initAnchoredPanels', () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    window.location.hash = '';
+  });
+
+  it('expands collapsed ancestor panels before scrolling to the contentpath target', () => {
+    document.body.innerHTML = /* html */ `
+      <section class="w-panel collapsed" data-panel id="appearance-section">
+        <div class="w-panel__header">
+          <button class="w-panel__toggle" type="button" data-panel-toggle aria-controls="appearance-content" aria-expanded="true"></button>
+          <h2 class="w-panel__heading" data-panel-heading>Appearance</h2>
+        </div>
+        <div id="appearance-content" class="w-panel__content">
+          <div data-contentpath="logo"><input id="logo" type="text"></div>
+        </div>
+      </section>
+    `;
+    window.location.hash = '#:w:contentpath=logo';
+
+    initCollapsiblePanels();
+    expect(
+      document
+        .querySelector('[data-panel-toggle]')
+        .getAttribute('aria-expanded'),
+    ).toEqual('false');
+
+    initAnchoredPanels();
+
+    expect(
+      document
+        .querySelector('[data-panel-toggle]')
+        .getAttribute('aria-expanded'),
+    ).toEqual('true');
+    expect(
+      document.getElementById('appearance-content').hasAttribute('hidden'),
+    ).toBe(false);
+  });
+
+  it('leaves panels that are not collapsed alone', () => {
+    document.body.innerHTML = /* html */ `
+      <section class="w-panel" data-panel id="appearance-section">
+        <div class="w-panel__header">
+          <button class="w-panel__toggle" type="button" data-panel-toggle aria-controls="appearance-content" aria-expanded="true"></button>
+        </div>
+        <div id="appearance-content" class="w-panel__content">
+          <div data-contentpath="logo"><input id="logo" type="text"></div>
+        </div>
+      </section>
+    `;
+    window.location.hash = '#:w:contentpath=logo';
+
+    initCollapsiblePanels();
+    initAnchoredPanels();
+
+    expect(
+      document
+        .querySelector('[data-panel-toggle]')
+        .getAttribute('aria-expanded'),
+    ).toEqual('true');
+    expect(
+      document.getElementById('appearance-content').hasAttribute('hidden'),
+    ).toBe(false);
+  });
+
+  it('expands multiple nested collapsed panels', () => {
+    document.body.innerHTML = /* html */ `
+      <section class="w-panel collapsed" data-panel id="outer-section">
+        <div class="w-panel__header">
+          <button class="w-panel__toggle" type="button" data-panel-toggle aria-controls="outer-content" aria-expanded="true"></button>
+        </div>
+        <div id="outer-content" class="w-panel__content">
+          <section class="w-panel collapsed" data-panel id="inner-section">
+            <div class="w-panel__header">
+              <button class="w-panel__toggle" type="button" data-panel-toggle aria-controls="inner-content" aria-expanded="true"></button>
+            </div>
+            <div id="inner-content" class="w-panel__content">
+              <div data-contentpath="logo"><input id="logo" type="text"></div>
+            </div>
+          </section>
+        </div>
+      </section>
+    `;
+    window.location.hash = '#:w:contentpath=logo';
+
+    initCollapsiblePanels();
+    initAnchoredPanels();
+
+    const toggles = document.querySelectorAll('[data-panel-toggle]');
+    expect(toggles.length).toEqual(2);
+    toggles.forEach((toggle) => {
+      expect(toggle.getAttribute('aria-expanded')).toEqual('true');
+    });
+    expect(
+      document.getElementById('outer-content').hasAttribute('hidden'),
+    ).toBe(false);
+    expect(
+      document.getElementById('inner-content').hasAttribute('hidden'),
+    ).toBe(false);
+  });
+
+  it('does not error when there is no contentpath target', () => {
+    document.body.innerHTML = '';
+    window.location.hash = '#:w:contentpath=missing';
+
+    expect(() => initAnchoredPanels()).not.toThrow();
+  });
+});

--- a/client/src/includes/panels.ts
+++ b/client/src/includes/panels.ts
@@ -119,6 +119,21 @@ export function initAnchoredPanels(
     : getElementByContentPath();
 
   if (target) {
+    // Expand any collapsed panels between the target and the top of the page,
+    // otherwise scrollIntoView won't reveal a target inside collapsed content.
+    let panel: HTMLElement | null = target;
+    while (panel) {
+      if (panel.matches('[data-panel]')) {
+        const toggle = panel.querySelector<HTMLButtonElement>(
+          '[data-panel-toggle]',
+        );
+        if (toggle && toggle.getAttribute('aria-expanded') !== 'true') {
+          toggleCollapsiblePanel(toggle, true);
+        }
+      }
+      panel = panel.parentElement;
+    }
+
     setTimeout(() => {
       target.scrollIntoView({ behavior: 'smooth' });
     }, 100);


### PR DESCRIPTION
Fixes #14428

### Description

When a contentpath link (e.g. the "Usage" view's links of the form `{edit_url}?#:w:contentpath=logo`) points at a field inside a collapsed panel, `initAnchoredPanels()` scrolled to the target without expanding its collapsed ancestors, so the field remained hidden and the page appeared to scroll nowhere useful.

This updates `initAnchoredPanels()` in `client/src/includes/panels.ts` to walk up from the target through every `[data-panel]` ancestor and expand any that are collapsed (via the existing `toggleCollapsiblePanel()`) before scrolling, so the target field is revealed. Panels that are already expanded are left untouched.

Added jest tests covering a single collapsed panel, an already-expanded panel, multiple nested collapsed panels, and the no-target case.

### AI usage

This pull request includes code written with the assistance of AI. I have reviewed and tested the code, understand it, and take final accountability for it.