### PR TITLE
Respect LockableMixin in page and snippets update APIs

### DIFF
--- a/wagtail/actions/edit.py
+++ b/wagtail/actions/edit.py
@@ -75,6 +75,25 @@ class EditAction(BaseAction):
         # The revision created by execute(), if any.
         self.revision = None
 
+    def check_lock(self):
+        from wagtail.models import LockableMixin
+
+        if (
+            isinstance(self.instance, LockableMixin)
+            and self.user
+            and (lock := self.instance.get_lock()) is not None
+            and lock.for_user(self.user)
+        ):
+            model_name = self.instance._meta.verbose_name
+            raise EditPermissionError(
+                f"The {model_name} could not be saved as it is locked."
+            )
+
+    def check(self, skip_permission_checks=False):
+        super().check(skip_permission_checks=skip_permission_checks)
+        if not skip_permission_checks:
+            self.check_lock()
+
     def _clean_instance(self):
         # Always clean if a form is provided, as the form cannot be saved
         # if it has not been validated.

--- a/wagtail/api/v3/errors.py
+++ b/wagtail/api/v3/errors.py
@@ -148,7 +148,7 @@ def register_exception_handlers(api: NinjaAPI):
         # v3 never trusts session auth: 401 unless a bearer token resolved.
         if not request.user.is_authenticated:
             return problem_response(status=401, detail="Authentication required")
-        return problem_response(status=403, detail="Permission denied")
+        return problem_response(status=403, detail=str(exc) or "Permission denied")
 
     @api.exception_handler(Http404)
     def not_found_handler(request: HttpRequest, exc: Http404):

--- a/wagtail/api/v3/tests/test_page_actions.py
+++ b/wagtail/api/v3/tests/test_page_actions.py
@@ -158,7 +158,7 @@ class TestV3PageUnpublish(TestV3PageActionsBase):
         self.assert_problem_response(
             response,
             status_code=403,
-            detail_contains="Permission denied",
+            detail_contains="You do not have permission to unpublish this page.",
         )
 
     def test_unknown_page_returns_404(self):

