### PR TITLE
Ensure rich text field is processed in snippets write API

### DIFF
--- a/wagtail/api/rich_text.py
+++ b/wagtail/api/rich_text.py
@@ -3,6 +3,7 @@ from typing import Any, Literal, cast
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from draftjs_exporter import MarkdownParseError
 
 from wagtail.rich_text import expand_db_html
 
@@ -10,7 +11,7 @@ RichTextOutputFormat = Literal["db_html", "html", "db_markdown", "markdown"]
 RichTextInputFormat = Literal["db_html", "db_markdown"]
 
 
-class RichTextFormatError(Exception):
+class RichTextFormatError(ValueError):
     pass
 
 
@@ -167,7 +168,13 @@ class APIRichText:
         # Lazy import: wagtail.api must stay importable without wagtail.admin.
         from wagtail.admin.rich_text.converters.markdown_db import MarkdownConverter
 
-        db_html = MarkdownConverter().to_database_format(content)
+        try:
+            db_html = MarkdownConverter().to_database_format(content)
+        except MarkdownParseError as e:
+            location = f" at line {e.line}" if e.line is not None else ""
+            raise RichTextFormatError(
+                f"Invalid Markdown in rich text{location}: {e.message}"
+            ) from e
         return APIRichText.sanitize_db_html(db_html, features=features)
 
     @classmethod

