### PR TITLE
Gate v3 API OpenAPI schema and docs behind a on/off setting

### DIFF
--- a/docs/advanced_topics/api/v3/index.md
+++ b/docs/advanced_topics/api/v3/index.md
@@ -57,7 +57,9 @@ This will expose all endpoints at the API root you decided. This includes read-o
 To get started, browse the generated docs:
 
 - A human-friendly documentation dashboard at `<API root>/docs/`
-- A machine-readable OpenAPI schema at `<API root>/openapi.json`.
+- A machine-readable OpenAPI schema at `<API root>/openapi.json`
+
+The OpenAPI schema (`<API root>/openapi.json`) and the interactive docs dashboard (`<API root>/docs/`) are publicly available, including descriptions of both anonymous and authenticated endpoints. To add a layer of obscurity, you can set the [`WAGTAILAPI_DOCS_ENABLED`](wagtailapi_settings) setting to `False` to disable both routes.
 
 The v3 API reads the same `WAGTAILAPI_*` settings as v2 where applicable (`WAGTAILAPI_BASE_URL`, `WAGTAILAPI_LIMIT_MAX`, `WAGTAILAPI_SEARCH_ENABLED`, `WAGTAILAPI_RICH_TEXT_FORMAT`). See [](api_v2_configuration) and the [API settings reference](wagtailapi_settings).
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -922,6 +922,14 @@ WAGTAILAPI_TOKEN_LAST_USED_INTERVAL = 60
 
 Applies to the v3 API only. How often an API token's `last_used_at` timestamp is updated, in seconds (default `60`). Successful authenticated requests update the timestamp at most once per this interval per token, limiting database writes on busy APIs. Set to `None` to disable these updates entirely, for example on sites running with a read-only production database. See [](api_v3_authentication).
 
+### `WAGTAILAPI_DOCS_ENABLED`
+
+```python
+WAGTAILAPI_DOCS_ENABLED = False
+```
+
+Applies to the v3 API only. Sets whether the API serves [OpenAPI schema and interactive docs](api_v3) or not. Defaults to `True`.
+
 ## Frontend cache
 
 For full documentation on frontend cache invalidation, including these settings, see [](frontend_cache_purging).

--- a/wagtail/api/v3/api.py
+++ b/wagtail/api/v3/api.py
@@ -1,3 +1,7 @@
+from functools import wraps
+
+from django.conf import settings
+from django.http import Http404
 from ninja import NinjaAPI
 
 from wagtail.api.v3.errors import register_exception_handlers
@@ -6,11 +10,27 @@ from wagtail.api.v3.routers.schema import router as schema_router
 from wagtail.api.v3.routers.sites import router as sites_router
 from wagtail.api.v3.routers.whoami import router as whoami_router
 
+
+def _gate_docs(view):
+    """
+    Uses ``WAGTAILAPI_DOCS_ENABLED`` to 404 the OpenAPI schema / interactive docs.
+    """
+
+    @wraps(view)
+    def wrapper(request, *args, **kwargs):
+        if not getattr(settings, "WAGTAILAPI_DOCS_ENABLED", True):
+            raise Http404
+        return view(request, *args, **kwargs)
+
+    return wrapper
+
+
 api = NinjaAPI(
     title="Wagtail API",
     version="3.0.0",
     description="Wagtail v3 read and write API",
     urls_namespace="wagtailapi_v3",
+    docs_decorator=_gate_docs,
     openapi_url="/openapi.json",
     docs_url="/docs/",
 )

--- a/wagtail/api/v3/tests/test_docs.py
+++ b/wagtail/api/v3/tests/test_docs.py
@@ -1,0 +1,19 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from wagtail.api.v3.tests.base import TestV3Base
+
+
+class TestAPIDocsGating(TestV3Base, TestCase):
+    def test_docs_served_by_default(self):
+        response = self.client.get(reverse("wagtailapi_v3:openapi-json"))
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(reverse("wagtailapi_v3:openapi-view"))
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(WAGTAILAPI_DOCS_ENABLED=False)
+    def test_docs_disabled_returns_404(self):
+        response = self.client.get(reverse("wagtailapi_v3:openapi-json"))
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get(reverse("wagtailapi_v3:openapi-view"))
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
Part of #14504. We felt some people might prefer the obscurity of disallowing access to the v3 API's OpenAPI schema (`/api/v3/openapi.json`) and interactive docs (`/api/v3/docs/`), via a setting.

This introduces `WAGTAILAPI_DOCS_ENABLED`, (default `True`), to set both requests to 404. It’s still possible to manually go to the relevant endpoints and see which ones do exist.

Alternative was to add auth support for this, but I felt like this wasn’t worthwhile here.

### AI usage

First draft with pi / DeepSeek V4 Flash. Manually edited / reviewed.