### PR TITLE
Require change permission on source snippet in copy-for-translation action

### DIFF
--- a/wagtail/actions/copy_for_translation.py
+++ b/wagtail/actions/copy_for_translation.py
@@ -199,6 +199,7 @@ class CopyForTranslationAction(BaseAction):
     """
 
     action_name = "copy_for_translation"
+    permission_policy_action = "change"
     permission_error_class = CopyForTranslationPermissionError
 
     def __init__(
@@ -213,14 +214,16 @@ class CopyForTranslationAction(BaseAction):
         self.locale = locale
         self.exclude_fields = exclude_fields
 
+    def user_has_permission(self):
+        # Use instance-level `change` via permission policy, and the global `submit_translation`.
+        return super().user_has_permission() and self.user.has_perms(
+            ["simple_translation.submit_translation"]
+        )
+
     def check(self, skip_permission_checks=False):
         # Permission checks
-        if (
-            self.user
-            and not skip_permission_checks
-            and not self.user.has_perms(["simple_translation.submit_translation"])
-        ):
-            raise CopyForTranslationPermissionError(
+        if self.user and not skip_permission_checks and not self.user_has_permission():
+            raise self.permission_error_class(
                 "You do not have permission to submit a translation for this object."
             )
 

--- a/wagtail/snippets/tests/test_api_v3/test_actions.py
+++ b/wagtail/snippets/tests/test_api_v3/test_actions.py
@@ -353,13 +353,24 @@ class TestV3SnippetCopyForTranslation(TestV3SnippetActionsBase):
         )
 
     def test_requires_submit_translation_permission(self):
-        self.login_with_permissions("add_fullfeaturedsnippet")
+        self.login_with_permissions(
+            "add_fullfeaturedsnippet", "change_fullfeaturedsnippet"
+        )
+        snippet = FullFeaturedSnippet.objects.create(text="Src")
+        response = self.post(snippet, {"locale": "fr"})
+        self.assert_problem_response(response, status_code=403)
+
+    def test_requires_change_permission_on_source_snippet(self):
+        user = self.login_with_permissions("add_fullfeaturedsnippet")
+        self.grant_submit_translation(user)
         snippet = FullFeaturedSnippet.objects.create(text="Src")
         response = self.post(snippet, {"locale": "fr"})
         self.assert_problem_response(response, status_code=403)
 
     def test_copy_for_translation(self):
-        user = self.login_with_permissions("add_fullfeaturedsnippet")
+        user = self.login_with_permissions(
+            "add_fullfeaturedsnippet", "change_fullfeaturedsnippet"
+        )
         self.grant_submit_translation(user)
         snippet = FullFeaturedSnippet.objects.create(text="Src")
 


### PR DESCRIPTION
Part of #14504. This is a similar change to 836452b90ffb7958696cb488d86b0afdc6ab525a which we did for pages’ `CopyPageForTranslationAction`, checking both the "global" `simple_translation.submit_translation` permission, and also whether the user has "edit" permission on the specific model.

### AI usage

PR written with pi + DeepSeek V4 Flash, manually edited and reviewed