### PR TITLE
Fix handling of empty query parameters in API filters

### DIFF
--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -28,6 +28,9 @@ class FieldsFilter(BaseFilterBackend):
             fields.remove("locale")
 
         for field_name, value in request.GET.items():
+            if not value:
+                continue
+
             if field_name in fields:
                 try:
                     field = queryset.model._meta.get_field(field_name)
@@ -122,41 +125,44 @@ class SearchFilter(BaseFilterBackend):
         Eg: ?search=James Joyce
         """
         search_enabled = getattr(settings, "WAGTAILAPI_SEARCH_ENABLED", True)
+        search_query = request.GET.get("search")
 
-        if "search" in request.GET:
-            if not search_enabled:
-                raise BadRequestError("search is disabled")
+        if not search_query:
+            return queryset
 
-            # Searching and filtering by tag at the same time is not supported
-            if getattr(queryset, "_filtered_by_tag", False):
-                raise BadRequestError(
-                    "filtering by tag with a search query is not supported"
+        if not search_enabled:
+            raise BadRequestError("search is disabled")
+
+        # Searching and filtering by tag at the same time is not supported
+        if getattr(queryset, "_filtered_by_tag", False):
+            raise BadRequestError(
+                "filtering by tag with a search query is not supported"
+            )
+
+        search_query = request.GET["search"]
+        search_operator = request.GET.get("search_operator", None)
+        order_by_relevance = "order" not in request.GET
+
+        sb = get_search_backend()
+        try:
+            queryset = sb.search(
+                search_query,
+                queryset,
+                operator=search_operator,
+                order_by_relevance=order_by_relevance,
+            )
+        except FilterFieldError as e:
+            raise BadRequestError(
+                "cannot filter by '{}' while searching (field is not indexed)".format(
+                    e.field_name
                 )
-
-            search_query = request.GET["search"]
-            search_operator = request.GET.get("search_operator", None)
-            order_by_relevance = "order" not in request.GET
-
-            sb = get_search_backend()
-            try:
-                queryset = sb.search(
-                    search_query,
-                    queryset,
-                    operator=search_operator,
-                    order_by_relevance=order_by_relevance,
+            ) from e
+        except OrderByFieldError as e:
+            raise BadRequestError(
+                "cannot order by '{}' while searching (field is not indexed)".format(
+                    e.field_name
                 )
-            except FilterFieldError as e:
-                raise BadRequestError(
-                    "cannot filter by '{}' while searching (field is not indexed)".format(
-                        e.field_name
-                    )
-                ) from e
-            except OrderByFieldError as e:
-                raise BadRequestError(
-                    "cannot order by '{}' while searching (field is not indexed)".format(
-                        e.field_name
-                    )
-                ) from e
+            ) from e
 
         return queryset
 
@@ -168,27 +174,31 @@ class ChildOfFilter(BaseFilterBackend):
     """
 
     def filter_queryset(self, request, queryset, view):
-        if "child_of" in request.GET:
-            try:
-                parent_page_id = int(request.GET["child_of"])
-                if parent_page_id < 0:
-                    raise ValueError()
+        child_of = request.GET.get("child_of")
 
-                parent_page = view.get_base_queryset().get(id=parent_page_id)
-            except ValueError as e:
-                if request.GET["child_of"] == "root":
-                    parent_page = view.get_root_page()
-                else:
-                    raise BadRequestError("child_of must be a positive integer") from e
-            except Page.DoesNotExist as e:
-                raise BadRequestError("parent page doesn't exist") from e
+        if not child_of:
+            return queryset
 
-            queryset = queryset.child_of(parent_page)
+        try:
+            parent_page_id = int(request.GET["child_of"])
+            if parent_page_id < 0:
+                raise ValueError()
 
