### PR TITLE
Fix Pages sidebar button not closing Page Explorer on second click (#14542)

### DIFF
--- a/client/src/components/PageExplorer/PageExplorerPanel.test.js
+++ b/client/src/components/PageExplorer/PageExplorerPanel.test.js
@@ -164,4 +164,29 @@ describe('PageExplorerPanel', () => {
       expect(wrapper.setProps({ depth: 0 }).state('transition')).toBe('pop');
     });
   });
+
+  describe('FocusTrap options', () => {
+    it('clickOutsideDeactivates ignores click on Pages trigger button', () => {
+      const wrapper = shallow(<PageExplorerPanel {...mockProps} />);
+      const focusTrapOptions =
+        wrapper.find('FocusTrap').prop('focusTrapOptions');
+
+      const button = document.createElement('button');
+      button.className = 'sidebar-menu-item__link';
+      const li = document.createElement('li');
+      li.className = 'sidebar-page-explorer-item';
+      li.appendChild(button);
+
+      // Should return false for clicks inside the Pages button
+      expect(
+        focusTrapOptions.clickOutsideDeactivates({ target: button }),
+      ).toBe(false);
+
+      // Should return true for clicks outside the Pages button
+      const outsideElement = document.createElement('div');
+      expect(
+        focusTrapOptions.clickOutsideDeactivates({ target: outsideElement }),
+      ).toBe(true);
+    });
+  });
 });

--- a/client/src/components/PageExplorer/PageExplorerPanel.tsx
+++ b/client/src/components/PageExplorer/PageExplorerPanel.tsx
@@ -125,7 +125,12 @@ class PageExplorerPanel extends React.Component<
         paused={!page || page.isFetchingChildren || page.isFetchingTranslations}
         focusTrapOptions={{
           onDeactivate: onClose,
-          clickOutsideDeactivates: true,
+          clickOutsideDeactivates: (event) => {
+            const target = event.target as HTMLElement | null;
+            return !target?.closest(
+              '.sidebar-page-explorer-item .sidebar-menu-item__link',
+            );
+          },
           allowOutsideClick: true,
         }}
       >


### PR DESCRIPTION
Fixes #14542

### Description

When the Page Explorer side panel is open, clicking the **Pages** button in the Wagtail admin sidebar a second time caused it to briefly close and immediately reopen, leaving `aria-expanded="true"`.

#### Cause:
The `<FocusTrap>` component in `PageExplorerPanel` was configured with `clickOutsideDeactivates: true`. When clicking the Pages toggle button, FocusTrap detected an outside click and deactivated first (setting Redux `navigationPath` to `''`). Immediately afterwards, the toggle button's own `onClick` handler executed. Because `isOpen` was now `false`, `onClick` interpreted the menu as closed and dispatched `set-navigation-path` (`path: '.explorer'`), reopening it.

#### Solution:
Changed `clickOutsideDeactivates` in `PageExplorerPanel` to a predicate function that returns `false` when the click target is the Pages sidebar trigger button (`.sidebar-page-explorer-item .sidebar-menu-item__link`). This prevents FocusTrap from racing with the button's native `onClick` handler, allowing the button to cleanly toggle the menu closed.

### AI usage

Used a little Claude to understand the codebase and help trace the focus-trap event handling.
