### PR TITLE
docs: Remove deprecated USE_L10N setting from documentation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,6 +43,7 @@ Changelog
  * Docs: Update image format docs to encourage more intentional conversions (Thibaud Colas)
  * Docs: Clarify Wagtail XSS protections for uploaded documents (Thibaud Colas)
  * Docs: Add section on customizing StreamField block API output with `get_api_representation` (Pranith Beeram)
+ * Docs: Removed now-deprecated `USE_L10N` setting from internationalization and project setup documentation (Piyush Bhakuni)
  * Maintenance: Formalized support for Django 6.1
  * Maintenance: Rename `request` argument to `cache_object` in `Page._get_site_root_paths()` for correctness (Kailesh)
  * Maintenance: Fix blank choice tests for Django 6.1 (Sage Abdullah)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -994,6 +994,7 @@
 * Anand Himanshu
 * Ta Duc Thien
 * tinyb0y
+* Piyush Bhakuni
 
 ## Translators
 

--- a/docs/advanced_topics/add_to_django_project.md
+++ b/docs/advanced_topics/add_to_django_project.md
@@ -239,7 +239,6 @@ DATABASES = {
 LANGUAGE_CODE = "en-us"
 TIME_ZONE = "UTC"
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 
 

--- a/docs/advanced_topics/i18n.md
+++ b/docs/advanced_topics/i18n.md
@@ -144,16 +144,6 @@ settings to `True`:
 USE_I18N = True
 WAGTAIL_I18N_ENABLED = True
 ```
-
-In addition, you might also want to enable Django's localization support. This
-will make dates and numbers display in the user's local format:
-
-```python
-# my_project/settings.py
-
-USE_L10N = True
-```
-
 (configuring_available_languages)=
 
 #### Configuring available languages

--- a/docs/releases/8.0.md
+++ b/docs/releases/8.0.md
@@ -101,6 +101,7 @@ Many thanks to tinyb0y for reporting this issue. For further details, please see
  * Update image format docs to encourage more intentional conversions (Thibaud Colas)
  * Clarify Wagtail XSS protections for uploaded documents (Thibaud Colas)
  * Add section on customizing StreamField block API output with `get_api_representation` (Pranith Beeram)
+ * Removed now-deprecated `USE_L10N` setting from internationalization and project setup documentation (Piyush Bhakuni)
 
 ### Maintenance
 


### PR DESCRIPTION
USE_L10N was deprecated in Django 4.0 and is always enabled as of Django 5.0. Since Wagtail 7.4 drops support for Django 4.2, this setting is no longer relevant and has been removed from the internationalization and project setup documentation.

Fixes #14552

<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #14552 

### Description
`USE_L10N` was deprecated in Django 4.0 and is always enabled as of Django 5.0. 
Since Wagtail 7.4 drops support for Django 4.2, the recommendation to set 
`USE_L10N = True` in the internationalization and project setup docs is no 
longer relevant and has been removed.
<!-- Please describe the problem you're fixing. -->


### AI usage
None
<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