-            # Save the parent page on the queryset. This is required for the page
-            # explorer, which needs to pass the parent page into
-            # `construct_explorer_page_queryset` hook functions
-            queryset._filtered_by_child_of = parent_page
+            parent_page = view.get_base_queryset().get(id=parent_page_id)
+        except ValueError as e:
+            if request.GET["child_of"] == "root":
+                parent_page = view.get_root_page()
+            else:
+                raise BadRequestError("child_of must be a positive integer") from e
+        except Page.DoesNotExist as e:
+            raise BadRequestError("parent page doesn't exist") from e
+
+        queryset = queryset.child_of(parent_page)
+
+        # Save the parent page on the queryset. This is required for the page
+        # explorer, which needs to pass the parent page into
+        # `construct_explorer_page_queryset` hook functions
+        queryset._filtered_by_child_of = parent_page
 
         return queryset
 
@@ -200,19 +210,23 @@ class AncestorOfFilter(BaseFilterBackend):
     """
 
     def filter_queryset(self, request, queryset, view):
-        if "ancestor_of" in request.GET:
-            try:
-                descendant_page_id = int(request.GET["ancestor_of"])
-                if descendant_page_id < 0:
-                    raise ValueError()
+        ancestor_of = request.GET.get("ancestor_of")
 
-                descendant_page = view.get_base_queryset().get(id=descendant_page_id)
-            except ValueError as e:
-                raise BadRequestError("ancestor_of must be a positive integer") from e
-            except Page.DoesNotExist as e:
-                raise BadRequestError("descendant page doesn't exist") from e
+        if not ancestor_of:
+            return queryset
 
-            queryset = queryset.ancestor_of(descendant_page)
+        try:
+            descendant_page_id = int(request.GET["ancestor_of"])
+            if descendant_page_id < 0:
+                raise ValueError()
+
+            descendant_page = view.get_base_queryset().get(id=descendant_page_id)
+        except ValueError as e:
+            raise BadRequestError("ancestor_of must be a positive integer") from e
+        except Page.DoesNotExist as e:
+            raise BadRequestError("descendant page doesn't exist") from e
+
+        queryset = queryset.ancestor_of(descendant_page)
 
         return queryset
 
@@ -224,28 +238,30 @@ class DescendantOfFilter(BaseFilterBackend):
     """
 
     def filter_queryset(self, request, queryset, view):
-        if "descendant_of" in request.GET:
-            if hasattr(queryset, "_filtered_by_child_of"):
-                raise BadRequestError(
-                    "filtering by descendant_of with child_of is not supported"
-                )
-            try:
-                parent_page_id = int(request.GET["descendant_of"])
-                if parent_page_id < 0:
-                    raise ValueError()
+        descendant_of = request.GET.get("descendant_of")
 
-                parent_page = view.get_base_queryset().get(id=parent_page_id)
-            except ValueError as e:
-                if request.GET["descendant_of"] == "root":
-                    parent_page = view.get_root_page()
-                else:
-                    raise BadRequestError(
-                        "descendant_of must be a positive integer"
-                    ) from e
-            except Page.DoesNotExist as e:
-                raise BadRequestError("ancestor page doesn't exist") from e
+        if not descendant_of:
+            return queryset
 
-            queryset = queryset.descendant_of(parent_page)
+        if hasattr(queryset, "_filtered_by_child_of"):
+            raise BadRequestError(
+                "filtering by descendant_of with child_of is not supported"
+            )
+        try:
+            parent_page_id = int(request.GET["descendant_of"])
+            if parent_page_id < 0:
+                raise ValueError()
+
+            parent_page = view.get_base_queryset().get(id=parent_page_id)
+        except ValueError as e:
+            if request.GET["descendant_of"] == "root":
+                parent_page = view.get_root_page()
+            else:
+                raise BadRequestError("descendant_of must be a positive integer") from e
+        except Page.DoesNotExist as e:
+            raise BadRequestError("ancestor page doesn't exist") from e
+
+        queryset = queryset.descendant_of(parent_page)
 
         return queryset
 
