### PR TITLE
Prevent page explorer from reopening when toggled

### DIFF
--- a/client/src/components/PageExplorer/PageExplorerPanel.test.js
+++ b/client/src/components/PageExplorer/PageExplorerPanel.test.js
@@ -31,6 +31,21 @@ describe('PageExplorerPanel', () => {
       expect(shallow(<PageExplorerPanel {...mockProps} />)).toMatchSnapshot();
     });
 
+    it('keeps the focus trap active when the page explorer button is clicked', () => {
+      document.body.innerHTML = `
+        <li class="sidebar-page-explorer-item"><button type="button"></button></li>
+      `;
+      const wrapper = shallow(<PageExplorerPanel {...mockProps} />);
+      const clickOutsideDeactivates = wrapper
+        .find('FocusTrap')
+        .prop('focusTrapOptions').clickOutsideDeactivates;
+
+      expect(
+        clickOutsideDeactivates({ target: document.querySelector('button') }),
+      ).toBe(false);
+      expect(clickOutsideDeactivates({ target: document.body })).toBe(true);
+    });
+
     it('#isFetching', () => {
       expect(
         shallow(

--- a/client/src/components/PageExplorer/PageExplorerPanel.tsx
+++ b/client/src/components/PageExplorer/PageExplorerPanel.tsx
@@ -125,7 +125,10 @@ class PageExplorerPanel extends React.Component<
         paused={!page || page.isFetchingChildren || page.isFetchingTranslations}
         focusTrapOptions={{
           onDeactivate: onClose,
-          clickOutsideDeactivates: true,
+          clickOutsideDeactivates: (event) =>
+            !(event.target as Element).closest(
+              '.sidebar-page-explorer-item > button',
+            ),
           allowOutsideClick: true,
         }}
       >

--- a/client/src/components/PageExplorer/__snapshots__/PageExplorerPanel.test.js.snap
+++ b/client/src/components/PageExplorer/__snapshots__/PageExplorerPanel.test.js.snap
@@ -7,7 +7,7 @@ exports[`PageExplorerPanel general rendering #isError 1`] = `
   focusTrapOptions={
     {
       "allowOutsideClick": true,
-      "clickOutsideDeactivates": true,
+      "clickOutsideDeactivates": [Function],
       "onDeactivate": [MockFunction],
     }
   }
@@ -82,7 +82,7 @@ exports[`PageExplorerPanel general rendering #isFetching 1`] = `
   focusTrapOptions={
     {
       "allowOutsideClick": true,
-      "clickOutsideDeactivates": true,
+      "clickOutsideDeactivates": [Function],
       "onDeactivate": [MockFunction],
     }
   }
@@ -138,7 +138,7 @@ exports[`PageExplorerPanel general rendering #items 1`] = `
   focusTrapOptions={
     {
       "allowOutsideClick": true,
-      "clickOutsideDeactivates": true,
+      "clickOutsideDeactivates": [Function],
       "onDeactivate": [MockFunction],
     }
   }
@@ -222,7 +222,7 @@ exports[`PageExplorerPanel general rendering no children 1`] = `
   focusTrapOptions={
     {
       "allowOutsideClick": true,
-      "clickOutsideDeactivates": true,
+      "clickOutsideDeactivates": [Function],
       "onDeactivate": [MockFunction],
     }
   }
@@ -275,7 +275,7 @@ exports[`PageExplorerPanel general rendering renders 1`] = `
   focusTrapOptions={
     {
       "allowOutsideClick": true,
-      "clickOutsideDeactivates": true,
+      "clickOutsideDeactivates": [Function],
       "onDeactivate": [MockFunction],
     }
   }


### PR DESCRIPTION
### Description

Clicking the **Pages** sidebar button while the Page Explorer was open caused it to close and immediately reopen. The focus trap handled the pointer event first and reset the sidebar navigation state, so the button's click handler treated the explorer as closed and opened it again.

This keeps the focus trap active when the outside click comes from the Page Explorer's own sidebar button. The button can then use its existing toggle behavior to close the explorer. Other outside clicks continue to deactivate the focus trap.

A regression test covers both the Pages button and other outside clicks.

### Fixes #14542 

### Testing

- `npx jest client/src/components/PageExplorer/PageExplorerPanel.test.js --runInBand`
- `npx eslint --report-unused-disable-directives client/src/components/PageExplorer/PageExplorerPanel.tsx client/src/components/PageExplorer/PageExplorerPanel.test.js`
- `npm run lint:ts`
- `npm run build`
- Checked in the local Wagtail admin that clicking **Pages** twice changes `aria-expanded` from `false` to `true` and back to `false`.
- Checked that clicking **Search** still closes the Page Explorer.

### AI usage

This code has been reviewed and observed by me, AI helped me to resolve this

### Video Proof

https://github.com/user-attachments/assets/66036fda-5ee6-4e28-a6ad-7cb7ec0de799