--- a/wagtail/api/v3/tests/test_page_update.py
+++ b/wagtail/api/v3/tests/test_page_update.py
@@ -873,3 +873,52 @@ class TestV3PageUpdate(TestV3Base, WagtailTestUtils, TestCase):
             },
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_update_page_when_locked_is_rejected(self):
+        page = self.root_page.add_child(
+            instance=BlogIndexPage(title="Original", slug="original", live=False)
+        )
+        # Lock with no locked_by (e.g. locked by a script): applies to everyone
+        page.locked = True
+        page.save()
+
+        logs_since = timezone.now()
+        response = self.patch(
+            page,
+            {
+                "meta": {"type": "demosite.BlogIndexPage"},
+                "title": "New title",
+            },
+        )
+        self.assert_problem_response(
+            response,
+            status_code=403,
+            detail_contains="could not be saved as it is locked.",
+        )
+
+        # Nothing was saved, the page is unchanged, no draft/revision/log entry
+        page.refresh_from_db()
+        self.assertEqual(page.title, "Original")
+        self.assertFalse(page.has_unpublished_changes)
+        self.assertFalse(page.revisions.exists())
+        self.assert_log_actions(page, [], since=logs_since)
+
+    def test_update_page_when_locked_by_self_is_allowed(self):
+        page = self.root_page.add_child(
+            instance=BlogIndexPage(title="Original", slug="original", live=False)
+        )
+        page.locked = True
+        page.locked_by = self.user
+        page.locked_at = timezone.now()
+        page.save()
+
+        response = self.patch(
+            page,
+            {
+                "meta": {"type": "demosite.BlogIndexPage"},
+                "title": "New title",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        page.refresh_from_db()
+        self.assertEqual(page.title, "New title")

--- a/wagtail/documents/tests/test_api_v3/test_delete.py
+++ b/wagtail/documents/tests/test_api_v3/test_delete.py
@@ -54,7 +54,10 @@ class TestV3DocumentDelete(TestV3DocumentsBase):
         self.assert_problem_response(
             response,
             status_code=403,
-            detail_contains="Permission denied",
+            detail_contains=(
+                "You do not have permission to perform the 'delete' "
+                "action on this object."
+            ),
         )
 
     def test_uploader_with_add_permission_can_delete_own_document(self):

--- a/wagtail/documents/tests/test_api_v3/test_update.py
+++ b/wagtail/documents/tests/test_api_v3/test_update.py
@@ -146,7 +146,10 @@ class TestV3DocumentUpdate(TestV3DocumentsBase):
         self.assert_problem_response(
             response,
             status_code=403,
-            detail_contains="Permission denied",
+            detail_contains=(
+                "You do not have permission to perform the 'edit' "
+                "action on this object."
+            ),
         )
 
     def test_unknown_id_returns_404(self):

--- a/wagtail/images/tests/test_api_v3/test_delete.py
+++ b/wagtail/images/tests/test_api_v3/test_delete.py
@@ -44,7 +44,12 @@ class TestV3ImageDelete(TestV3ImagesBase):
         self.login(user)
         response = self.delete(image.id)
         self.assert_problem_response(
-            response, status_code=403, detail_contains="Permission denied"
+            response,
+            status_code=403,
+            detail_contains=(
+                "You do not have permission to perform the 'delete' "
+                "action on this object."
+            ),
         )
 
     def test_uploader_with_add_permission_can_delete_own_image(self):

--- a/wagtail/images/tests/test_api_v3/test_update.py
+++ b/wagtail/images/tests/test_api_v3/test_update.py
@@ -147,7 +147,12 @@ class TestV3ImageUpdate(TestV3ImagesBase):
         self.login(user)
         response = self.patch(self.image.id, {"title": "Theirs"})
         self.assert_problem_response(
-            response, status_code=403, detail_contains="Permission denied"
+            response,
+            status_code=403,
+            detail_contains=(
+                "You do not have permission to perform the 'edit' "
+                "action on this object."
+            ),
         )
 
     def test_audit_log(self):

--- a/wagtail/snippets/tests/test_api_v3/test_update.py
+++ b/wagtail/snippets/tests/test_api_v3/test_update.py
@@ -3,6 +3,7 @@ import json
 from django.contrib.auth.models import Permission
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 
 from wagtail.api.v3.tests.base import TestV3Base
 from wagtail.documents.models import Document
@@ -636,6 +637,49 @@ class TestV3SnippetUpdateWithDraftState(TestV3SnippetUpdateBase):
         latest_revision.publish()
         snippet.refresh_from_db()
         self.assertEqual(snippet.text, "New Draft Text")
+
+
+class TestV3SnippetUpdateWhenLocked(TestV3SnippetUpdateBase):
+    model = FullFeaturedSnippet
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.snippet = FullFeaturedSnippet.objects.create(
+            text="Original", some_number=1, live=False
+        )
+
+    def test_update_when_locked_is_rejected(self):
+        # Lock with no locked_by (e.g. locked by a script): applies to everyone
+        self.snippet.locked = True
+        self.snippet.save()
+
+        logs_since = timezone.now()
+        response = self.patch(self.snippet.pk, {"text": "Updated"})
+        self.assert_problem_response(
+            response,
+            status_code=403,
+            detail_contains=(
+                "The full-featured snippet could not be saved as it is locked."
+            ),
+        )
+
+        # Nothing was saved, no change, no draft/revision/log entry
+        self.snippet.refresh_from_db()
+        self.assertEqual(self.snippet.text, "Original")
+        self.assertFalse(self.snippet.has_unpublished_changes)
+        self.assertEqual(self.snippet.revisions.count(), 0)
+        self.assert_log_actions(self.snippet, [], since=logs_since)
+
+    def test_update_when_locked_by_self_is_allowed(self):
+        self.snippet.locked = True
+        self.snippet.locked_by = self.user
+        self.snippet.locked_at = timezone.now()
+        self.snippet.save()
+
+        response = self.patch(self.snippet.pk, {"text": "Updated"})
+        self.assertEqual(response.status_code, 200)
+        self.snippet.refresh_from_db()
+        self.assertEqual(self.snippet.text, "Updated")
 
 
 class TestV3SnippetUpdateWithPermissionedFields(TestV3SnippetUpdateBase):

--- a/wagtail/tests/actions/test_edit.py
+++ b/wagtail/tests/actions/test_edit.py
@@ -9,7 +9,12 @@ from wagtail.log_actions import registry as log_registry
 from wagtail.models import Revision
 from wagtail.permission_policies import ModelPermissionPolicy
 from wagtail.signals import published
-from wagtail.test.testapp.models import Advert, DraftStateModel, RevisableModel
+from wagtail.test.testapp.models import (
+    Advert,
+    DraftStateModel,
+    LockableModel,
+    RevisableModel,
+)
 from wagtail.test.utils import WagtailTestUtils
 
 AdvertForm = modelform_factory(Advert, fields=["text", "url", "tags"])
@@ -252,3 +257,53 @@ class TestEditAction(WagtailTestUtils, TestCase):
         EditAction(advert, user=user).execute(skip_permission_checks=True)
         advert.refresh_from_db()
         self.assertEqual(advert.text, "Bypass")
+
+    def test_edit_locked_model_is_rejected(self):
+        instance = LockableModel.objects.create(text="Original", locked=True)
+        instance.text = "Edited"
+        with self.assertRaisesMessage(
+            EditPermissionError,
+            "The lockable model could not be saved as it is locked.",
+        ):
+            EditAction(instance, user=self.user).execute()
+
+        instance.refresh_from_db()
+        self.assertEqual(instance.text, "Original")
+        self.assertEqual(
+            log_registry.get_logs_for_instance(instance)
+            .filter(action="wagtail.edit")
+            .count(),
+            0,
+        )
+
+    def test_edit_locked_model_locked_by_other_user_is_rejected(self):
+        other_user = self.create_user(username="other")
+        instance = LockableModel.objects.create(
+            text="Original",
+            locked=True,
+            locked_by=other_user,
+        )
+        instance.text = "Edited"
+        with self.assertRaisesMessage(
+            EditPermissionError,
+            "The lockable model could not be saved as it is locked.",
+        ):
+            EditAction(instance, user=self.user).execute()
+
+    def test_edit_locked_model_locked_by_self_is_allowed(self):
+        instance = LockableModel.objects.create(
+            text="Original",
+            locked=True,
+            locked_by=self.user,
+        )
+        instance.text = "Edited"
+        EditAction(instance, user=self.user).execute()
+        instance.refresh_from_db()
+        self.assertEqual(instance.text, "Edited")
+
+    def test_edit_locked_model_with_skip_permission_checks_is_allowed(self):
+        instance = LockableModel.objects.create(text="Original", locked=True)
+        instance.text = "Edited"
+        EditAction(instance, user=self.user).execute(skip_permission_checks=True)
+        instance.refresh_from_db()
+        self.assertEqual(instance.text, "Edited")


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Refs #14504

### Description

<!-- Please describe the problem you're fixing. -->

This ensures lock state is respected when making edits via the API, similar to the admin views.

### AI Usage

Kimi K3 with high thinking via Pi was used to write the first pass, but then I refactored the code manually to follow our common practices.

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>