### PR TITLE
Exclude base page model from type union in page create and update API

### DIFF
--- a/wagtail/api/v3/registry.py
+++ b/wagtail/api/v3/registry.py
@@ -64,9 +64,7 @@ class ContentTypeRegistry:
         """Return the JSON schemas for each direction of content type ``name``.
 
         Returns ``None`` when ``name`` is not registered. Directions without a
-        schema fall back to a placeholder (``{"description": "Not yet available."}``)
-        for ``create`` and ``patch`` so schema discovery keeps advertising the
-        planned write directions.
+        schema fall back to a placeholder (``{"description": "Not available."}``).
         """
         registration = self.get(name)
         if registration is None:
@@ -77,10 +75,8 @@ class ContentTypeRegistry:
             schema = self._schema_for_direction(registration, direction)
             if schema is not None:
                 result[direction] = schema
-            elif direction in ("create", "patch"):
-                # TODO Placeholder until write endpoints land; keeps schema discovery
-                # showing that create/patch directions are planned.
-                result[direction] = {"description": "Not yet available."}
+            else:
+                result[direction] = {"description": "Not available."}
         return result
 
     def register_defaults(self) -> None:

--- a/wagtail/api/v3/registry.py
+++ b/wagtail/api/v3/registry.py
@@ -103,24 +103,32 @@ class ContentTypeRegistry:
         )
 
         for model in get_page_models():
+            read_schema = read_generator.generate_schema(model, base_class=PageSchema)
+            # Do not generate create and patch schemas for the base page model
+            # unless it is explicitly marked as creatable.
+            if model is model.base_page_model and not model.is_creatable:
+                create_schema = None
+                patch_schema = None
+            else:
+                create_schema = create_generator.generate_schema(
+                    model,
+                    base_class=PageCreateBaseSchema,
+                    fields=BASE_PAGE_FIELDS,
+                    required_fields=("title",),
+                )
+                patch_schema = patch_generator.generate_schema(
+                    model,
+                    base_class=PageUpdateBaseSchema,
+                    fields=BASE_PAGE_FIELDS,
+                )
+
             self.register(
                 ContentTypeRegistration(
                     name=model._meta.label,
                     label=str(model._meta.verbose_name),
-                    read_schema=read_generator.generate_schema(
-                        model, base_class=PageSchema
-                    ),
-                    create_schema=create_generator.generate_schema(
-                        model,
-                        base_class=PageCreateBaseSchema,
-                        fields=BASE_PAGE_FIELDS,
-                        required_fields=("title",),
-                    ),
-                    patch_schema=patch_generator.generate_schema(
-                        model,
-                        base_class=PageUpdateBaseSchema,
-                        fields=BASE_PAGE_FIELDS,
-                    ),
+                    read_schema=read_schema,
+                    create_schema=create_schema,
+                    patch_schema=patch_schema,
                 )
             )
 

--- a/wagtail/api/v3/registry.py
+++ b/wagtail/api/v3/registry.py
@@ -94,14 +94,6 @@ class ContentTypeRegistry:
         )
         from wagtail.models import get_page_models
 
-        self.register(
-            ContentTypeRegistration(
-                name="pages",
-                label="Pages",
-                read_schema=PageSchema,
-            )
-        )
-
         for model in get_page_models():
             read_schema = read_generator.generate_schema(model, base_class=PageSchema)
             # Do not generate create and patch schemas for the base page model

--- a/wagtail/api/v3/schemas/base.py
+++ b/wagtail/api/v3/schemas/base.py
@@ -2,7 +2,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Annotated, Any, Iterable, Union
 
-from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model
 from ninja import Schema
 from pydantic import Discriminator, Tag