@@ -257,29 +273,33 @@ class TranslationOfFilter(BaseFilterBackend):
     """
 
     def filter_queryset(self, request, queryset, view):
-        if "translation_of" in request.GET:
-            try:
-                page_id = int(request.GET["translation_of"])
-                if page_id < 0:
-                    raise ValueError()
+        translation_of = request.GET.get("translation_of")
 
-                page = view.get_base_queryset().get(id=page_id)
-            except ValueError as e:
-                if request.GET["translation_of"] == "root":
-                    page = view.get_root_page()
-                else:
-                    raise BadRequestError(
-                        "translation_of must be a positive integer"
-                    ) from e
-            except Page.DoesNotExist as e:
-                raise BadRequestError("translation_of page doesn't exist") from e
+        if not translation_of:
+            return queryset
 
-            _filtered_by_child_of = getattr(queryset, "_filtered_by_child_of", None)
+        try:
+            page_id = int(request.GET["translation_of"])
+            if page_id < 0:
+                raise ValueError()
 
-            queryset = queryset.translation_of(page)
+            page = view.get_base_queryset().get(id=page_id)
+        except ValueError as e:
+            if request.GET["translation_of"] == "root":
+                page = view.get_root_page()
+            else:
+                raise BadRequestError(
+                    "translation_of must be a positive integer"
+                ) from e
+        except Page.DoesNotExist as e:
+            raise BadRequestError("translation_of page doesn't exist") from e
 
-            if _filtered_by_child_of:
-                queryset._filtered_by_child_of = _filtered_by_child_of
+        _filtered_by_child_of = getattr(queryset, "_filtered_by_child_of", None)
+
+        queryset = queryset.translation_of(page)
+
+        if _filtered_by_child_of:
+            queryset._filtered_by_child_of = _filtered_by_child_of
 
         return queryset
 
@@ -291,13 +311,17 @@ class LocaleFilter(BaseFilterBackend):
     """
 
     def filter_queryset(self, request, queryset, view):
-        if "locale" in request.GET:
-            _filtered_by_child_of = getattr(queryset, "_filtered_by_child_of", None)
+        locale = request.GET.get("locale")
 
-            locale = get_object_or_404(Locale, language_code=request.GET["locale"])
-            queryset = queryset.filter(locale=locale)
+        if not locale:
+            return queryset
 
-            if _filtered_by_child_of:
-                queryset._filtered_by_child_of = _filtered_by_child_of
+        _filtered_by_child_of = getattr(queryset, "_filtered_by_child_of", None)
+
+        locale = get_object_or_404(Locale, language_code=request.GET["locale"])
+        queryset = queryset.filter(locale=locale)
+
+        if _filtered_by_child_of:
+            queryset._filtered_by_child_of = _filtered_by_child_of
 
         return queryset

--- a/wagtail/api/v2/tests/test_documents.py
+++ b/wagtail/api/v2/tests/test_documents.py
@@ -218,6 +218,17 @@ class TestDocumentListing(PageFixturesMixin, TestCase):
             self.get_document_id_list(content_filtered),
         )
 
+    def test_filtering_mixed_empty_nonempty_query_string_param(self):
+        response = self.get_response(search="James")
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(search="James", title="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_document_id_list(content),
+            self.get_document_id_list(content_filtered),
+        )
+
     def test_filtering_exact_filter(self):
         response = self.get_response(title="James Joyce")
         content = json.loads(response.content.decode("UTF-8"))
