### PR TITLE
Combine translated page descendant count queries into a single query

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Changelog
  * Fix: Prevent stale content types from breaking audit log message formatting (Thibaud Colas)
  * Fix: Ensure form field clean_name is consistently set on form pages if autosave runs prematurely (Joey Jurjens)
  * Fix: Enforce 'choose' permission on image chooser select-format view (Matt Westcott)
+ * Fix: Reduce the number of queries when fetching the translated descendant count shown on the page unpublish confirmation view (Saksham Chawla)
  * Docs: Add reference documentation entry for `SnippetChooserViewSet` (Sage Abdullah)
  * Docs: Fix panel classname and deprecated usage of `format_html` in `construct_homepage_panels` example (Andreas Nüßlein)
  * Docs: Add docs for `request.in_preview_panel` to explain its use (Raghad Dahi)

--- a/wagtail/admin/views/pages/unpublish.py
+++ b/wagtail/admin/views/pages/unpublish.py
@@ -1,6 +1,7 @@
 import swapper
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -87,12 +88,22 @@ class UnpublishView(GenericUnpublishView):
                 "page": self.object,
                 "live_descendant_count": self.object.get_descendants().live().count(),
                 "translation_count": len(self.objects_to_unpublish[1:]),
-                "translation_descendant_count": sum(
-                    [
-                        p.get_descendants().filter(alias_of__isnull=True).live().count()
-                        for p in self.objects_to_unpublish[1:]
-                    ]
-                ),
+                "translation_descendant_count": self.get_translation_descendant_count(),
             }
         )
         return context
+
+    def get_translation_descendant_count(self):
+        translations = self.objects_to_unpublish[1:]
+        if not translations:
+            return 0
+
+        # Combine the per-translation descendant lookups into a single query
+        # rather than running one ``count()`` per translated page.
+        descendant_q = Q()
+        for page in translations:
+            descendant_q |= Page.objects.descendant_of_q(page)
+
+        return Page.objects.filter(
+            descendant_q, alias_of__isnull=True, live=True
+        ).count()

--- a/wagtail/contrib/simple_translation/tests/test_wagtail_hooks.py
+++ b/wagtail/contrib/simple_translation/tests/test_wagtail_hooks.py
@@ -1,6 +1,8 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
+from django.db import connection
 from django.test import TestCase, override_settings
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
 from wagtail import hooks
@@ -214,6 +216,90 @@ class TestConstructSyncedPageTreeListHook(Utils):
         # Test that both the English and French homepages are unpublished
         self.assertFalse(self.en_homepage.live)
         self.assertFalse(self.fr_homepage.live)
+
+    @override_settings(
+        WAGTAILSIMPLETRANSLATION_SYNC_PAGE_TREE=True, WAGTAIL_I18N_ENABLED=True
+    )
+    def test_translation_descendant_count_in_context(self):
+        # Login to access the admin
+        self.login()
+
+        # Give the English homepage live children and translate them, so the
+        # French and German homepages each get live descendants.
+        self.en_child = TestPage(title="English child", slug="en-child")
+        self.en_homepage.add_child(instance=self.en_child)
+        self.en_other_child = TestPage(
+            title="English other child", slug="en-other-child"
+        )
+        self.en_homepage.add_child(instance=self.en_other_child)
+
+        self.fr_blog_index = self.en_blog_index.copy_for_translation(self.fr_locale)
+        self.fr_blog_post = self.en_blog_post.copy_for_translation(self.fr_locale)
+        self.fr_blog_post.live = True
+        self.fr_blog_post.save()
+
+        # Make sure the French and German homepages are published/live
+        self.fr_homepage.live = True
+        self.fr_homepage.save()
+        self.de_homepage.live = True
+        self.de_homepage.save()
+
+        response = self.client.get(
+            reverse("wagtailadmin_pages:unpublish", args=(self.en_homepage.id,))
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # The confirmation page should show the combined translated descendant
+        # count: only the live descendant of the translated (fr) page counts,
+        # not the English children (which belong to the page being unpublished).
+        self.assertEqual(
+            response.context["translation_descendant_count"],
+            1,
+        )
+
+    @override_settings(
+        WAGTAILSIMPLETRANSLATION_SYNC_PAGE_TREE=True, WAGTAIL_I18N_ENABLED=True
+    )
+    def test_translation_descendant_count_uses_single_query(self):
+        # Login to access the admin
+        self.login()
+
+        # Give the English homepage live children and translate them, so the
+        # French and German homepages each get live descendants.
+        self.en_child = TestPage(title="English child", slug="en-child")
+        self.en_homepage.add_child(instance=self.en_child)
+        self.en_other_child = TestPage(
+            title="English other child", slug="en-other-child"
+        )
+        self.en_homepage.add_child(instance=self.en_other_child)
+
+        self.fr_blog_index = self.en_blog_index.copy_for_translation(self.fr_locale)
+        self.fr_blog_post = self.en_blog_post.copy_for_translation(self.fr_locale)
+        self.fr_blog_post.live = True
+        self.fr_blog_post.save()
+
+        self.fr_homepage.live = True
+        self.fr_homepage.save()
+        self.de_homepage.live = True
+        self.de_homepage.save()
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(
+                reverse("wagtailadmin_pages:unpublish", args=(self.en_homepage.id,))
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.context["translation_descendant_count"], 1)
+
+        # The descendant count must be computed in a single query regardless of
+        # how many translated pages are involved (regression test for #13937).
+        # The descendant count must be computed in a single query regardless of
+        # how many translated pages are involved (regression test for #13937).
+        descendant_count_queries = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if "SELECT COUNT" in q["sql"] and "alias_of" in q["sql"]
+        ]
+        self.assertEqual(len(descendant_count_queries), 1)
 
 
 class TestMovingTranslatedPages(Utils):


### PR DESCRIPTION
Fixes #13937

### Description

When unpublishing a page with translations, the unpublish confirmation view computed `translation_descendant_count` by running one `COUNT(*)` query per translated page:

```python
sum(
    [p.get_descendants().filter(alias_of__isnull=True).live().count() for p in self.objects_to_unpublish[1:]]
)
```

This results in N+1 queries — one per translated page. This PR replaces that with a single query that combines the per-translation descendant lookups into one `Q` object:

```python
descendant_q = Q()
for page in translations:
    descendant_q |= Page.objects.descendant_of_q(page)

return Page.objects.filter(descendant_q, alias_of__isnull=True, live=True).count()
```

The behaviour is identical, but the count is always computed with a single query regardless of how many translations the page has.

### Tests

Added `test_translation_descendant_count_in_context` (verifies the count is correct when translations have live descendants) and `test_translation_descendant_count_uses_single_query` (asserts that only one `COUNT` query touching `alias_of` is issued). The query-count test fails with the previous implementation (2 queries) and passes with this change.

Existing tests in `wagtail.contrib.simple_translation.tests` and `wagtail.admin.tests.pages.test_unpublish_page` all pass.

### AI usage

This pull request includes code written with the assistance of AI. The code has **not yet been reviewed** by a human.
