### PR TITLE
Document ShowInMenusMixin and DefaultBasePageMixin

### DIFF
--- a/docs/advanced_topics/customization/custom_base_page_models.md
+++ b/docs/advanced_topics/customization/custom_base_page_models.md
@@ -29,7 +29,9 @@ class BasePage(AbstractPage):
     promote_panels = AbstractPage.promote_panels + ["category", "review_date"]
 ```
 
-`AbstractPage` provides all of the standard fields from {class}`~wagtail.models.Page` with the exception of `show_in_menus`, `seo_title` and `search_description`.
+```{note}
+`AbstractPage` provides all of the standard fields from {class}`~wagtail.models.Page` with the exception of `show_in_menus`, `seo_title` and `search_description`. This means that the {meth}`~wagtail.query.PageQuerySet.in_menu` and {meth}`~wagtail.query.PageQuerySet.not_in_menu` methods will not work. To include the show-in-menu flag in your page model, set your class to inherit from both `AbstractPage` and {class}`~wagtail.models.ShowInMenusMixin`. To include all the default fields from `Page`, inherit from both `AbstractPage` and {class}`~wagtail.models.DefaultBasePageMixin`.
+```
 
 Add the setting `WAGTAIL_PAGE_MODEL` to your project's settings file, giving the dotted {attr}`~django.db.models.Options.label` of the base page model qualified by the app name:
 

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -118,19 +118,7 @@ This document contains reference information for the model classes inside the `w
 
         A ``translation_key`` value can only be used on one page in each locale.
 
-.. class:: Page
-
-    .. attribute:: seo_title
-
-        (text)
-
-        Alternate SEO-crafted title, for use in the page's ``<title>`` HTML tag.
-
-    .. attribute:: search_description
-
-        (text)
-
-        SEO-crafted description of the content, used for search indexing. This is also suitable for the page's ``<meta name="description">`` HTML tag.
+.. class:: ShowInMenusMixin
 
     .. attribute:: show_in_menus
 
@@ -148,6 +136,23 @@ This document contains reference information for the model classes inside the `w
 
             To set the global default for all pages, set ``Page.show_in_menus_default = True`` once where you first import the ``Page`` model.
 
+.. class:: DefaultBasePageMixin
+
+    .. attribute:: seo_title
+
+        (text)
+
+        Alternate SEO-crafted title, for use in the page's ``<title>`` HTML tag.
+
+    .. attribute:: search_description
+
+        (text)
+
+        SEO-crafted description of the content, used for search indexing. This is also suitable for the page's ``<meta name="description">`` HTML tag.
+
+.. class:: Page
+
+    The standard base page model that all page types descend from, unless overridden with :ref:`wagtail_page_model` (see :ref:`custom_page_models`).
 ```
 
 ### Methods and properties

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -262,6 +262,16 @@ DATETIME_INPUT_FORMATS = [
 
 ## Page editing
 
+(wagtail_page_model)=
+
+### `WAGTAIL_PAGE_MODEL`
+
+```python
+WAGTAIL_PAGE_MODEL = "basepage.BasePage"
+```
+
+Specifies a base page model to use in place of {class}`~wagtail.models.Page`. See [](custom_page_models).
+
 ### `WAGTAILADMIN_COMMENTS_ENABLED`
 
 ```python


### PR DESCRIPTION
### Description

As suggested by @lasse-cs in https://github.com/wagtail/wagtail/discussions/14501#discussioncomment-18077063 - document the mixins that allow restoring the show-in-menu flag and other fields to custom base page models.

### AI usage

Claude Code to help with Myst/Restructuredtext cross-reference syntax. All text is mine.