@@ -259,6 +270,17 @@ class TestDocumentListing(PageFixturesMixin, TestCase):
         response = self.get_response()
         content = json.loads(response.content.decode("UTF-8"))
         response_filtered = self.get_response(order="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_document_id_list(content),
+            self.get_document_id_list(content_filtered),
+        )
+
+    def test_ordering_by_title_with_empty_query_string_param(self):
+        response = self.get_response(order="title")
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(order="title", title="")
         content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
 
         self.assertEqual(

--- a/wagtail/api/v2/tests/test_documents.py
+++ b/wagtail/api/v2/tests/test_documents.py
@@ -207,6 +207,17 @@ class TestDocumentListing(PageFixturesMixin, TestCase):
 
     # FILTERING
 
+    def test_filtering_empty_query_string_param(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(title="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_document_id_list(content),
+            self.get_document_id_list(content_filtered),
+        )
+
     def test_filtering_exact_filter(self):
         response = self.get_response(title="James Joyce")
         content = json.loads(response.content.decode("UTF-8"))
@@ -243,6 +254,17 @@ class TestDocumentListing(PageFixturesMixin, TestCase):
         )
 
     # ORDERING
+
+    def test_ordering_by_empty_order_param(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(order="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_document_id_list(content),
+            self.get_document_id_list(content_filtered),
+        )
 
     def test_ordering_by_title(self):
         response = self.get_response(order="title")

--- a/wagtail/api/v2/tests/test_images.py
+++ b/wagtail/api/v2/tests/test_images.py
@@ -210,6 +210,17 @@ class TestImageListing(PageFixturesMixin, TestCase):
 
     # FILTERING
 
+    def test_filtering_empty_query_string_param(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(title="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_image_id_list(content),
+            self.get_image_id_list(content_filtered),
+        )
+
     def test_filtering_exact_filter(self):
         response = self.get_response(title="James Joyce")
         content = json.loads(response.content.decode("UTF-8"))
@@ -246,6 +257,17 @@ class TestImageListing(PageFixturesMixin, TestCase):
         )
 
     # ORDERING
+
+    def test_ordering_by_empty_order_param(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(order="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_image_id_list(content),
+            self.get_image_id_list(content_filtered),
+        )
 
     def test_ordering_by_title(self):
         response = self.get_response(order="title")

--- a/wagtail/api/v2/tests/test_images.py
+++ b/wagtail/api/v2/tests/test_images.py
@@ -221,6 +221,17 @@ class TestImageListing(PageFixturesMixin, TestCase):
             self.get_image_id_list(content_filtered),
         )
 
+    def test_filtering_mixed_empty_nonempty_query_string_param(self):
+        response = self.get_response(search="James")
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(search="James", title="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_image_id_list(content),
+            self.get_image_id_list(content_filtered),
+        )
+
     def test_filtering_exact_filter(self):
         response = self.get_response(title="James Joyce")
         content = json.loads(response.content.decode("UTF-8"))
@@ -262,6 +273,17 @@ class TestImageListing(PageFixturesMixin, TestCase):
         response = self.get_response()
         content = json.loads(response.content.decode("UTF-8"))
         response_filtered = self.get_response(order="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_image_id_list(content),
+            self.get_image_id_list(content_filtered),
+        )
+
+    def test_ordering_by_title_with_empty_query_string_param(self):
+        response = self.get_response(order="title")
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(order="title", title="")
         content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
 
         self.assertEqual(

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -245,6 +245,19 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
         self.assertEqual(len(content["items"]), 1)
         self.assertEqual(content["items"][0]["id"], french_homepage.id)
 
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_locale_filter_with_empty_query_string_param(self):
+        french = Locale.objects.create(language_code="fr")
+        homepage = self.get_homepage()
+        french_homepage = homepage.copy_for_translation(french)
+        french_homepage.get_latest_revision().publish()
+
+        response = self.get_response(locale="fr", title="")
+        content = json.loads(response.content.decode("UTF-8"))
+
+        self.assertEqual(len(content["items"]), 1)
+        self.assertEqual(content["items"][0]["id"], french_homepage.id)
+
     # TRANSLATION OF FILTER
 
     @override_settings(WAGTAIL_I18N_ENABLED=True)
@@ -272,6 +285,19 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
         french_homepage.get_latest_revision().publish()
 
         response = self.get_response(translation_of=homepage.id)
+        content = json.loads(response.content.decode("UTF-8"))
+
+        self.assertEqual(len(content["items"]), 1)
+        self.assertEqual(content["items"][0]["id"], french_homepage.id)
+
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_translation_of_filter_with_empty_query_string_param(self):
+        french = Locale.objects.create(language_code="fr")
+        homepage = self.get_homepage()
+        french_homepage = homepage.copy_for_translation(french)
+        french_homepage.get_latest_revision().publish()
+
+        response = self.get_response(translation_of=homepage.id, title="")
         content = json.loads(response.content.decode("UTF-8"))
 
         self.assertEqual(len(content["items"]), 1)
@@ -650,6 +676,17 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
             self.get_page_id_list(content_filtered),
         )
 
+    def test_filtering_mixed_empty_nonempty_query_string_param(self):
+        response = self.get_response(search="Home")
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(search="Home", title="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_page_id_list(content),
+            self.get_page_id_list(content_filtered),
+        )
+
     def test_filtering_exact_filter(self):
         response = self.get_response(title="Home page")
         content = json.loads(response.content.decode("UTF-8"))
@@ -795,6 +832,13 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
         page_id_list = self.get_page_id_list(content)
         self.assertEqual(page_id_list, [16, 18, 19])
 
+    def test_child_of_filter_with_empty_query_string_param(self):
+        response = self.get_response(child_of=5, title="")
+        content = json.loads(response.content.decode("UTF-8"))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16, 18, 19])
+
     def test_child_of_root(self):
         # "root" gets children of the homepage of the current site
         response = self.get_response(child_of="root")
