### PR TITLE
Allow ChooserBlock.bulk_to_python to resolve custom primary keys

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Changelog
  * Fix: Prevent stale content types from breaking audit log message formatting (Thibaud Colas)
  * Fix: Ensure form field clean_name is consistently set on form pages if autosave runs prematurely (Joey Jurjens)
  * Fix: Enforce 'choose' permission on image chooser select-format view (Matt Westcott)
+ * Fix: Allow `ChooserBlock.bulk_to_python()` to resolve records with primary keys that need converting to their native type, such as UUIDs (Saksham Chawla)
  * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
  * Docs: Fix panel classname and deprecated usage of `format_html` in `construct_homepage_panels` example (Andreas Nüßlein)
  * Docs: Add docs for `request.in_preview_panel` to explain its use (Raghad Dahi)

--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -899,6 +899,12 @@ class ChooserBlock(FieldBlock):
             help_text=self._help_text,
         )
 
+    @cached_property
+    def pk_field(self):
+        # the primary key field of the target model, used to convert serialised
+        # primary key values to their native Python type in bulk_to_python
+        return self.model_class._meta.pk
+
     def to_python(self, value):
         # the incoming serialised value should be None or an ID
         if value is None:
@@ -915,11 +921,17 @@ class ChooserBlock(FieldBlock):
         The instances must be returned in the same order as the values and keep None values.
         If the same ID appears multiple times, a distinct object instance is created for each one.
         """
-        objects = self.model_class.objects.in_bulk(values)
+        # serialised primary key values (e.g. a UUID string) need to be converted to the
+        # field's native Python type before looking them up, as in_bulk keys them by that
+        pk_values = [
+            self.pk_field.to_python(value) if value is not None else None
+            for value in values
+        ]
+        objects = self.model_class.objects.in_bulk(pk_values)
         seen_ids = set()
         result = []
 
-        for id in values:
+        for id in pk_values:
             obj = objects.get(id)
             if obj is not None and id in seen_ids:
                 # this object is already in the result list, so we need to make a copy

--- a/wagtail/snippets/tests/test_chooser_block.py
+++ b/wagtail/snippets/tests/test_chooser_block.py
@@ -5,7 +5,11 @@ from wagtail.blocks.field_block import FieldBlockAdapter
 from wagtail.models import Locale
 from wagtail.snippets.blocks import SnippetChooserBlock
 from wagtail.snippets.widgets import AdminSnippetChooser
-from wagtail.test.testapp.models import Advert, AdvertWithCustomPrimaryKey
+from wagtail.test.testapp.models import (
+    Advert,
+    AdvertWithCustomPrimaryKey,
+    AdvertWithCustomUUIDPrimaryKey,
+)
 from wagtail.test.utils import PageFixturesMixin
 
 
@@ -31,6 +35,14 @@ class TestSnippetChooserBlock(PageFixturesMixin, TestCase):
 
         # None should deserialize to None
         self.assertIsNone(block.to_python(None))
+
+    def test_bulk_to_python_with_uuid_primary_key(self):
+        # See: https://github.com/wagtail/wagtail/issues/6509
+        block = SnippetChooserBlock(AdvertWithCustomUUIDPrimaryKey)
+        test_advert = AdvertWithCustomUUIDPrimaryKey.objects.create(text="test_advert")
+
+        result = block.bulk_to_python([str(test_advert.pk)])
+        self.assertEqual(result, [test_advert])
 
     def test_reference_model_by_string(self):
         block = SnippetChooserBlock("tests.Advert")


### PR DESCRIPTION
Fixes #6509

### Description

`ChooserBlock.bulk_to_python()` passed the serialised primary key values straight into `objects.in_bulk()`, then looked each one up with `objects.get(id)`. For models whose primary key field converts between its database/serialised form and its Python type (e.g. a `UUIDField`), `in_bulk()` keys its result by the *prepared* Python value (`UUID` objects), while the loop looked up by the raw serialised string — so every value resolved to `None`. `to_python()` worked correctly because the `pk=` lookup goes through the field's `get_prep_value`.

The fix converts each value through the PK field's `to_python()` before the lookup, so custom primary keys resolve correctly and non-custom (e.g. integer) primary keys are unaffected.

### Tests

- `TestSnippetChooserBlock.test_bulk_to_python_with_uuid_primary_key`: asserts a `SnippetChooserBlock` over the existing `AdvertWithCustomUUIDPrimaryKey` test model resolves a serialised UUID string to the matching instance (verified it returns `[None]` on `main` before the fix).
- Full suites pass: `wagtail.tests.test_blocks`, `wagtail.images.tests.test_blocks`, `wagtail.documents.tests.test_blocks`, `wagtail.snippets.tests.test_chooser_block`, `wagtail.snippets.tests.test_chooser_views`, `wagtail.tests.test_streamfield` (520+ tests). `ruff` clean.

### AI usage

This pull request includes code written with the assistance of AI. I have reviewed and tested the code, understand it, and take final accountability for it.