### PR TITLE
Adds the same cache check before setting found in get_renditions to get_rendition

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -557,10 +557,11 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
             # Reuse this rendition if requested again from this object
             self._add_to_prefetched_renditions(rendition)
 
-        cache_key = Rendition.construct_cache_key(
-            self, filter.get_cache_key(self), filter.spec
-        )
-        Rendition.cache_backend.set(cache_key, rendition)
+        if not getattr(rendition, "_from_cache", False):
+            cache_key = Rendition.construct_cache_key(
+                self, filter.get_cache_key(self), filter.spec
+            )
+            Rendition.cache_backend.set(cache_key, rendition)
 
         return rendition
 


### PR DESCRIPTION
### Description

`AbstractImage.get_rendition()` calls a set on the cache even when the rendition has `_from_cache=True` set. `AbstractImage.get_renditions()` has a check for this but the singular doesn't. This is the one used by the `{% image %}` template tag


### AI usage

Claude was used to go through server log files and git commits to find cache writes against a remote cache were causing a slowdown and where the cache write was.