--- a/wagtail/api/v3/errors.py
+++ b/wagtail/api/v3/errors.py
@@ -36,6 +36,11 @@ def as_validation_error(
     Useful for converting exceptions raised in code that is normally caught
     via other mechanisms e.g. Django form validation or prevented by normal
     user interface.
+
+    The ``loc`` argument is best-effort, as the caller may not have enough
+    context to provide a full path to the field that caused the error. It may
+    also be different to how Ninja normally reports validation errors, which is
+    based on the request shape (i.e. may include "body" or "query").
     """
     return PydanticValidationError.from_exception_data(
         "Validation error",

--- a/wagtail/api/v3/form_data.py
+++ b/wagtail/api/v3/form_data.py
@@ -315,6 +315,9 @@ def _set_field_value(field: Field, name: str, value: Any, data: MultiValueDict) 
     elif getattr(field.widget, "allow_multiple_selected", False):
         data.setlist(name, list(value) if value else [])
     elif hasattr(field.widget, "converter"):
+        # Normally this is an envelope dict, but it can also be a plain str
+        # e.g. if the field was not in the payload and thus the Pydantic field
+        # default "" is used.
         if isinstance(value, dict):
             value = value.get("content", "")
         # A rich text editor widget (Draftail's `to_database_format`/

--- a/wagtail/api/v3/form_data.py
+++ b/wagtail/api/v3/form_data.py
@@ -14,6 +14,7 @@ from permissionedforms import PermissionedForm
 from wagtail.admin.forms.models import WagtailAdminModelForm
 from wagtail.admin.panels import Panel, get_edit_handler, get_form_for_model
 from wagtail.api.rich_text import APIRichText
+from wagtail.api.v3.errors import as_validation_error
 from wagtail.api.v3.registry import ContentTypeRegistration, registry
 from wagtail.api.v3.schemas import create_generator
 from wagtail.blocks.base import BlockField
@@ -281,7 +282,10 @@ def flatten_block_value(block, value: Any, prefix: str, data: MultiValueDict) ->
             flatten_block_value(child_block, value.get(name), f"{prefix}-{name}", data)
     elif isinstance(block, RichTextBlock):
         if value is not None:
-            value, _ = APIRichText.convert_input(value, features=block.features)
+            try:
+                value, _ = APIRichText.convert_input(value, features=block.features)
+            except ValueError as e:
+                raise as_validation_error(e, loc=(prefix,)) from e
         data[prefix] = block.field.widget.format_value(value)
     else:
         # A leaf field block (CharBlock, BooleanBlock, ChooserBlock, ...):

--- a/wagtail/api/v3/form_data.py
+++ b/wagtail/api/v3/form_data.py
@@ -4,19 +4,16 @@ from typing import Any, cast
 import swapper
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.auth.models import AnonymousUser
-from django.core.exceptions import FieldDoesNotExist, ValidationError
+from django.core.exceptions import ValidationError
 from django.db.models import Model
 from django.forms import BaseForm, Field
 from django.utils.datastructures import MultiValueDict
-from draftjs_exporter import MarkdownParseError
 from ninja.schema import BaseModel
 from permissionedforms import PermissionedForm
 
 from wagtail.admin.forms.models import WagtailAdminModelForm
 from wagtail.admin.panels import Panel, get_edit_handler, get_form_for_model
-from wagtail.admin.rich_text.converters.db_html import RichTextRemoval
 from wagtail.api.rich_text import APIRichText
-from wagtail.api.v3.errors import as_validation_error
 from wagtail.api.v3.registry import ContentTypeRegistration, registry
 from wagtail.api.v3.schemas import create_generator
 from wagtail.blocks.base import BlockField
@@ -24,7 +21,6 @@ from wagtail.blocks.field_block import RichTextBlock
 from wagtail.blocks.list_block import ListBlock
 from wagtail.blocks.stream_block import BaseStreamBlock
 from wagtail.blocks.struct_block import BaseStructBlock
-from wagtail.fields import RichTextField
 
 Page = swapper.load_model("wagtailcore", "Page")
 
@@ -115,46 +111,6 @@ def get_api_form_class(model: type[Model], field_names: Iterable[str] | None = N
     )
 
 
-def convert_rich_text_payload(
-    model: type[Model], payload: dict[str, Any]
-) -> tuple[dict[str, Any], list[tuple[str, RichTextRemoval]]]:
-    """Sanitise RichTextField values in a create/update payload.
-
-    Converts each accepted input shape (plain DB HTML string or
-    {"format", "content"} envelope) to database HTML, enforcing the field's
-    declared features. Returns the updated payload and a list of
-    (field_name, RichTextRemoval) tuples for everything that was stripped.
-
-    Only top-level model RichTextFields are handled; rich text inside
-    StreamField values is out of scope (#14310).
-    """
-    removals: list[tuple[str, RichTextRemoval]] = []
-    for name in list(payload):
-        try:
-            model_field = model._meta.get_field(name)
-        except FieldDoesNotExist:
-            continue
-        if not isinstance(model_field, RichTextField):
-            continue
-        value = payload[name]
-        if value is None:
-            continue
-        try:
-            db_html, field_removals = APIRichText.convert_input(
-                value, features=model_field.features
-            )
-        except MarkdownParseError as e:
-            location = f" at line {e.line}" if e.line is not None else ""
-            raise as_validation_error(
-                e,
-                f"Invalid Markdown in rich text{location}: {e.message}",
-                loc=("body", name),
-            ) from e
-        payload[name] = db_html
-        removals.extend((name, removal) for removal in field_removals)
-    return payload, removals
-
-
 def build_page_form(
     model: type[Page],
     parent: Page,
@@ -190,7 +146,6 @@ def build_page_form(
         payload["slug"] = page.slug
         page._cached_parent_obj = None
 
-    payload, _ = convert_rich_text_payload(model, payload)
     form_data = build_form_data(form_class, payload)
 
     return form_class(data=form_data, instance=page, parent_page=parent, for_user=user)
@@ -227,7 +182,6 @@ def build_page_update_form(
     """
     model = type(page)
     payload = data.dict(exclude={"meta"}, exclude_unset=True)
-    payload, _ = convert_rich_text_payload(model, payload)
     form_class = get_api_form_class(model, field_names=payload.keys())
     form_data = build_form_data(form_class, payload, instance=page)
 
@@ -361,6 +315,8 @@ def _set_field_value(field: Field, name: str, value: Any, data: MultiValueDict) 
     elif getattr(field.widget, "allow_multiple_selected", False):
         data.setlist(name, list(value) if value else [])
     elif hasattr(field.widget, "converter"):
+        if isinstance(value, dict):
+            value = value.get("content", "")
         # A rich text editor widget (Draftail's `to_database_format`/
         # `from_database_format` contract - core ships only Draftail, but
         # third-party editors may implement the same converter pattern).

--- a/wagtail/api/v3/routers/pages.py
+++ b/wagtail/api/v3/routers/pages.py
@@ -18,7 +18,7 @@ from wagtail.actions.copy_for_translation import ParentNotTranslatedError
 from wagtail.actions.copy_page import CopyPageIntegrityError
 from wagtail.actions.create_alias import CreatePageAliasIntegrityError
 from wagtail.actions.publish_page_revision import PublishPagePermissionError
-from wagtail.api.rich_text import APIRichText, RichTextOutputFormat
+from wagtail.api.rich_text import RichTextOutputFormat
 from wagtail.api.v3.auth import AllowAnonymous, BearerTokenAuth
 from wagtail.api.v3.errors import as_validation_error
 from wagtail.api.v3.form_data import build_page_form, build_page_update_form
@@ -287,7 +287,6 @@ def get_page(
     version: Optional[Literal["live", "draft"]] = Query("live"),  # ty: ignore[call-non-callable]
     rich_text_format: RichTextOutputFormat | None = Query(None),  # ty: ignore[call-non-callable]
 ):
-    APIRichText.resolve_format(rich_text_format)
     page = get_object_or_404(get_pages_queryset(request), pk=page_id)
     if version == "draft" and request.user.is_authenticated:
         return page.get_latest_revision_as_object()
@@ -308,7 +307,6 @@ def create_page(
     data: PageCreateSchema = Body(...),  # ty: ignore[call-non-callable]
     rich_text_format: RichTextOutputFormat | None = Query(None),  # ty: ignore[call-non-callable]
 ):
-    APIRichText.resolve_format(rich_text_format)
     model = resolve_model_string(data.meta.type)
     parent = get_object_or_404(Page, id=data.meta.parent_id).specific
     form = build_page_form(model, parent, data, request.user)
@@ -339,7 +337,6 @@ def update_page(
     data: PageUpdateSchema = PageTypeInjectingBody(...),
     rich_text_format: RichTextOutputFormat | None = Query(None),  # ty: ignore[call-non-callable]
 ):
-    APIRichText.resolve_format(rich_text_format)
     model = resolve_model_string(data.meta.type)
     page = get_object_or_404(model, pk=page_id)
     form = build_page_update_form(page, data, request.user)

--- a/wagtail/api/v3/schemas/base.py
+++ b/wagtail/api/v3/schemas/base.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any, Iterable, Union
 
 from django.db.models import Model
 from ninja import Schema
-from pydantic import Discriminator, Tag
+from pydantic import Discriminator, Field, Tag
 
 
 class BaseMetaSchema(Schema):
@@ -92,6 +92,18 @@ def build_discriminated_union(
     return Annotated[
         Union[members],  # ty: ignore[invalid-type-form]
         Discriminator(discriminate_meta_type),
+        # Ideally, we'd use the proper "discriminator" OpenAPI field here, but
+        # it only supports a field on the same level as the union, while our
+        # "type" is nested under "meta". (Pydantic would also automatically add
+        # it if we did not use a callable discriminator.)
+        Field(
+            json_schema_extra={
+                "description": (
+                    "A union of models, discriminated by the content type in "
+                    "`meta.type`."
+                )
+            }
+        ),
     ]
 
 

--- a/wagtail/api/v3/schemas/generators/read.py
+++ b/wagtail/api/v3/schemas/generators/read.py
@@ -32,24 +32,25 @@ class SchemaGenerator:
     best-effort basis - see ``build_schema`` for the exact rules.
     """
 
-    field_schemas: dict[type[Field | ForeignObjectRel], FieldSchemaFunc] = {}
-    """
-    Map of Django field classes to functions that return a tuple of
-    (annotation, default value, resolver function) for that field type.
-    """
+    def __init__(self):
+        self.field_schemas: dict[type[Field | ForeignObjectRel], FieldSchemaFunc] = {}
+        """
+        Map of Django field classes to functions that return a tuple of
+        (annotation, default value, resolver function) for that field type.
+        """
 
-    _reverse_related_schema_cache: dict[type[Model], type[Schema]] = {}
-    """
-    Schemas already built for a given reverse-related model, so a model
-    referenced by several models' api_fields only gets built once.
-    """
+        self._reverse_related_schema_cache: dict[type[Model], type[Schema]] = {}
+        """
+        Schemas already built for a given reverse-related model, so a model
+        referenced by several models' api_fields only gets built once.
+        """
 
-    _foreign_key_schema_cache: dict[type[Model], type[Schema]] = {}
-    """
-    Schemas already built for a given foreign key's related model, keyed
-    separately from `_nested_schema_cache` since these are a distinct, much
-    smaller shape (primary key(s) plus a meta.type), not a full nested schema.
-    """
+        self._foreign_key_schema_cache: dict[type[Model], type[Schema]] = {}
+        """
+        Schemas already built for a given foreign key's related model, keyed
+        separately from `_nested_schema_cache` since these are a distinct, much
+        smaller shape (primary key(s) plus a meta.type), not a full nested schema.
+        """
 
     @staticmethod
     def _get_pk_names(model: type[Model]) -> list[str]:

--- a/wagtail/api/v3/schemas/generators/read.py
+++ b/wagtail/api/v3/schemas/generators/read.py
@@ -350,7 +350,10 @@ def rich_text_schema(generator: SchemaGenerator, field: Field) -> FieldSchema:
             value, format=rich_text_format, features=field.features
         )
 
-    default = FieldInfo(default=None, json_schema_extra={"features": resolved_features})
+    default = FieldInfo(
+        default=None,
+        json_schema_extra={"x-rich-text-features": resolved_features},
+    )
     return cast(type, str | None), default, staticmethod(resolve)
 
 

--- a/wagtail/api/v3/schemas/generators/write.py
+++ b/wagtail/api/v3/schemas/generators/write.py
@@ -369,9 +369,10 @@ def rich_text_schema(generator: InputSchemaGenerator, field: Field) -> InputFiel
         if field.features is not None
         else feature_registry.get_default_features()
     )
+    # Default is not normalized to an envelope for simplicity
     default = FieldInfo(default="", json_schema_extra={"features": resolved_features})
 
-    def convert_content(value: str | RichTextInputSchema) -> str | RichTextInputSchema:
+    def convert_content(value: str | RichTextInputSchema) -> RichTextInputSchema:
         input = value if isinstance(value, str) else value.model_dump()
         try:
             db_html, _ = APIRichText.convert_input(input, features=field.features)
@@ -380,12 +381,8 @@ def rich_text_schema(generator: InputSchemaGenerator, field: Field) -> InputFiel
             raise ValueError(
                 f"Invalid Markdown in rich text{location}: {e.message}"
             ) from e
-        # Result is normalized as db_html, with an envelope if it came with one.
-        return (
-            db_html
-            if isinstance(value, str)
-            else RichTextInputSchema(format="db_html", content=db_html)
-        )
+        # Result is normalized as an enveloped db_html
+        return RichTextInputSchema(format="db_html", content=db_html)
 
     annotation = Annotated[str | RichTextInputSchema, AfterValidator(convert_content)]
 

--- a/wagtail/api/v3/schemas/generators/write.py
+++ b/wagtail/api/v3/schemas/generators/write.py
@@ -1,20 +1,21 @@
 from collections.abc import Iterable
 from types import UnionType
-from typing import Any, Callable, Literal, Union, cast, get_args, get_origin
+from typing import Annotated, Any, Callable, Literal, Union, cast, get_args, get_origin
 
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db.models import Field, ForeignKey, Model
 from django.db.models.fields.reverse_related import ForeignObjectRel
+from draftjs_exporter import MarkdownParseError
 from modelcluster.models import get_all_child_relations
 from ninja import Schema
 from ninja.orm import create_schema
 from ninja.orm.fields import get_schema_field
-from pydantic import BaseModel
+from pydantic import AfterValidator, BaseModel
 from pydantic.fields import FieldInfo
 from taggit.managers import TaggableManager
 
 from wagtail.api import APIField
-from wagtail.api.rich_text import RichTextInputFormat
+from wagtail.api.rich_text import APIRichText, RichTextInputFormat
 from wagtail.fields import RichTextField, StreamField
 from wagtail.rich_text import features as feature_registry
 
@@ -354,7 +355,7 @@ class InputSchemaGenerator:
         return cast(type[Schema], metaclass(name, (schema,), namespace))
 
 
-class RichTextInputSchema(Schema):
+class RichTextInputSchema(BaseModel):
     """Envelope form of rich text input. A plain string means DB HTML."""
 
     format: RichTextInputFormat = "db_html"
@@ -369,7 +370,26 @@ def rich_text_schema(generator: InputSchemaGenerator, field: Field) -> InputFiel
         else feature_registry.get_default_features()
     )
     default = FieldInfo(default="", json_schema_extra={"features": resolved_features})
-    return str | RichTextInputSchema, default
+
+    def convert_content(value: str | RichTextInputSchema) -> str | RichTextInputSchema:
+        input = value if isinstance(value, str) else value.model_dump()
+        try:
+            db_html, _ = APIRichText.convert_input(input, features=field.features)
+        except MarkdownParseError as e:
+            location = f" at line {e.line}" if e.line is not None else ""
+            raise ValueError(
+                f"Invalid Markdown in rich text{location}: {e.message}"
+            ) from e
+        # Result is normalized as db_html, with an envelope if it came with one.
+        return (
+            db_html
+            if isinstance(value, str)
+            else RichTextInputSchema(format="db_html", content=db_html)
+        )
+
+    annotation = Annotated[str | RichTextInputSchema, AfterValidator(convert_content)]
+
+    return annotation, default
 
 
 def streamfield_schema(

--- a/wagtail/api/v3/schemas/generators/write.py
+++ b/wagtail/api/v3/schemas/generators/write.py
@@ -5,7 +5,6 @@ from typing import Annotated, Any, Callable, Literal, Union, cast, get_args, get
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db.models import Field, ForeignKey, Model
 from django.db.models.fields.reverse_related import ForeignObjectRel
-from draftjs_exporter import MarkdownParseError
 from modelcluster.models import get_all_child_relations
 from ninja import Schema
 from ninja.orm import create_schema
@@ -374,13 +373,7 @@ def rich_text_schema(generator: InputSchemaGenerator, field: Field) -> InputFiel
 
     def convert_content(value: str | RichTextInputSchema) -> RichTextInputSchema:
         input = value if isinstance(value, str) else value.model_dump()
-        try:
-            db_html, _ = APIRichText.convert_input(input, features=field.features)
-        except MarkdownParseError as e:
-            location = f" at line {e.line}" if e.line is not None else ""
-            raise ValueError(
-                f"Invalid Markdown in rich text{location}: {e.message}"
-            ) from e
+        db_html, _ = APIRichText.convert_input(input, features=field.features)
         # Result is normalized as an enveloped db_html
         return RichTextInputSchema(format="db_html", content=db_html)
 

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -2720,7 +2720,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Body",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -2733,8 +2734,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Body"
+            ]
           },
           "carousel_items": {
             "default": [],
@@ -3202,7 +3202,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Intro",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -3215,8 +3216,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Intro"
+            ]
           },
           "meta": {
             "$ref": "#/components/schemas/BlogIndexPageMetaSchema"
@@ -5654,7 +5654,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Body",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -5667,8 +5668,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Body"
+            ]
           },
           "city": {
             "anyOf": [
@@ -8930,7 +8930,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Body",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -8943,8 +8944,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Body"
+            ]
           },
           "id": {
             "title": "Id",
@@ -10569,7 +10569,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Intro",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -10582,8 +10583,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Intro"
+            ]
           },
           "meta": {
             "$ref": "#/components/schemas/EventIndexPageMetaSchema"
@@ -15975,7 +15975,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Body",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -15988,8 +15989,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Body"
+            ]
           },
           "carousel_items": {
             "default": [],
@@ -23938,8 +23938,8 @@
                 "type": "null"
               }
             ],
-            "features": ["quotation", "embed", "made-up-feature"],
-            "title": "Body"
+            "title": "Body",
+            "x-rich-text-features": ["quotation", "embed", "made-up-feature"]
           },
           "id": {
             "title": "Id",
@@ -28966,7 +28966,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Intro",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -28979,8 +28980,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Intro"
+            ]
           },
           "meta": {
             "$ref": "#/components/schemas/StandardIndexPageMetaSchema"
@@ -29635,7 +29635,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Body",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -29648,8 +29649,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Body"
+            ]
           },
           "carousel_items": {
             "default": [],
@@ -29682,7 +29682,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Intro",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -29695,8 +29696,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Intro"
+            ]
           },
           "meta": {
             "$ref": "#/components/schemas/StandardPageMetaSchema"
@@ -32011,8 +32011,14 @@
                 "type": "null"
               }
             ],
-            "features": ["image", "italic", "link", "quotation", "embed"],
-            "title": "Rich Body"
+            "title": "Rich Body",
+            "x-rich-text-features": [
+              "image",
+              "italic",
+              "link",
+              "quotation",
+              "embed"
+            ]
           },
           "sections": {
             "default": [],
@@ -33603,7 +33609,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Body",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -33616,8 +33623,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Body"
+            ]
           },
           "carousel_items": {
             "default": [],
@@ -35243,7 +35249,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Biography",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -35256,8 +35263,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Biography"
+            ]
           },
           "city": {
             "anyOf": [
@@ -35333,7 +35339,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Intro",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -35346,8 +35353,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Intro"
+            ]
           },
           "last_name": {
             "maxLength": 255,

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -20537,6 +20537,7 @@
             "$ref": "#/components/schemas/ContentTypeSchema"
           },
           "content_object": {
+            "description": "A union of models, discriminated by the content type in `meta.type`.",
             "oneOf": [
               {
                 "$ref": "#/components/schemas/PageSchema"
@@ -21907,6 +21908,7 @@
           },
           "items": {
             "items": {
+              "description": "A union of models, discriminated by the content type in `meta.type`.",
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/AdvertSchema"
@@ -27929,6 +27931,7 @@
             "$ref": "#/components/schemas/ContentTypeSchema"
           },
           "content_object": {
+            "description": "A union of models, discriminated by the content type in `meta.type`.",
             "oneOf": [
               {
                 "$ref": "#/components/schemas/DraftStateCustomPrimaryKeyModelSchema"
@@ -36535,6 +36538,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "description": "A union of models, discriminated by the content type in `meta.type`.",
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/EarlyPageCreateSchema"
@@ -36797,6 +36801,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/PageSchema"
@@ -37144,6 +37149,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/PageSchema"
@@ -37498,6 +37504,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/PageSchema"
@@ -37804,6 +37811,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "description": "A union of models, discriminated by the content type in `meta.type`.",
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/EarlyPagePatchSchema"
@@ -38066,6 +38074,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/PageSchema"
@@ -38356,6 +38365,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/PageSchema"
@@ -38667,6 +38677,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/PageSchema"
@@ -38967,6 +38978,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/PageSchema"
@@ -39276,6 +39288,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/PageSchema"
@@ -39605,6 +39618,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/PageSchema"
@@ -39895,6 +39909,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/PageSchema"
@@ -40195,6 +40210,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/PageSchema"
@@ -40502,6 +40518,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/PageSchema"
@@ -41704,6 +41721,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "description": "A union of models, discriminated by the content type in `meta.type`.",
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/AdvertCreateSchema"
@@ -41735,6 +41753,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/AdvertSchema"
@@ -41878,6 +41897,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/AdvertSchema"
@@ -41964,6 +41984,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "description": "A union of models, discriminated by the content type in `meta.type`.",
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/AdvertPatchSchema"
@@ -41995,6 +42016,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/AdvertSchema"
@@ -42163,6 +42185,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/DraftStateCustomPrimaryKeyModelSchema"
@@ -42230,6 +42253,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/DraftStateCustomPrimaryKeyModelSchema"
@@ -42289,6 +42313,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/DraftStateCustomPrimaryKeyModelSchema"

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -41604,6 +41604,23 @@
           },
           {
             "in": "query",
+            "name": "rich_text_format",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": ["db_html", "html", "db_markdown", "markdown"],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Rich Text Format"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -41663,6 +41680,23 @@
               ],
               "title": "Type",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rich_text_format",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": ["db_html", "html", "db_markdown", "markdown"],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Rich Text Format"
             }
           }
         ],
@@ -41820,6 +41854,23 @@
               "title": "Version",
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "rich_text_format",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": ["db_html", "html", "db_markdown", "markdown"],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Rich Text Format"
+            }
           }
         ],
         "responses": {
@@ -41889,6 +41940,23 @@
             "schema": {
               "title": "Pk",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rich_text_format",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": ["db_html", "html", "db_markdown", "markdown"],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Rich Text Format"
             }
           }
         ],

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -31847,20 +31847,7 @@
               }
             ],
             "default": "",
-            "features": [
-              "embed",
-              "image",
-              "hr",
-              "link",
-              "bold",
-              "italic",
-              "h2",
-              "h3",
-              "h4",
-              "ol",
-              "ul",
-              "document-link"
-            ],
+            "features": ["image", "italic", "link", "quotation", "embed"],
             "title": "Rich Body"
           },
           "sections": {
@@ -31962,20 +31949,7 @@
               }
             ],
             "default": "",
-            "features": [
-              "embed",
-              "image",
-              "hr",
-              "link",
-              "bold",
-              "italic",
-              "h2",
-              "h3",
-              "h4",
-              "ol",
-              "ul",
-              "document-link"
-            ],
+            "features": ["image", "italic", "link", "quotation", "embed"],
             "title": "Rich Body"
           },
           "sections": {
@@ -32034,20 +32008,7 @@
                 "type": "null"
               }
             ],
-            "features": [
-              "embed",
-              "image",
-              "hr",
-              "link",
-              "bold",
-              "italic",
-              "h2",
-              "h3",
-              "h4",
-              "ol",
-              "ul",
-              "document-link"
-            ],
+            "features": ["image", "italic", "link", "quotation", "embed"],
             "title": "Rich Body"
           },
           "sections": {

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -32506,6 +32506,23 @@
           },
           {
             "in": "query",
+            "name": "rich_text_format",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": ["db_html", "html", "db_markdown", "markdown"],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Rich Text Format"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -32565,6 +32582,23 @@
               ],
               "title": "Type",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rich_text_format",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": ["db_html", "html", "db_markdown", "markdown"],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Rich Text Format"
             }
           }
         ],
@@ -32722,6 +32756,23 @@
               "title": "Version",
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "rich_text_format",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": ["db_html", "html", "db_markdown", "markdown"],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Rich Text Format"
+            }
           }
         ],
         "responses": {
@@ -32791,6 +32842,23 @@
             "schema": {
               "title": "Pk",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rich_text_format",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": ["db_html", "html", "db_markdown", "markdown"],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Rich Text Format"
             }
           }
         ],

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -23545,20 +23545,7 @@
               }
             ],
             "default": "",
-            "features": [
-              "embed",
-              "image",
-              "hr",
-              "link",
-              "bold",
-              "italic",
-              "h2",
-              "h3",
-              "h4",
-              "ol",
-              "ul",
-              "document-link"
-            ],
+            "features": ["image", "italic", "link", "quotation", "embed"],
             "title": "Rich Body"
           },
           "sections": {
@@ -23660,20 +23647,7 @@
               }
             ],
             "default": "",
-            "features": [
-              "embed",
-              "image",
-              "hr",
-              "link",
-              "bold",
-              "italic",
-              "h2",
-              "h3",
-              "h4",
-              "ol",
-              "ul",
-              "document-link"
-            ],
+            "features": ["image", "italic", "link", "quotation", "embed"],
             "title": "Rich Body"
           },
           "sections": {
@@ -23732,20 +23706,7 @@
                 "type": "null"
               }
             ],
-            "features": [
-              "embed",
-              "image",
-              "hr",
-              "link",
-              "bold",
-              "italic",
-              "h2",
-              "h3",
-              "h4",
-              "ol",
-              "ul",
-              "document-link"
-            ],
+            "features": ["image", "italic", "link", "quotation", "embed"],
             "title": "Rich Body"
           },
           "sections": {

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -15312,6 +15312,7 @@
             "$ref": "#/components/schemas/ContentTypeSchema"
           },
           "content_object": {
+            "description": "A union of models, discriminated by the content type in `meta.type`.",
             "oneOf": [
               {
                 "$ref": "#/components/schemas/BasePageSchema"
@@ -16330,6 +16331,7 @@
           },
           "items": {
             "items": {
+              "description": "A union of models, discriminated by the content type in `meta.type`.",
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/AdvertSchema"
@@ -20717,6 +20719,7 @@
             "$ref": "#/components/schemas/ContentTypeSchema"
           },
           "content_object": {
+            "description": "A union of models, discriminated by the content type in `meta.type`.",
             "oneOf": [
               {
                 "$ref": "#/components/schemas/DraftStateCustomPrimaryKeyModelSchema"
@@ -27437,6 +27440,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "description": "A union of models, discriminated by the content type in `meta.type`.",
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/EarlyPageCreateSchema"
@@ -27699,6 +27703,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/BasePageSchema"
@@ -28046,6 +28051,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/BasePageSchema"
@@ -28400,6 +28406,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/BasePageSchema"
@@ -28706,6 +28713,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "description": "A union of models, discriminated by the content type in `meta.type`.",
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/EarlyPagePatchSchema"
@@ -28968,6 +28976,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/BasePageSchema"
@@ -29258,6 +29267,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/BasePageSchema"
@@ -29569,6 +29579,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/BasePageSchema"
@@ -29869,6 +29880,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/BasePageSchema"
@@ -30178,6 +30190,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/BasePageSchema"
@@ -30507,6 +30520,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/BasePageSchema"
@@ -30797,6 +30811,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/BasePageSchema"
@@ -31097,6 +31112,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/BasePageSchema"
@@ -31404,6 +31420,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/BasePageSchema"
@@ -32606,6 +32623,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "description": "A union of models, discriminated by the content type in `meta.type`.",
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/AdvertCreateSchema"
@@ -32637,6 +32655,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/AdvertSchema"
@@ -32780,6 +32799,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/AdvertSchema"
@@ -32866,6 +32886,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "description": "A union of models, discriminated by the content type in `meta.type`.",
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/AdvertPatchSchema"
@@ -32897,6 +32918,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/AdvertSchema"
@@ -33065,6 +33087,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/DraftStateCustomPrimaryKeyModelSchema"
@@ -33132,6 +33155,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/DraftStateCustomPrimaryKeyModelSchema"
@@ -33191,6 +33215,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "A union of models, discriminated by the content type in `meta.type`.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/DraftStateCustomPrimaryKeyModelSchema"

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -2203,7 +2203,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Body",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -2216,8 +2217,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Body"
+            ]
           },
           "carousel_items": {
             "default": [],
@@ -2576,7 +2576,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Intro",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -2589,8 +2590,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Intro"
+            ]
           },
           "meta": {
             "$ref": "#/components/schemas/BlogIndexPageMetaSchema"
@@ -4265,7 +4265,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Body",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -4278,8 +4279,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Body"
+            ]
           },
           "city": {
             "anyOf": [
@@ -6560,7 +6560,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Body",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -6573,8 +6574,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Body"
+            ]
           },
           "id": {
             "title": "Id",
@@ -7801,7 +7801,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Intro",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -7814,8 +7815,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Intro"
+            ]
           },
           "meta": {
             "$ref": "#/components/schemas/EventIndexPageMetaSchema"
@@ -11970,7 +11970,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Body",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -11983,8 +11984,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Body"
+            ]
           },
           "carousel_items": {
             "default": [],
@@ -17925,8 +17925,8 @@
                 "type": "null"
               }
             ],
-            "features": ["quotation", "embed", "made-up-feature"],
-            "title": "Body"
+            "title": "Body",
+            "x-rich-text-features": ["quotation", "embed", "made-up-feature"]
           },
           "id": {
             "title": "Id",
@@ -21465,7 +21465,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Intro",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -21478,8 +21479,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Intro"
+            ]
           },
           "meta": {
             "$ref": "#/components/schemas/StandardIndexPageMetaSchema"
@@ -21987,7 +21987,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Body",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -22000,8 +22001,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Body"
+            ]
           },
           "carousel_items": {
             "default": [],
@@ -22034,7 +22034,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Intro",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -22047,8 +22048,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Intro"
+            ]
           },
           "meta": {
             "$ref": "#/components/schemas/StandardPageMetaSchema"
@@ -23709,8 +23709,14 @@
                 "type": "null"
               }
             ],
-            "features": ["image", "italic", "link", "quotation", "embed"],
-            "title": "Rich Body"
+            "title": "Rich Body",
+            "x-rich-text-features": [
+              "image",
+              "italic",
+              "link",
+              "quotation",
+              "embed"
+            ]
           },
           "sections": {
             "default": [],
@@ -25067,7 +25073,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Body",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -25080,8 +25087,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Body"
+            ]
           },
           "carousel_items": {
             "default": [],
@@ -26145,7 +26151,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Biography",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -26158,8 +26165,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Biography"
+            ]
           },
           "city": {
             "anyOf": [
@@ -26235,7 +26241,8 @@
                 "type": "null"
               }
             ],
-            "features": [
+            "title": "Intro",
+            "x-rich-text-features": [
               "embed",
               "image",
               "hr",
@@ -26248,8 +26255,7 @@
               "ol",
               "ul",
               "document-link"
-            ],
-            "title": "Intro"
+            ]
           },
           "last_name": {
             "maxLength": 255,

--- a/wagtail/api/v3/tests/test_page_input_schemas.py
+++ b/wagtail/api/v3/tests/test_page_input_schemas.py
@@ -262,12 +262,21 @@ class TestRichTextFieldInputSchema(TestSchemaGenerator):
     def test_plain_string_validates(self):
         schema = self.generate(self.make_model())
         instance = schema(body="<p>x</p>")
-        self.assertEqual(instance.body, "<p>x</p>")
+        # Normalizes into an envelope
+        self.assertEqual(instance.body.format, "db_html")
+        self.assertEqual(instance.body.content, "<p>x</p>")
 
     def test_envelope_validates(self):
         schema = self.generate(self.make_model())
         instance = schema(body={"format": "db_html", "content": "<p>x</p>"})
+        self.assertEqual(instance.body.format, "db_html")
         self.assertEqual(instance.body.content, "<p>x</p>")
+
+    def test_normalizes_other_format_into_db_html_envelope(self):
+        schema = self.generate(self.make_model())
+        instance = schema(body={"format": "db_markdown", "content": "**Hi**"})
+        self.assertEqual(instance.body.format, "db_html")
+        self.assertEqual(instance.body.content, "<p><b>Hi</b></p>")
 
     def test_unknown_format_rejected(self):
         from pydantic import ValidationError as PydanticValidationError

--- a/wagtail/api/v3/tests/test_rich_text.py
+++ b/wagtail/api/v3/tests/test_rich_text.py
@@ -65,7 +65,9 @@ class TestV3RichTextWrite(TestV3Base, WagtailTestUtils, TestCase):
         )
         self.assertEqual(response.status_code, 201)
         page = self.model.objects.get(slug="rich")
-        self.assertNotIn("<script", self.body_value(page))
+        value = self.body_value(page)
+        self.assertNotIn("<script", value)
+        self.assertRegex(value, r"^<p data-block-key=\"[a-z0-9]+\">hi alert\(1\)</p>$")
 
     def test_entity_references_survive(self):
         response = self.create_page('<p><a linktype="page" id="2">home</a></p>')

--- a/wagtail/api/v3/tests/test_rich_text.py
+++ b/wagtail/api/v3/tests/test_rich_text.py
@@ -303,8 +303,8 @@ class TestV3RichTextRead(TestV3Base, WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 200)
         read_schema = response.json()["read"]
         body_schema = read_schema["properties"]["body"]
-        self.assertIn("features", body_schema)
-        self.assertIn("bold", body_schema["features"])
+        self.assertIn("x-rich-text-features", body_schema)
+        self.assertIn("bold", body_schema["x-rich-text-features"])
 
 
 class TestV3RichTextBlockRead(TestV3RichTextRead):

--- a/wagtail/api/v3/tests/test_rich_text.py
+++ b/wagtail/api/v3/tests/test_rich_text.py
@@ -17,7 +17,6 @@ from wagtail.test.utils import Page, WagtailTestUtils
 
 class TestV3RichTextWrite(TestV3Base, WagtailTestUtils, TestCase):
     model = DefaultRichTextFieldPage
-    unknown_format_status = 422
 
     def setUp(self):
         super().setUp()
@@ -79,7 +78,7 @@ class TestV3RichTextWrite(TestV3Base, WagtailTestUtils, TestCase):
 
     def test_unknown_format_rejected(self):
         response = self.create_page({"format": "markdown", "content": "# Hi"})
-        self.assert_problem_response(response, status_code=self.unknown_format_status)
+        self.assert_problem_response(response, status_code=422)
 
     def create_page_without_body(self, action=None, **data):
         meta = {
@@ -135,13 +134,48 @@ class TestV3RichTextWrite(TestV3Base, WagtailTestUtils, TestCase):
         self.assertNotIn("<h2>", page.body)
         self.assertNotIn("<b>", page.body)
 
+    def test_with_db_markdown(self):
+        response = self.create_page(
+            {
+                "format": "db_markdown",
+                "content": "# Title\n\n[home](wagtail://page?id=2)",
+            }
+        )
+        self.assertEqual(response.status_code, 201)
+        page = self.model.objects.get(slug="rich")
+        body = self.body_value(page)
+        self.assertNotIn("<h1", body)
+        self.assertIn("Title", body)
+        self.assertIn('linktype="page"', body)
+        self.assertIn('id="2"', body)
+
+    def test_with_incorrect_db_markdown(self, loc=None):
+        response = self.create_page(
+            {
+                "format": "db_markdown",
+                "content": "[home](wagtail://page?)",
+            }
+        )
+        data = self.assert_problem_response(
+            response,
+            status_code=422,
+            detail_contains="Validation failed",
+        )
+        loc = loc or ["body", "data", self.model._meta.label, "body"]
+        self.assertEqual(len(data["errors"]), 1)
+        self.assertEqual(data["errors"][0]["loc"], loc)
+        self.assertIn(
+            "Invalid Markdown in rich text: wagtail://page reference requires id",
+            data["errors"][0]["msg"],
+        )
+        self.assertFalse(self.model.objects.filter(slug="rich").exists())
+
 
 class TestV3RichTextBlockWrite(TestV3RichTextWrite):
     """RichTextBlock counterpart of TestV3RichTextWrite."""
 
     model = DefaultRichBlockFieldPage
     type_name = "tests.DefaultRichBlockFieldPage"
-    unknown_format_status = 400
 
     def build_body(self, value):
         return [{"type": "rich_text", "value": value}]
@@ -196,6 +230,9 @@ class TestV3RichTextBlockWrite(TestV3RichTextWrite):
         value = page.body[0].value.source
         self.assertIn("<h2>", value)
         self.assertIn("<b>", value)
+
+    def test_with_incorrect_db_markdown(self, loc=None):
+        return super().test_with_incorrect_db_markdown(loc=["body-0-value"])
 
 
 class TestV3RichTextRead(TestV3Base, WagtailTestUtils, TestCase):

--- a/wagtail/snippets/api/v3/router.py
+++ b/wagtail/snippets/api/v3/router.py
@@ -12,6 +12,7 @@ from pydantic import PositiveInt
 
 from wagtail.actions import action_registry
 from wagtail.actions.publish_revision import PublishPermissionError
+from wagtail.api.rich_text import RichTextOutputFormat
 from wagtail.api.v3.auth import BearerTokenAuth
 from wagtail.api.v3.form_data import build_model_form, build_model_update_form
 from wagtail.api.v3.pagination import WagtailLimitOffsetPagination
@@ -126,6 +127,7 @@ def list_snippets(
     translation_filter: TranslationFilterSchema = Query(...),  # ty: ignore[call-non-callable]
     ordering: OrderingSchema = Query(...),  # ty: ignore[call-non-callable]
     search: SearchSchema = Query(...),  # ty: ignore[call-non-callable]
+    rich_text_format: RichTextOutputFormat | None = Query(None),  # ty: ignore[call-non-callable]
     **kwargs,
 ):
     pagination_info = cast(
@@ -165,6 +167,7 @@ def get_snippet(
     type: SnippetTypeLiteral,
     pk: str,
     version: Literal["live", "draft"] = Query("live"),  # ty: ignore[call-non-callable]
+    rich_text_format: RichTextOutputFormat | None = Query(None),  # ty: ignore[call-non-callable]
 ):
     model = resolve_model_string(type)
     permission_policy = policy_registry.get_by_type(model)
@@ -192,6 +195,7 @@ def create_snippet(
     request: HttpRequest,
     type: SnippetTypeLiteral,
     data: SnippetCreateSchema = ParamTypeInjectingBody(...),
+    rich_text_format: RichTextOutputFormat | None = Query(None),  # ty: ignore[call-non-callable]
 ):
     model = resolve_model_string(type)
     form = build_model_form(model, data, user=request.user)
@@ -219,6 +223,7 @@ def update_snippet(
     type: SnippetTypeLiteral,
     pk: str,
     data: SnippetUpdateSchema = ParamTypeInjectingBody(...),
+    rich_text_format: RichTextOutputFormat | None = Query(None),  # ty: ignore[call-non-callable]
 ):
     model = resolve_model_string(type)
     instance = get_object_or_404(model, pk=unquote(pk))

--- a/wagtail/snippets/tests/test_api_v3/test_create.py
+++ b/wagtail/snippets/tests/test_api_v3/test_create.py
@@ -24,12 +24,13 @@ class TestV3SnippetCreateBase(TestV3Base, WagtailTestUtils, TestCase):
         super().setUp()
         self.user = self.login()
 
-    def post(self, data):
+    def post(self, data, query_params=""):
         return self.client.post(
             reverse(
                 "wagtailapi_v3:create_snippet",
                 kwargs={"type": self.model._meta.label},
-            ),
+            )
+            + f"?{query_params}",
             data=json.dumps(data),
             content_type="application/json",
         )
@@ -463,8 +464,8 @@ class TestV3SnippetCreateWithRelationsFieldFiltering(TestV3SnippetCreateBase):
 class TestV3SnippetCreateWithRichText(TestV3SnippetCreateBase):
     model = UUIDSnippetWithRelations
 
-    def create_snippet(self, value):
-        return self.post({"text": "Hello", "rich_body": value})
+    def create_snippet(self, value, query_params=""):
+        return self.post({"text": "Hello", "rich_body": value}, query_params)
 
     def test_plain_string_stored_sanitised(self):
         response = self.create_snippet("<p><i>x</i></p><script>alert(1)</script>")
@@ -500,6 +501,16 @@ class TestV3SnippetCreateWithRichText(TestV3SnippetCreateBase):
         response = self.create_snippet({"format": "markdown", "content": "# Hi"})
         self.assert_problem_response(response, status_code=422)
         self.assertFalse(UUIDSnippetWithRelations.objects.exists())
+
+    def test_write_response_honours_format(self):
+        # Write endpoints return the detail schema, so the format applies
+        # there too.
+        response = self.create_snippet(
+            '<p><a linktype="page" id="2">home</a></p>',
+            "rich_text_format=html",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertIn("<a href=", response.json()["rich_body"])
 
     def test_omitted_blank_rich_body_allowed(self):
         # rich_body is blank=True, so omitting it entirely is fine. The

--- a/wagtail/snippets/tests/test_api_v3/test_create.py
+++ b/wagtail/snippets/tests/test_api_v3/test_create.py
@@ -460,6 +460,135 @@ class TestV3SnippetCreateWithRelationsFieldFiltering(TestV3SnippetCreateBase):
         )
 
 
+class TestV3SnippetCreateWithRichText(TestV3SnippetCreateBase):
+    model = UUIDSnippetWithRelations
+
+    def create_snippet(self, value):
+        return self.post({"text": "Hello", "rich_body": value})
+
+    def test_plain_string_stored_sanitised(self):
+        response = self.create_snippet("<p><i>x</i></p><script>alert(1)</script>")
+        self.assertEqual(response.status_code, 201)
+        snippet = UUIDSnippetWithRelations.objects.get(text="Hello")
+        self.assertNotIn("<script", snippet.rich_body)
+        self.assertIn("<i>x</i>", snippet.rich_body)
+
+    def test_feature_restricted_field_strips_out_of_features(self):
+        # bold/h2 are not enabled in rich_body features list
+        response = self.create_snippet("<h2>T</h2><p><b>x</b></p>")
+        self.assertEqual(response.status_code, 201)
+        snippet = UUIDSnippetWithRelations.objects.get(text="Hello")
+        self.assertNotIn("<h2>", snippet.rich_body)
+        self.assertNotIn("<b>", snippet.rich_body)
+
+    def test_envelope_stored_sanitised(self):
+        body = {"format": "db_html", "content": "<p>hi <script>alert(1)</script></p>"}
+        response = self.create_snippet(body)
+        self.assertEqual(response.status_code, 201)
+        snippet = UUIDSnippetWithRelations.objects.get(text="Hello")
+        self.assertNotIn("<script", snippet.rich_body)
+        self.assertIn("hi", snippet.rich_body)
+
+    def test_entity_references_survive(self):
+        response = self.create_snippet('<p><a linktype="page" id="2">home</a></p>')
+        self.assertEqual(response.status_code, 201)
+        snippet = UUIDSnippetWithRelations.objects.get(text="Hello")
+        self.assertIn('linktype="page"', snippet.rich_body)
+        self.assertIn('id="2"', snippet.rich_body)
+
+    def test_unknown_format_rejected(self):
+        response = self.create_snippet({"format": "markdown", "content": "# Hi"})
+        self.assert_problem_response(response, status_code=422)
+        self.assertFalse(UUIDSnippetWithRelations.objects.exists())
+
+    def test_omitted_blank_rich_body_allowed(self):
+        # rich_body is blank=True, so omitting it entirely is fine. The
+        # Draftail widget round-trip normalises the empty value to an empty
+        # paragraph, so what gets stored is not "".
+        response = self.post({"text": "Hello"})
+        self.assertEqual(response.status_code, 201)
+        snippet = UUIDSnippetWithRelations.objects.get(text="Hello")
+        self.assertRegex(snippet.rich_body, r'^<p data-block-key="[a-z0-9]+"></p>$')
+
+
+class TestV3SnippetCreateWithRichTextMarkdown(TestV3SnippetCreateBase):
+    model = UUIDSnippetWithRelations
+
+    def create_snippet(self, content, rich_text_format="db_markdown"):
+        return self.post(
+            {
+                "text": "Hello",
+                "rich_body": {"format": rich_text_format, "content": content},
+            }
+        )
+
+    def test_db_markdown_input_on_create(self):
+        response = self.create_snippet("# Title\n\n[home](wagtail://page?id=2)")
+        self.assertEqual(response.status_code, 201, response.json())
+        snippet = UUIDSnippetWithRelations.objects.get(text="Hello")
+        # h1 is out of the field's features → unwrapped; page reference kept by id
+        self.assertNotIn("<h1", snippet.rich_body)
+        self.assertIn("Title", snippet.rich_body)
+        self.assertIn('linktype="page"', snippet.rich_body)
+        self.assertIn('id="2"', snippet.rich_body)
+
+    def test_malformed_reference_gives_422_with_field_and_line(self):
+        response = self.create_snippet("[x](wagtail://page?id=abc)")
+        self.assert_problem_response(
+            response,
+            status_code=422,
+            detail_contains="Validation failed",
+            errors=[
+                {
+                    "type": "value_error",
+                    "loc": [
+                        "body",
+                        "data",
+                        "tests.UUIDSnippetWithRelations",
+                        "rich_body",
+                    ],
+                    "msg": (
+                        "Value error, Invalid Markdown in rich text at line 1: "
+                        "Entity resolver failed for URL 'wagtail://page?id=abc': "
+                        "invalid literal for int() with base 10: 'abc'"
+                    ),
+                }
+            ],
+        )
+
+    def test_wagtail_ref_without_id_gives_422(self):
+        # A wagtail:// reference missing its id must fail validation, never 500.
+        response = self.create_snippet("[x](wagtail://page)")
+        self.assert_problem_response(
+            response,
+            status_code=422,
+            detail_contains="Validation failed",
+            errors=[
+                {
+                    "type": "value_error",
+                    "loc": [
+                        "body",
+                        "data",
+                        "tests.UUIDSnippetWithRelations",
+                        "rich_body",
+                    ],
+                    "msg": (
+                        "Value error, Invalid Markdown in rich text: "
+                        "wagtail://page reference requires id"
+                    ),
+                }
+            ],
+        )
+
+    def test_empty_image_format_stripped_not_stored(self):
+        # `format=` (empty) behaves like a missing format: the embed is
+        # dropped, never stored verbatim to poison later output.
+        response = self.create_snippet("![a](wagtail://image?id=1&format=)")
+        self.assertEqual(response.status_code, 201, response.json())
+        snippet = UUIDSnippetWithRelations.objects.get(text="Hello")
+        self.assertNotIn('format=""', snippet.rich_body)
+
+
 class TestV3SnippetCreateWithDraftState(TestV3SnippetCreateBase):
     """meta.action support for DraftStateMixin snippets."""
 

--- a/wagtail/snippets/tests/test_api_v3/test_detail.py
+++ b/wagtail/snippets/tests/test_api_v3/test_detail.py
@@ -8,22 +8,28 @@ from wagtail.test.testapp.models import (
     Advert,
     AdvertWithCustomPrimaryKey,
     FullFeaturedSnippet,
+    UUIDSnippetWithRelations,
 )
-from wagtail.test.utils import WagtailTestUtils
+from wagtail.test.utils import Page, WagtailTestUtils
 
 
-class TestV3SnippetDetail(TestV3Base, WagtailTestUtils, TestCase):
-    def setUp(self):
-        super().setUp()
-        self.advert = Advert.objects.create(text="Advert 1", url="https://wagtail.org")
+class TestV3SnippetDetailBase(TestV3Base, WagtailTestUtils, TestCase):
+    model = Advert
 
-    def get_response(self, pk):
+    def get_response(self, pk=None, **params):
         return self.client.get(
             reverse(
                 "wagtailapi_v3:detail_snippet",
-                kwargs={"type": "tests.Advert", "pk": pk},
-            )
+                kwargs={"type": self.model._meta.label, "pk": pk or self.snippet.pk},
+            ),
+            params,
         )
+
+
+class TestV3SnippetDetail(TestV3SnippetDetailBase):
+    def setUp(self):
+        super().setUp()
+        self.advert = Advert.objects.create(text="Advert 1", url="https://wagtail.org")
 
     def test_anonymous_returns_401(self):
         response = self.get_response(self.advert.pk)
@@ -94,6 +100,85 @@ class TestV3SnippetDetail(TestV3Base, WagtailTestUtils, TestCase):
             f"/api/v3/snippets/tests.Advert/{self.advert.pk}/",
             content["meta"]["detail_url"],
         )
+
+
+class TestV3SnippetDetailWithRichText(TestV3SnippetDetailBase):
+    model = UUIDSnippetWithRelations
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.home_page = Page.objects.get(depth=2)
+        cls.snippet = cls.model.objects.create(
+            text="Hello", rich_body=cls.build_rich_body()
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.login()
+
+    @classmethod
+    def build_rich_body(cls):
+        return f'<p><a linktype="page" id="{cls.home_page.pk}">home</a></p>'
+
+    def body_value(self, response):
+        return response.json()["rich_body"]
+
+    def test_default_output_is_db_html(self):
+        response = self.get_response()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.body_value(response), self.build_rich_body())
+
+    def test_html_output_expands_references(self):
+        response = self.get_response(rich_text_format="html")
+        self.assertEqual(response.status_code, 200)
+        body = self.body_value(response)
+        self.assertIn("<a href=", body)
+        self.assertNotIn("linktype", body)
+
+    def test_invalid_format_is_422_problem_json(self):
+        response = self.get_response(rich_text_format="nope")
+        self.assert_problem_response(
+            response,
+            status_code=422,
+            detail_contains="Validation failed",
+            errors=[
+                {
+                    "type": "literal_error",
+                    "loc": ["query", "rich_text_format"],
+                    "msg": "Input should be 'db_html', 'html', 'db_markdown' or 'markdown'",
+                }
+            ],
+        )
+
+    @override_settings(WAGTAILAPI_RICH_TEXT_FORMAT="html")
+    def test_project_wide_default_setting(self):
+        response = self.get_response()
+        self.assertIn("<a href=", self.body_value(response))
+
+    def test_db_markdown_output_on_detail(self):
+        response = self.get_response(rich_text_format="db_markdown")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            self.body_value(response),
+            "[home](wagtail://page?id=%d)\n\n" % self.home_page.pk,
+        )
+
+    def test_markdown_output_resolves_reference(self):
+        response = self.get_response(rich_text_format="markdown")
+        home_url = self.home_page.url or "/"
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.body_value(response), "[home](%s)\n\n" % home_url)
+
+    def test_output_uses_field_features(self):
+        # rich_body does not declare h2 in features, so the stored <h2> cannot
+        # convert to a contentstate heading and must not appear as `## ` in
+        # markdown output. (ORM save stores verbatim.)
+        self.snippet.rich_body = "<h2>Title</h2>"
+        self.snippet.save()
+        response = self.get_response(rich_text_format="db_markdown")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("## ", self.body_value(response))
+        self.assertIn("Title", self.body_value(response))
 
 
 class TestV3SnippetDetailVersion(TestV3Base, WagtailTestUtils, TestCase):

--- a/wagtail/snippets/tests/test_api_v3/test_listing.py
+++ b/wagtail/snippets/tests/test_api_v3/test_listing.py
@@ -10,8 +10,9 @@ from wagtail.test.testapp.models import (
     Advert,
     AdvertWithCustomPrimaryKey,
     FullFeaturedSnippet,
+    UUIDSnippetWithRelations,
 )
-from wagtail.test.utils import WagtailTestUtils
+from wagtail.test.utils import Page, WagtailTestUtils
 
 
 class TestV3SnippetListingBase(TestV3Base, WagtailTestUtils):
@@ -515,3 +516,40 @@ class TestV3SnippetListingSearch(TestV3SnippetListingBase, TransactionTestCase):
 
         content = self.get_response(translation_of=self.apple.pk, search="zebra").json()
         self.assertEqual(self.get_id_list(content), [])
+
+
+class TestV3SnippetListingWithRichText(TestV3SnippetListingBase, TestCase):
+    # Unlike the pages listing, the snippets listing serialises the full
+    # detail schema (including api_fields), so rich_text_format applies
+    # here as well as on the detail endpoint.
+    model = UUIDSnippetWithRelations
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.home_page = Page.objects.get(depth=2)
+        cls.snippet = cls.model.objects.create(
+            text="Hello",
+            rich_body=f'<p><a linktype="page" id="{cls.home_page.pk}">home</a></p>',
+        )
+
+    def test_listing_applies_rich_text_format(self):
+        response = self.get_response(rich_text_format="html")
+        self.assertEqual(response.status_code, 200)
+        body = response.json()["items"][0]["rich_body"]
+        self.assertIn("<a href=", body)
+        self.assertNotIn("linktype", body)
+
+    def test_listing_invalid_rich_text_format_is_422(self):
+        response = self.get_response(rich_text_format="nope")
+        self.assert_problem_response(
+            response,
+            status_code=422,
+            detail_contains="Validation failed",
+            errors=[
+                {
+                    "type": "literal_error",
+                    "loc": ["query", "rich_text_format"],
+                    "msg": "Input should be 'db_html', 'html', 'db_markdown' or 'markdown'",
+                }
+            ],
+        )

--- a/wagtail/snippets/tests/test_api_v3/test_update.py
+++ b/wagtail/snippets/tests/test_api_v3/test_update.py
@@ -578,6 +578,150 @@ class TestV3SnippetUpdateWithRelations(TestV3SnippetUpdateBase):
         )
 
 
+class TestV3SnippetUpdateWithRichText(TestV3SnippetUpdateBase):
+    model = UUIDSnippetWithRelations
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.snippet = UUIDSnippetWithRelations.objects.create(
+            text="Hello", rich_body="<p>original</p>"
+        )
+
+    def patch_rich_body(self, value):
+        return self.patch(self.snippet.pk, {"rich_body": value})
+
+    def test_plain_string_stored_sanitised(self):
+        response = self.patch_rich_body("<p><i>x</i></p><script>alert(1)</script>")
+        self.assertEqual(response.status_code, 200)
+        self.snippet.refresh_from_db()
+        self.assertNotIn("<script", self.snippet.rich_body)
+        self.assertIn("<i>x</i>", self.snippet.rich_body)
+
+    def test_feature_restricted_field_strips_out_of_features(self):
+        # bold/h2 are not enabled in rich_body features list
+        response = self.patch_rich_body("<h2>T</h2><p><b>x</b></p>")
+        self.assertEqual(response.status_code, 200)
+        self.snippet.refresh_from_db()
+        self.assertNotIn("<h2>", self.snippet.rich_body)
+        self.assertNotIn("<b>", self.snippet.rich_body)
+
+    def test_envelope_stored_sanitised(self):
+        response = self.patch_rich_body(
+            {"format": "db_html", "content": "<p>hi <script>alert(1)</script></p>"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.snippet.refresh_from_db()
+        self.assertNotIn("<script", self.snippet.rich_body)
+        self.assertIn("hi", self.snippet.rich_body)
+
+    def test_entity_references_survive(self):
+        response = self.patch_rich_body('<p><a linktype="page" id="2">home</a></p>')
+        self.assertEqual(response.status_code, 200)
+        self.snippet.refresh_from_db()
+        self.assertIn('linktype="page"', self.snippet.rich_body)
+        self.assertIn('id="2"', self.snippet.rich_body)
+
+    def test_unknown_format_rejected(self):
+        response = self.patch_rich_body({"format": "markdown", "content": "# Hi"})
+        self.assert_problem_response(response, status_code=422)
+        self.snippet.refresh_from_db()
+        self.assertEqual(self.snippet.rich_body, "<p>original</p>")
+
+    def test_rich_body_untouched_when_omitted(self):
+        response = self.patch(self.snippet.pk, {"text": "Updated"})
+        self.assertEqual(response.status_code, 200)
+        self.snippet.refresh_from_db()
+        self.assertEqual(self.snippet.text, "Updated")
+        self.assertEqual(self.snippet.rich_body, "<p>original</p>")
+
+    def test_rich_body_cleared_with_empty_string(self):
+        # The Draftail widget round-trip normalises the empty value to an
+        # empty paragraph, so what gets stored is not "".
+        response = self.patch_rich_body("")
+        self.assertEqual(response.status_code, 200)
+        self.snippet.refresh_from_db()
+        self.assertRegex(
+            self.snippet.rich_body,
+            r'^<p data-block-key="[a-z0-9]+"></p>$',
+        )
+
+
+class TestV3SnippetUpdateWithRichTextMarkdown(TestV3SnippetUpdateBase):
+    model = UUIDSnippetWithRelations
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.snippet = UUIDSnippetWithRelations.objects.create(
+            text="Hello", rich_body="<p>original</p>"
+        )
+
+    def patch_rich_body(self, content, rich_text_format="db_markdown"):
+        return self.patch(
+            self.snippet.pk,
+            {"rich_body": {"format": rich_text_format, "content": content}},
+        )
+
+    def test_db_markdown_input_on_patch(self):
+        response = self.patch_rich_body("*after*")
+        self.assertEqual(response.status_code, 200, response.json())
+        self.snippet.refresh_from_db()
+        self.assertNotIn("original", self.snippet.rich_body)
+        # italic is in the field's features, so *after* becomes <i> markup
+        self.assertIn("<i>after</i>", self.snippet.rich_body)
+
+    def test_malformed_reference_gives_422_with_field_and_line(self):
+        response = self.patch_rich_body("[x](wagtail://page?id=abc)")
+        self.assert_problem_response(
+            response,
+            status_code=422,
+            detail_contains="Validation failed",
+            errors=[
+                {
+                    "type": "value_error",
+                    "loc": [
+                        "body",
+                        "data",
+                        "tests.UUIDSnippetWithRelations",
+                        "rich_body",
+                    ],
+                    "msg": (
+                        "Value error, Invalid Markdown in rich text at line 1: "
+                        "Entity resolver failed for URL 'wagtail://page?id=abc': "
+                        "invalid literal for int() with base 10: 'abc'"
+                    ),
+                }
+            ],
+        )
+        self.snippet.refresh_from_db()
+        self.assertEqual(self.snippet.rich_body, "<p>original</p>")
+
+    def test_wagtail_ref_without_id_gives_422(self):
+        # A wagtail:// reference missing its id must fail validation, never 500.
+        response = self.patch_rich_body("[x](wagtail://page)")
+        self.assert_problem_response(
+            response,
+            status_code=422,
+            detail_contains="Validation failed",
+            errors=[
+                {
+                    "type": "value_error",
+                    "loc": [
+                        "body",
+                        "data",
+                        "tests.UUIDSnippetWithRelations",
+                        "rich_body",
+                    ],
+                    "msg": (
+                        "Value error, Invalid Markdown in rich text: "
+                        "wagtail://page reference requires id"
+                    ),
+                }
+            ],
+        )
+        self.snippet.refresh_from_db()
+        self.assertEqual(self.snippet.rich_body, "<p>original</p>")
+
+
 class TestV3SnippetUpdateWithDraftState(TestV3SnippetUpdateBase):
     """meta.action support for DraftStateMixin snippets."""
 

--- a/wagtail/snippets/tests/test_api_v3/test_update.py
+++ b/wagtail/snippets/tests/test_api_v3/test_update.py
@@ -28,12 +28,13 @@ class TestV3SnippetUpdateBase(TestV3Base, WagtailTestUtils, TestCase):
         super().setUp()
         self.user = self.login()
 
-    def patch(self, pk, data):
+    def patch(self, pk, data, query_params=""):
         return self.client.patch(
             reverse(
                 "wagtailapi_v3:update_snippet",
                 kwargs={"type": self.model._meta.label, "pk": pk},
-            ),
+            )
+            + f"?{query_params}",
             data=json.dumps(data),
             content_type="application/json",
         )
@@ -587,8 +588,8 @@ class TestV3SnippetUpdateWithRichText(TestV3SnippetUpdateBase):
             text="Hello", rich_body="<p>original</p>"
         )
 
-    def patch_rich_body(self, value):
-        return self.patch(self.snippet.pk, {"rich_body": value})
+    def patch_rich_body(self, value, query_params=""):
+        return self.patch(self.snippet.pk, {"rich_body": value}, query_params)
 
     def test_plain_string_stored_sanitised(self):
         response = self.patch_rich_body("<p><i>x</i></p><script>alert(1)</script>")
@@ -644,6 +645,16 @@ class TestV3SnippetUpdateWithRichText(TestV3SnippetUpdateBase):
             self.snippet.rich_body,
             r'^<p data-block-key="[a-z0-9]+"></p>$',
         )
+
+    def test_write_response_honours_format(self):
+        # Write endpoints return the detail schema, so the format applies
+        # there too.
+        response = self.patch_rich_body(
+            '<p><a linktype="page" id="2">home</a></p>',
+            "rich_text_format=html",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("<a href=", response.json()["rich_body"])
 
 
 class TestV3SnippetUpdateWithRichTextMarkdown(TestV3SnippetUpdateBase):

--- a/wagtail/test/testapp/migrations/0062_uuidsnippetwithrelations_and_more.py
+++ b/wagtail/test/testapp/migrations/0062_uuidsnippetwithrelations_and_more.py
@@ -34,7 +34,13 @@ class Migration(migrations.Migration):
                 ("text", models.CharField(max_length=255)),
                 ("subtitle", models.CharField(blank=True, max_length=255)),
                 ("intro", models.CharField(blank=True, max_length=255)),
-                ("rich_body", wagtail.fields.RichTextField(blank=True)),
+                (
+                    "rich_body",
+                    wagtail.fields.RichTextField(
+                        blank=True,
+                        features=["image","italic", "link", "quotation", "embed"],
+                    ),
+                ),
                 (
                     "body",
                     wagtail.fields.StreamField(

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -1189,7 +1189,10 @@ class UUIDSnippetWithRelations(index.Indexed, ClusterableModel):
     text = models.CharField(max_length=255)
     subtitle = models.CharField(max_length=255, blank=True)
     intro = models.CharField(max_length=255, blank=True)
-    rich_body = RichTextField(blank=True)
+    rich_body = RichTextField(
+        blank=True,
+        features=["image", "italic", "link", "quotation", "embed"],
+    )
     feed_image = models.ForeignKey(
         Image,
         null=True,


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Ref #14504

### Description

<!-- Please describe the problem you're fixing. -->
This allows rich text content to properly go through the conversion process if the schema was generated using the generator.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->

Implementation changes were written by me with GitHub Copilot for code autocompletion, while the tests were written by Kimi K3 via Pi.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>