### PR TITLE
Fix locales listing to show all items without pagination (#14399)

### DIFF
--- a/wagtail/locales/tests/test_admin_views.py
+++ b/wagtail/locales/tests/test_admin_views.py
@@ -43,6 +43,24 @@ class TestLocaleIndexView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         Locale.objects.create(language_code="de")
         self.assertContains(self.get(), self.add_url)
 
+    def test_index_view_shows_all_locales_without_pagination(self):
+        """
+        Verify that the locales listing shows all locales without pagination.
+        Regression test for https://github.com/wagtail/wagtail/issues/14399
+        """
+        # Create more than 20 locales to exceed the default page size
+        language_codes = [f"lang{i}" for i in range(25)]
+        for code in language_codes:
+            Locale.objects.create(language_code=code)
+
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+
+        # All locales should be shown (25 created + 1 default "en" = 26)
+        # The page should NOT be paginated
+        self.assertFalse(response.context["is_paginated"])
+        self.assertEqual(len(response.context["table"].data), 26)
+
 
 class TestLocaleCreateView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
     def setUp(self):

--- a/wagtail/locales/views.py
+++ b/wagtail/locales/views.py
@@ -127,6 +127,7 @@ class LocaleViewSet(ModelViewSet):
     icon = "site"
     model = Locale
     add_to_reference_index = False
+    list_per_page = None
 
     index_view_class = IndexView
     add_view_class = CreateView


### PR DESCRIPTION
Fixes wagtail/wagtail-localize#950

## Summary

The locales listing was capped at 20 items with no pagination controls, because `LocaleViewSet` inherited the default `list_per_page = 20` from `ModelViewSet`.

Since locales are a small, finite set tied to content languages, this PR sets `list_per_page = None` to show all locales without pagination.

## Changes

- `wagtail/locales/views.py`: Added `list_per_page = None` to `LocaleViewSet`
- `wagtail/locales/tests/test_admin_views.py`: Added regression test that creates 25+ locales and verifies all are shown without pagination

## Testing

All 23 locale tests pass:


This pull request includes code written with the assistance of AI.