@@ -852,6 +896,13 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
         page_id_list = self.get_page_id_list(content)
         self.assertEqual(page_id_list, [2, 6])
 
+    def test_ancestor_of_filter_with_empty_query_string_param(self):
+        response = self.get_response(ancestor_of=10, title="")
+        content = response.json()
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [2, 6])
+
     def test_ancestor_of_with_type(self):
         response = self.get_response(type="demosite.eventindexpage", ancestor_of=8)
         content = response.json()
@@ -896,6 +947,13 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
 
     def test_descendant_of_filter(self):
         response = self.get_response(descendant_of=6)
+        content = json.loads(response.content.decode("UTF-8"))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [10, 15, 17, 21, 22, 23])
+
+    def test_descendant_of_filter_with_empty_query_string_param(self):
+        response = self.get_response(descendant_of=6, title="")
         content = json.loads(response.content.decode("UTF-8"))
 
         page_id_list = self.get_page_id_list(content)
@@ -987,6 +1045,17 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
         response = self.get_response()
         content = json.loads(response.content.decode("UTF-8"))
         response_filtered = self.get_response(order="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_page_id_list(content),
+            self.get_page_id_list(content_filtered),
+        )
+
+    def test_ordering_by_title_with_empty_query_string_param(self):
+        response = self.get_response(order="title")
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(order="title", title="")
         content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
 
         self.assertEqual(

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -216,6 +216,23 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
     # LOCALE FILTER
 
     @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_locale_filter_with_empty_param(self):
+        french = Locale.objects.create(language_code="fr")
+        homepage = self.get_homepage()
+        french_homepage = homepage.copy_for_translation(french)
+        french_homepage.get_latest_revision().publish()
+
+        response_filtered = self.get_response(locale="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+        response = self.get_response()
+        content = json.loads(response.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_page_id_list(content),
+            self.get_page_id_list(content_filtered),
+        )
+
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
     def test_locale_filter(self):
         french = Locale.objects.create(language_code="fr")
         homepage = self.get_homepage()
@@ -229,6 +246,23 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
         self.assertEqual(content["items"][0]["id"], french_homepage.id)
 
     # TRANSLATION OF FILTER
+
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_translation_of_filter_with_empty_param(self):
+        french = Locale.objects.create(language_code="fr")
+        homepage = self.get_homepage()
+        french_homepage = homepage.copy_for_translation(french)
+        french_homepage.get_latest_revision().publish()
+
+        response_filtered = self.get_response(translation_of="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+        response = self.get_response()
+        content = json.loads(response.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_page_id_list(content),
+            self.get_page_id_list(content_filtered),
+        )
 
     @override_settings(WAGTAIL_I18N_ENABLED=True)
     def test_translation_of_filter(self):
@@ -605,6 +639,17 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
 
     # FILTERING
 
+    def test_filtering_empty_query_string_param(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(title="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_page_id_list(content),
+            self.get_page_id_list(content_filtered),
+        )
+
     def test_filtering_exact_filter(self):
         response = self.get_response(title="Home page")
         content = json.loads(response.content.decode("UTF-8"))
@@ -732,6 +777,17 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
 
     # CHILD OF FILTER
 
+    def test_child_of_filter_with_empty_param(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(child_of="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_page_id_list(content),
+            self.get_page_id_list(content_filtered),
+        )
+
     def test_child_of_filter(self):
         response = self.get_response(child_of=5)
         content = json.loads(response.content.decode("UTF-8"))
@@ -778,6 +834,17 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
 
     # ANCESTOR OF FILTER
 
+    def test_ancestor_of_filter_with_empty_param(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(ancestor_of="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_page_id_list(content),
+            self.get_page_id_list(content_filtered),
+        )
+
     def test_ancestor_of_filter(self):
         response = self.get_response(ancestor_of=10)
         content = response.json()
@@ -815,6 +882,17 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
         self.assertEqual(page_id_list, [])
 
     # DESCENDANT OF FILTER
+
+    def test_descendant_of_filter_with_empty_param(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(descendant_of="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_page_id_list(content),
+            self.get_page_id_list(content_filtered),
+        )
 
     def test_descendant_of_filter(self):
         response = self.get_response(descendant_of=6)
@@ -904,6 +982,17 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
         self.assertEqual(page_id_list, [24, 25])
 
     # ORDERING
+
+    def test_ordering_by_empty_order_param(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(order="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
+
+        self.assertEqual(
+            self.get_page_id_list(content),
+            self.get_page_id_list(content_filtered),
+        )
 
     def test_ordering_default(self):
         response = self.get_response()
@@ -1307,11 +1396,15 @@ class TestPageListingSearch(PageFixturesMixin, WagtailTestUtils, TransactionTest
         self.assertEqual(set(page_id_list), {16, 18, 19})
 
     def test_empty_searches_work(self):
-        response = self.get_response(search="")
+        response = self.get_response()
         content = json.loads(response.content.decode("UTF-8"))
+        response_filtered = self.get_response(search="")
+        content_filtered = json.loads(response_filtered.content.decode("UTF-8"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-type"], "application/json")
-        self.assertEqual(content["meta"]["total_count"], 0)
+        self.assertEqual(
+            content["meta"]["total_count"], content_filtered["meta"]["total_count"]
+        )
 
 
 class TestPageDetail(PageFixturesMixin, TestCase):


### PR DESCRIPTION
Fixes #14513

### Description

This PR updates the API filter logic to properly ignore query parameters that are passed as empty strings (e.g., `?search=`, `?type=`, or custom field filters).

#### The Problem

Previously, if a headless frontend passed an empty value to a filter parameter, the API would attempt to process the empty string, resulting in an empty result set. This caused unnecessary friction, forcing frontend developers to write boilerplate code to actively strip empty parameters from their request state before calling the Wagtail API.

#### The Solution:

This aligns Wagtail's API with standard RESTful conventions. An empty parameter is now treated as if it were omitted entirely, returning the default, unfiltered paginated queryset. This applies globally across filter backends, including `SearchFilter`, `FieldsFilter`, and others.

### AI usage

AI is used for writing PR description.
