### PR TITLE
Run apt-get update before installing libpq-dev in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,9 @@ jobs:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
       - name: Install libpq-dev
-        run: sudo apt-get install -y libpq-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install dependencies
@@ -358,7 +360,9 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install libpq-dev
-        run: sudo apt-get install -y libpq-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install dependencies


### PR DESCRIPTION
Fixes CI failure between https://github.com/wagtail/wagtail/actions/runs/32408877379/job/96554377570 and https://github.com/wagtail/wagtail/actions/runs/32532271167/job/96926468673

The switch to the ubuntu-26.04-arm runner image left the local apt package index stale, causing libpq-dev installation to fail.

### AI usage

Diagnosed and fix provided by Claude Code, verified by me