@@ -86,8 +85,9 @@ def build_discriminated_union(
         return schema_for(models[0])
 
     members = tuple(
-        Annotated[schema_for(model), Tag(model._meta.label)]  # ty: ignore[invalid-type-form]
+        Annotated[schema, Tag(model._meta.label)]  # ty: ignore[invalid-type-form]
         for model in models
+        if (schema := schema_for(model)) is not None
     )
     return Annotated[
         Union[members],  # ty: ignore[invalid-type-form]
@@ -119,12 +119,6 @@ def build_union_schemas(models: Iterable[type[Model]]) -> DiscriminatedUnionSche
     def registered_schema_for(model: type[Model], attr: str):
         registration = registry.get(model._meta.label)
         schema = registration and getattr(registration, attr)
-        if schema is None:
-            raise ImproperlyConfigured(
-                f"{model._meta.label} has no registered {attr} - "
-                f"ContentTypeRegistry.register_defaults() must run before "
-                f"build_union_schemas()."
-            )
         return schema
 
     models = list(models)

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -20273,101 +20273,6 @@
         "title": "PageCreateAliasSchema",
         "type": "object"
       },
-      "PageCreateMetaSchema": {
-        "properties": {
-          "action": {
-            "anyOf": [
-              {
-                "const": "publish",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Action"
-          },
-          "parent_id": {
-            "title": "Parent Id",
-            "type": "integer"
-          },
-          "type": {
-            "const": "wagtailcore.Page",
-            "title": "Type",
-            "type": "string"
-          }
-        },
-        "required": ["type", "parent_id"],
-        "title": "PageCreateMetaSchema",
-        "type": "object"
-      },
-      "PageCreateSchema": {
-        "properties": {
-          "meta": {
-            "$ref": "#/components/schemas/PageCreateMetaSchema"
-          },
-          "search_description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The descriptive text displayed underneath a headline in search engine results.",
-            "title": "Meta Description"
-          },
-          "seo_title": {
-            "anyOf": [
-              {
-                "maxLength": 255,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The name of the page displayed on search engine results as the clickable headline.",
-            "title": "Title Tag"
-          },
-          "show_in_menus": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": false,
-            "description": "Whether a link to this page will appear in automatically generated menus",
-            "title": "Show In Menus"
-          },
-          "slug": {
-            "anyOf": [
-              {
-                "maxLength": 255,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The name of the page as it will appear in URLs e.g http://domain.com/blog/[my-slug]/",
-            "title": "Slug"
-          },
-          "title": {
-            "description": "The page title as you'd like it to be seen by the public",
-            "maxLength": 255,
-            "title": "Title",
-            "type": "string"
-          }
-        },
-        "required": ["meta", "title"],
-        "title": "PageCreateSchema",
-        "type": "object"
-      },
       "PageFilterSchema": {
         "properties": {
           "ancestor_of": {
@@ -20600,117 +20505,6 @@
         },
         "required": ["destination_id"],
         "title": "PageMoveSchema",
-        "type": "object"
-      },
-      "PagePatchMetaSchema": {
-        "properties": {
-          "action": {
-            "anyOf": [
-              {
-                "const": "publish",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Action"
-          },
-          "type": {
-            "anyOf": [
-              {
-                "const": "wagtailcore.Page",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Type"
-          }
-        },
-        "required": ["type"],
-        "title": "PagePatchMetaSchema",
-        "type": "object"
-      },
-      "PagePatchSchema": {
-        "properties": {
-          "meta": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/PagePatchMetaSchema"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "search_description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The descriptive text displayed underneath a headline in search engine results.",
-            "title": "Meta Description"
-          },
-          "seo_title": {
-            "anyOf": [
-              {
-                "maxLength": 255,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The name of the page displayed on search engine results as the clickable headline.",
-            "title": "Title Tag"
-          },
-          "show_in_menus": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": false,
-            "description": "Whether a link to this page will appear in automatically generated menus",
-            "title": "Show In Menus"
-          },
-          "slug": {
-            "anyOf": [
-              {
-                "maxLength": 255,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The name of the page as it will appear in URLs e.g http://domain.com/blog/[my-slug]/",
-            "title": "Slug"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "maxLength": 255,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The page title as you'd like it to be seen by the public",
-            "title": "Title"
-          }
-        },
-        "title": "PagePatchSchema",
         "type": "object"
       },
       "PageRevertSchema": {
@@ -36782,9 +36576,6 @@
               "schema": {
                 "oneOf": [
                   {
-                    "$ref": "#/components/schemas/PageCreateSchema"
-                  },
-                  {
                     "$ref": "#/components/schemas/EarlyPageCreateSchema"
                   },
                   {
@@ -38053,9 +37844,6 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/PagePatchSchema"
-                  },
                   {
                     "$ref": "#/components/schemas/EarlyPagePatchSchema"
                   },

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -1291,63 +1291,6 @@
         "title": "BaseMetaSchema",
         "type": "object"
       },
-      "BasePageCreateMetaSchema": {
-        "properties": {
-          "action": {
-            "anyOf": [
-              {
-                "const": "publish",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Action"
-          },
-          "parent_id": {
-            "title": "Parent Id",
-            "type": "integer"
-          },
-          "type": {
-            "const": "basepage.BasePage",
-            "title": "Type",
-            "type": "string"
-          }
-        },
-        "required": ["type", "parent_id"],
-        "title": "BasePageCreateMetaSchema",
-        "type": "object"
-      },
-      "BasePageCreateSchema": {
-        "properties": {
-          "meta": {
-            "$ref": "#/components/schemas/BasePageCreateMetaSchema"
-          },
-          "slug": {
-            "anyOf": [
-              {
-                "maxLength": 255,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The name of the page as it will appear in URLs e.g http://domain.com/blog/[my-slug]/",
-            "title": "Slug"
-          },
-          "title": {
-            "description": "The page title as you'd like it to be seen by the public",
-            "maxLength": 255,
-            "title": "Title",
-            "type": "string"
-          }
-        },
-        "required": ["meta", "title"],
-        "title": "BasePageCreateSchema",
-        "type": "object"
-      },
       "BasePageForeignKeySchema": {
         "properties": {
           "id": {
@@ -1434,79 +1377,6 @@
         },
         "required": ["slug"],
         "title": "BasePageMetaSchema",
-        "type": "object"
-      },
-      "BasePagePatchMetaSchema": {
-        "properties": {
-          "action": {
-            "anyOf": [
-              {
-                "const": "publish",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Action"
-          },
-          "type": {
-            "anyOf": [
-              {
-                "const": "basepage.BasePage",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Type"
-          }
-        },
-        "required": ["type"],
-        "title": "BasePagePatchMetaSchema",
-        "type": "object"
-      },
-      "BasePagePatchSchema": {
-        "properties": {
-          "meta": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/BasePagePatchMetaSchema"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "slug": {
-            "anyOf": [
-              {
-                "maxLength": 255,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The name of the page as it will appear in URLs e.g http://domain.com/blog/[my-slug]/",
-            "title": "Slug"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "maxLength": 255,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The page title as you'd like it to be seen by the public",
-            "title": "Title"
-          }
-        },
-        "title": "BasePagePatchSchema",
         "type": "object"
       },
       "BasePageSchema": {
@@ -27608,9 +27478,6 @@
               "schema": {
                 "oneOf": [
                   {
-                    "$ref": "#/components/schemas/BasePageCreateSchema"
-                  },
-                  {
                     "$ref": "#/components/schemas/EarlyPageCreateSchema"
                   },
                   {
@@ -28879,9 +28746,6 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/BasePagePatchSchema"
-                  },
                   {
                     "$ref": "#/components/schemas/EarlyPagePatchSchema"
                   },

--- a/wagtail/api/v3/tests/test_page_create.py
+++ b/wagtail/api/v3/tests/test_page_create.py
@@ -1,6 +1,5 @@
 import json
 
-import swapper
 from django.contrib.auth.models import Group, Permission
 from django.test import TestCase
 from django.urls import reverse
@@ -16,7 +15,7 @@ from wagtail.test.demosite.models import (
     EventPage,
     HomePage,
 )
-from wagtail.test.testapp.models import StreamPage
+from wagtail.test.testapp.models import SimpleParentPage, StreamPage
 from wagtail.test.utils import Page, WagtailTestUtils
 
 
@@ -510,6 +509,10 @@ class TestV3PageCreate(TestV3Base, WagtailTestUtils, TestCase):
             ),
             ({"parent_id": self.root_page.pk, "type": "not.AType"}, "not.AType"),
             ({"parent_id": self.root_page.pk, "type": "auth.User"}, "auth.User"),
+            (
+                {"parent_id": self.root_page.pk, "type": Page._meta.label},
+                Page._meta.label,
+            ),
         ]
         for meta, extracted in problem_metas:
             with self.subTest(meta=meta):
@@ -602,16 +605,16 @@ class TestV3PageCreate(TestV3Base, WagtailTestUtils, TestCase):
         self.assertEqual(PageLogEntry.objects.count(), logs_before)
 
     def test_disallowed_subpage_type_returns_403(self):
-        # BlogIndexPage's default page-type rules allow being created
-        # under the root, but wagtailcore.Page itself is not creatable at all.
         parent = self.root_page.add_child(
-            instance=BlogIndexPage(title="Parent", slug="parent-page")
+            instance=SimpleParentPage(title="Parent", slug="parent-page")
         )
         response = self.post(
             {
                 "meta": {
                     "parent_id": parent.pk,
-                    "type": swapper.get_model_name("wagtailcore", "Page"),
+                    # SimpleParentPage only allows SimpleChildPage as subpages,
+                    # so this should be rejected.
+                    "type": HomePage._meta.label,
                 },
                 "title": "New page",
                 "slug": "new-page",

--- a/wagtail/api/v3/tests/test_page_update.py
+++ b/wagtail/api/v3/tests/test_page_update.py
@@ -786,6 +786,7 @@ class TestV3PageUpdate(TestV3Base, WagtailTestUtils, TestCase):
             ({"type": 123}, "123"),
             ({"type": ["not", "a", "string"]}, "['not', 'a', 'string']"),
             ({"type": self.user._meta.label}, self.user._meta.label),
+            ({"type": Page._meta.label}, Page._meta.label),
         ]
         for meta, extracted in problem_metas:
             with self.subTest(meta=meta):

--- a/wagtail/api/v3/tests/test_schema_discovery.py
+++ b/wagtail/api/v3/tests/test_schema_discovery.py
@@ -54,8 +54,8 @@ class TestV3SchemaDiscovery(TestV3Base, WagtailTestUtils, TestCase):
         self.assertEqual(
             set(meta_schema["properties"].keys()), PAGE_READ_META_SCHEMA_FIELDS
         )
-        self.assertEqual(content["create"], {"description": "Not yet available."})
-        self.assertEqual(content["patch"], {"description": "Not yet available."})
+        self.assertEqual(content["create"], {"description": "Not available."})
+        self.assertEqual(content["patch"], {"description": "Not available."})
 
     def test_get_specific_page_type_schema_includes_create_schema(self):
         response = self.client.get(

--- a/wagtail/api/v3/tests/test_schema_discovery.py
+++ b/wagtail/api/v3/tests/test_schema_discovery.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from wagtail.api.v3.tests.base import TestV3Base
-from wagtail.test.utils import WagtailTestUtils
+from wagtail.test.utils import Page, WagtailTestUtils
 
 PAGE_READ_SCHEMA_FIELDS = {"id", "title", "meta"}
 PAGE_READ_META_SCHEMA_FIELDS = {
@@ -35,13 +35,13 @@ class TestV3SchemaDiscovery(TestV3Base, WagtailTestUtils, TestCase):
         content = response.json()
         self.assertIn("types", content)
         names = [entry["name"] for entry in content["types"]]
-        self.assertIn("pages", names)
+        self.assertIn(Page._meta.label, names)
 
     def test_get_pages_schema(self):
         response = self.client.get(
             reverse(
                 "wagtailapi_v3:get_schema_for_type",
-                kwargs={"type_name": "pages"},
+                kwargs={"type_name": Page._meta.label},
             )
         )
         self.assertEqual(response.status_code, 200)
@@ -50,7 +50,7 @@ class TestV3SchemaDiscovery(TestV3Base, WagtailTestUtils, TestCase):
         self.assertEqual(
             set(content["read"]["properties"].keys()), PAGE_READ_SCHEMA_FIELDS
         )
-        meta_schema = content["read"]["$defs"]["PageMetaSchema"]
+        meta_schema = content["read"]["$defs"][f"{Page._meta.object_name}MetaSchema"]
         self.assertEqual(
             set(meta_schema["properties"].keys()), PAGE_READ_META_SCHEMA_FIELDS
         )


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Ref #14504

### Description

<!-- Please describe the problem you're fixing. -->
I originally had the idea to allow the base page model to be used as meta.type as a shortcut when you only want to fill in the base page fields. It also could be useful if you want to edit a page that is missing the specific instance for some reason. However, now that we have the meta.type autofilling mechanism, this is no longer very useful.

In fact, working with the base page model would actually cause problems because save_revision() requires working with the specific model, and would raise a RuntimeError otherwise.
### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
GitHub Copilot for code completion

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>