### PR TITLE
Validate slug format in v3 API copy and create_alias actions

### DIFF
--- a/wagtail/api/v3/routers/pages.py
+++ b/wagtail/api/v3/routers/pages.py
@@ -1,6 +1,7 @@
 from typing import Literal, Optional, TypeAlias, cast
 
 import swapper
+from django import forms
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
@@ -445,12 +446,33 @@ def unpublish(
     return page
 
 
+def _validate_slug(value: Optional[str]) -> Optional[str]:
+    """
+    Checks for Wagtail’s slug format, respecting unicode on/off settings.
+    Replicates ``SlugField`` from ``CopyForm`` in the admin.
+    """
+    if value is None:
+        return None
+    allow_unicode = getattr(settings, "WAGTAIL_ALLOW_UNICODE_SLUGS", True)
+    field = forms.SlugField(allow_unicode=allow_unicode)
+    try:
+        field.clean(value)
+    except forms.ValidationError as exc:
+        raise ValueError(exc.messages[0]) from exc
+    return value
+
+
 class PageCopySchema(Schema):
     destination_id: Optional[PositiveInt] = None
     recursive: bool = False
     keep_live: bool = True
     slug: Optional[str] = None
     title: Optional[str] = None
+
+    @field_validator("slug", mode="after")
+    @classmethod
+    def validate_slug(cls, value: Optional[str]) -> Optional[str]:
+        return _validate_slug(value)
 
     def get_destination(self) -> Page:
         if self.destination_id is None:
@@ -612,6 +634,11 @@ class PageCreateAliasSchema(Schema):
     destination_id: Optional[PositiveInt] = None
     recursive: bool = False
     slug: Optional[str] = None
+
+    @field_validator("slug", mode="after")
+    @classmethod
+    def validate_slug(cls, value: Optional[str]) -> Optional[str]:
+        return _validate_slug(value)
 
     def get_destination(self) -> Page | None:
         if self.destination_id is None:

--- a/wagtail/api/v3/tests/test_page_actions.py
+++ b/wagtail/api/v3/tests/test_page_actions.py
@@ -336,6 +336,31 @@ class TestV3PageCopy(TestV3PageActionsBase):
         new_page = Page.objects.get(pk=response.json()["id"])
         self.assertEqual(new_page.title, "Custom Title")
 
+    def test_invalid_slug_returns_422(self):
+        self.login()
+        page = self.add_simple_page(self.home_page, title="Src", slug="src")
+        # keep_live=False exercises minimal_clean(), which previously skipped
+        # slug format validation and allowed a malformed slug to be saved.
+        response = self.post(page, {"keep_live": False, "slug": "bad slug"})
+        self.assert_problem_response(
+            response,
+            status_code=422,
+            detail_contains="Validation failed",
+            errors=[{"type": "value_error", "loc": ["body", "data", "slug"]}],
+        )
+
+    def test_non_ascii_slug_rejected_when_unicode_disabled(self):
+        self.login()
+        page = self.add_simple_page(self.home_page, title="Src", slug="src")
+        with self.settings(WAGTAIL_ALLOW_UNICODE_SLUGS=False):
+            response = self.post(page, {"keep_live": False, "slug": "pàgé"})
+        self.assert_problem_response(
+            response,
+            status_code=422,
+            detail_contains="Validation failed",
+            errors=[{"type": "value_error", "loc": ["body", "data", "slug"]}],
+        )
+
     def test_unknown_destination_returns_404(self):
         self.login()
         page = self.add_simple_page(self.home_page, title="Src", slug="src")
@@ -860,6 +885,17 @@ class TestV3PageCreateAlias(TestV3PageActionsBase):
         self.assertEqual(response.status_code, 201)
         new_page = Page.objects.get(pk=response.json()["id"])
         self.assertEqual(new_page.slug, "custom-alias-slug")
+
+    def test_invalid_slug_returns_422(self):
+        self.login()
+        page = self.add_simple_page(self.home_page, title="Src", slug="src")
+        response = self.post(page, {"slug": "bad slug"})
+        self.assert_problem_response(
+            response,
+            status_code=422,
+            detail_contains="Validation failed",
+            errors=[{"type": "value_error", "loc": ["body", "data", "slug"]}],
+        )
 
     def test_unknown_destination_returns_404(self):
         self.login()


### PR DESCRIPTION
Part of #14504. Previously the slugs would be trusted as-is from API requests, while the admin enforces slug formatting with `SlugField` and uniqueness on publish with extra logic. This PR introduces formatting checks at the schema level, while the uniqueness is done later on in the copying flow.

There is also an opportunity here to validate uniqueness at the schema layer for consistency with other validation. I chose to not do that for now. I’m not a fan of this whole implementation, but it’s needed here because contrary to other page endpoints we don’t create a Django form for those views for feature parity. I think we’ll revisit this with @laymonage - at the very least move this helper code elsewhere, if not bigger refactorings. For now I have backlogged this on #14295.

### AI usage

PR created with pi + DeepSeek V4 Flash. Manually reviewed and edited.