### PR TITLE
Allow contentpath links to resolve to fields inside InlinePanels

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Changelog
  * Fix: Prevent stale content types from breaking audit log message formatting (Thibaud Colas)
  * Fix: Ensure form field clean_name is consistently set on form pages if autosave runs prematurely (Joey Jurjens)
  * Fix: Enforce 'choose' permission on image chooser select-format view (Matt Westcott)
+ * Fix: Allow contentpath links to resolve to fields inside InlinePanels (Saksham Chawla)
  * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
  * Docs: Fix panel classname and deprecated usage of `format_html` in `construct_homepage_panels` example (Andreas Nüßlein)
  * Docs: Add docs for `request.in_preview_panel` to explain its use (Raghad Dahi)

--- a/client/src/utils/contentPath.test.js
+++ b/client/src/utils/contentPath.test.js
@@ -89,3 +89,35 @@ describe('getElementByContentPath', () => {
     expect(getElementByContentPath()).toBeNull();
   });
 });
+
+describe('getElementByContentPath with inline panel content', () => {
+  afterEach(() => {
+    window.location.hash = '';
+  });
+
+  it('should resolve a content path into an InlinePanel child field', () => {
+    document.body.innerHTML = /* html */ `
+      <section data-panel data-contentpath="speakers">
+        <div data-inline-panel-child data-contentpath-disabled data-contentpath="42">
+          <div class="w-field" data-field data-contentpath="image"></div>
+        </div>
+      </section>
+    `;
+
+    const element = getElementByContentPath('speakers.42.image');
+    expect(element).toBeTruthy();
+    expect(element.classList.contains('w-field')).toBe(true);
+  });
+
+  it('should not match InlinePanel children without a stored id', () => {
+    document.body.innerHTML = /* html */ `
+      <section data-panel data-contentpath="speakers">
+        <div data-inline-panel-child data-contentpath-disabled>
+          <div class="w-field" data-field data-contentpath="image"></div>
+        </div>
+      </section>
+    `;
+
+    expect(getElementByContentPath('speakers.42.image')).toBeNull();
+  });
+});

--- a/wagtail/admin/panels/inline_panel.py
+++ b/wagtail/admin/panels/inline_panel.py
@@ -183,6 +183,15 @@ class InlinePanel(Panel):
                 )
             ]
 
+        @property
+        def attrs(self):
+            # The content path to a field nested in this panel's children is
+            # built from the relation name (e.g. ``speakers``), so expose it on
+            # the panel element for the usage view's contentpath links to resolve.
+            attrs = self.panel.attrs.copy()
+            attrs["data-contentpath"] = self.panel.relation_name
+            return attrs
+
         telepath_adapter_name = "wagtail.panels.InlinePanel"
 
         def js_opts(self):

--- a/wagtail/admin/templates/wagtailadmin/panels/inline_panel_child.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/inline_panel_child.html
@@ -2,7 +2,7 @@
 
 {% fragment as id %}inline_child_{{ child.form.prefix }}{% endfragment %}
 {% fragment as panel_id %}{{ id }}-panel{% endfragment %}
-<div data-inline-panel-child id="{{ id }}" data-contentpath-disabled{% if child.instance.pk is not None %} data-contentpath="{{ child.instance.pk }}"{% endif %}>
+<div data-inline-panel-child id="{{ id }}" data-contentpath-disabled{% if child.instance.pk is not None %} data-contentpath="{{ child.instance.pk|stringformat:'s' }}"{% endif %}>
     {% fragment as header_controls %}
         {% if can_order %}
             <button type="button" class="button button--icon text-replace white" data-inline-panel-child-move-up title="{% trans 'Move up' %}">{% icon name="arrow-up" %}</button>

--- a/wagtail/admin/templates/wagtailadmin/panels/inline_panel_child.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/inline_panel_child.html
@@ -2,7 +2,7 @@
 
 {% fragment as id %}inline_child_{{ child.form.prefix }}{% endfragment %}
 {% fragment as panel_id %}{{ id }}-panel{% endfragment %}
-<div data-inline-panel-child id="{{ id }}" data-contentpath-disabled>
+<div data-inline-panel-child id="{{ id }}" data-contentpath-disabled{% if child.instance.pk is not None %} data-contentpath="{{ child.instance.pk }}"{% endif %}>
     {% fragment as header_controls %}
         {% if can_order %}
             <button type="button" class="button button--icon text-replace white" data-inline-panel-child-move-up title="{% trans 'Move up' %}">{% icon name="arrow-up" %}</button>

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -1437,6 +1437,33 @@ class TestInlinePanel(PageFixturesMixin, WagtailTestUtils, TestCase):
         self.assertIn("data-inline-panel-child-move-down", result)
         self.assertIn("data-inline-panel-child-drag", result)
 
+    def test_render_has_contentpath_attributes(self):
+        """
+        The usage view links to nested fields using a contentpath such as
+        ``speakers.{pk}.image``. The rendered InlinePanel must include matching
+        data-contentpath attributes on the panel and each child element so those
+        links resolve to the field in the edit page.
+        """
+        speaker_object_list = ObjectList(
+            [InlinePanel("speakers", label="speaker")]
+        ).bind_to_model(EventPage)
+        EventPageForm = speaker_object_list.get_form_class()
+
+        event_page = EventPage.objects.get(slug="christmas")
+        speaker = event_page.speakers.first()
+        self.assertIsNotNone(speaker.pk)
+
+        form = EventPageForm(instance=event_page)
+        panel = speaker_object_list.get_bound_panel(
+            instance=event_page, form=form, request=self.request
+        )
+
+        result = panel.render_html()
+
+        self.assertIn('data-contentpath="speakers"', result)
+        self.assertIn(f'data-contentpath="{speaker.pk}"', result)
+        self.assertIn('data-contentpath="image"', result)
+
     def test_render_with_panel_overrides(self):
         """
         Check that inline panel renders the panels listed in the InlinePanel definition


### PR DESCRIPTION
Fixes #14434

### Description

When a `ClusterableModel` has a child relation rendered through an `InlinePanel`, the usage view links to nested fields using a contentpath such as `speakers.{pk}.image`. Until now the edit page never rendered the matching `data-contentpath` attributes, so clicking those links did nothing: `getElementByContentPath()` couldn't resolve the path to the field.

This makes InlinePanel children addressable:

- `InlinePanel.BoundPanel` now exposes `data-contentpath="{relation_name}"` on the panel element (via `attrs`, which `object_list` and `multi_field_panel_child` already pass through).
- Each `data-inline-panel-child` wrapper now renders `data-contentpath="{pk}"` for saved children, matching the `child_object.pk` segment that `ReferenceIndex._extract_references_from_object()` uses for nested references.

Comments on inline panels remain disabled (`data-contentpath-disabled` is kept) — child models still have no stable id before they're persisted, so this only enables one-shot anchor navigation, not comment anchoring.

### Tests

- `TestInlinePanel.test_render_has_contentpath_attributes` renders an InlinePanel with a saved child and asserts the `data-contentpath` attributes for the panel, the child, and the field are present (verified it fails on `main` before the fix).
- `contentPath.test.js` gains two cases locking in the expected DOM contract: a saved InlinePanel child resolves via `getElementByContentPath()`, and an unsaved child (no pk) does not.
- `test_edit_handlers`, `test_reference_index`, snippets usage and model viewset suites all pass (280+ tests); `ruff` clean; jest clean; prettier clean.

### AI usage

This pull request includes code written with the assistance of AI. I have reviewed and tested the code, understand it, and take final accountability for it.