### PR TITLE
Support comparing reverse OneToOneField relations

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Changelog
  * Fix: Prevent stale content types from breaking audit log message formatting (Thibaud Colas)
  * Fix: Ensure form field clean_name is consistently set on form pages if autosave runs prematurely (Joey Jurjens)
  * Fix: Enforce 'choose' permission on image chooser select-format view (Matt Westcott)
+ * Fix: Allow comparing page revisions that include the reverse side of a OneToOneField relation (Saksham Chawla)
  * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
  * Docs: Fix panel classname and deprecated usage of `format_html` in `construct_homepage_panels` example (Andreas Nüßlein)
  * Docs: Add docs for `request.in_preview_panel` to explain its use (Raghad Dahi)

--- a/wagtail/admin/compare.py
+++ b/wagtail/admin/compare.py
@@ -1,6 +1,6 @@
 import difflib
 
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.db import models
 from django.utils.encoding import force_str
 from django.utils.html import escape, format_html, format_html_join
@@ -510,6 +510,51 @@ class ForeignObjectComparison(FieldComparison):
                 return escape(force_str(obj_a))
             else:
                 return _("None")
+
+
+class OneToOneRelComparison(FieldComparison):
+    """Comparison for the reverse side of a OneToOneField (a ``OneToOneRel``)."""
+
+    is_field = True
+    is_child_relation = False
+
+    def __init__(self, field, obj_a, obj_b):
+        self.field = field
+
+        def get_related(obj):
+            if obj is None:
+                return None
+            try:
+                return getattr(obj, field.name)
+            except ObjectDoesNotExist:
+                return None
+
+        self.obj_a = get_related(obj_a)
+        self.obj_b = get_related(obj_b)
+
+    def htmldiff(self):
+        obj_a, obj_b = self.obj_a, self.obj_b
+
+        if obj_a != obj_b:
+            if obj_a and obj_b:
+                # Changed
+                return TextDiff(
+                    [("deletion", force_str(obj_a)), ("addition", force_str(obj_b))]
+                ).to_html()
+            elif obj_b:
+                # Added
+                return TextDiff([("addition", force_str(obj_b))]).to_html()
+            elif obj_a:
+                # Removed
+                return TextDiff([("deletion", force_str(obj_a))]).to_html()
+        else:
+            if obj_a:
+                return escape(force_str(obj_a))
+            else:
+                return _("None")
+
+    def has_changed(self):
+        return self.obj_a != self.obj_b
 
 
 class ChildRelationComparison:

--- a/wagtail/admin/panels/field_panel.py
+++ b/wagtail/admin/panels/field_panel.py
@@ -89,6 +89,11 @@ class FieldPanel(Panel):
         try:
             field = self.db_field
 
+            if field.is_relation and field.one_to_one and not field.concrete:
+                # The reverse side of a OneToOneField (a OneToOneRel) has no
+                # choices and no value_from_object; use a dedicated comparison.
+                return compare.OneToOneRelComparison
+
             if field.choices:
                 return compare.ChoiceFieldComparison
 

--- a/wagtail/admin/tests/test_compare.py
+++ b/wagtail/admin/tests/test_compare.py
@@ -4,9 +4,11 @@ from django.test import TestCase
 from django.utils.safestring import SafeString
 
 from wagtail.admin import compare
+from wagtail.admin.panels import FieldPanel
 from wagtail.blocks import StreamValue
 from wagtail.images import get_image_model
 from wagtail.images.tests.utils import get_test_image_file
+from wagtail.models import Page
 from wagtail.test.testapp.models import (
     AdvertWithCustomPrimaryKey,
     EventCategory,
@@ -1149,6 +1151,59 @@ class TestForeignObjectComparison(TestCase):
         )
         self.assertIsInstance(comparison.htmldiff(), SafeString)
         self.assertTrue(comparison.has_changed())
+
+
+class TestOneToOneRelComparison(TestCase):
+    """The reverse side of a OneToOneField should be comparable."""
+
+    fixtures = ["test.json"]
+    comparison_class = compare.OneToOneRelComparison
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.event_page = EventPage.objects.get(url_path="/home/events/christmas/")
+        cls.other_event_page = EventPage.objects.get(
+            url_path="/home/events/saint-patrick/"
+        )
+
+    def _field(self):
+        return EventPage._meta.get_field("page_ptr").remote_field
+
+    def _comparison(self, obj_a, obj_b):
+        return self.comparison_class(self._field(), obj_a, obj_b)
+
+    def test_hasnt_changed(self):
+        comparison = self._comparison(self.event_page, self.event_page)
+        self.assertTrue(comparison.is_field)
+        self.assertFalse(comparison.is_child_relation)
+        self.assertFalse(comparison.has_changed())
+        self.assertEqual(comparison.htmldiff(), str(self.event_page))
+        self.assertIsInstance(comparison.htmldiff(), SafeString)
+
+    def test_has_changed(self):
+        comparison = self._comparison(self.event_page, self.other_event_page)
+        self.assertTrue(comparison.has_changed())
+        self.assertEqual(
+            comparison.htmldiff(),
+            f'<span class="deletion">{self.event_page}</span>'
+            f'<span class="addition">{self.other_event_page}</span>',
+        )
+        self.assertIsInstance(comparison.htmldiff(), SafeString)
+
+    def test_one_side_missing(self):
+        comparison = self._comparison(None, self.event_page)
+        self.assertTrue(comparison.has_changed())
+        self.assertEqual(
+            comparison.htmldiff(),
+            f'<span class="addition">{self.event_page}</span>',
+        )
+
+    def test_panel_get_comparison_class(self):
+        # The panel comparison lookup must not raise AttributeError for the
+        # reverse side of a OneToOneField (which has no 'choices' attribute).
+        panel = FieldPanel("eventpage").bind_to_model(Page)
+        comparison_class = panel.get_comparison_class()
+        self.assertIs(comparison_class, compare.OneToOneRelComparison)
 
 
 class TestForeignObjectComparisonWithCustomPK(TestCase):


### PR DESCRIPTION
Fixes #5929

### Description

When a page contains the reverse side of a `OneToOneField` relation (for example, a `PageChooserPanel` bound to the reverse accessor of a one-to-one relation), comparing revisions crashes:

```
AttributeError: 'OneToOneRel' object has no attribute 'choices'
```

`FieldPanel.get_comparison_class()` reads `field.choices` before checking for relations, but `OneToOneRel` (the reverse side of a `OneToOneField`) has no `choices` attribute, nor a `value_from_object` method.

This PR:

- Adds a dedicated `OneToOneRelComparison` class that reads the related object on each revision (guarded against `ObjectDoesNotExist`) and diffs it with `htmldiff`, mirroring the existing `ForeignObjectComparison`.
- Updates `FieldPanel.get_comparison_class()` to return `OneToOneRelComparison` for reverse one-to-one fields before the `choices` check.

### Tests

- `TestOneToOneRelComparison` covering unchanged, changed, and missing related objects, plus a test asserting the panel comparison lookup returns `OneToOneRelComparison` (this last test raises the `AttributeError` above on `main`).

### AI usage

This pull request includes code written with the assistance of AI. I have reviewed and tested the code, understand it, and take final accountability for it.