### PR TITLE
Use non-ARM runner for CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ jobs:
       security-events: write # to upload SARIF results (github/codeql-action/analyze)
 
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-26.04-arm
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:
@@ -36,12 +36,12 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: '/language:${{matrix.language}}'


### PR DESCRIPTION
### Description

#14506 switched the GitHub Actions to ARM, however the CodeQL CLI doesn't support ARM. See https://codeql.github.com/docs/codeql-overview/system-requirements/

Failed workflow run: https://github.com/wagtail/wagtail/actions/runs/32231548808

While here, I've bumped the action version https://github.com/github/codeql-action/releases/tag/v4.37.7

### AI usage

This PR has been lovingly hand-crafted