### PR TITLE
Keep v3 API tokens outside of sessions

### DIFF
--- a/wagtail/users/locale/en/LC_MESSAGES/django.po
+++ b/wagtail/users/locale/en/LC_MESSAGES/django.po
@@ -483,15 +483,11 @@ msgstr ""
 msgid "Revoke"
 msgstr ""
 
-#: views/api_tokens.py:154
+#: views/api_tokens.py:148
 msgid "API token created"
 msgstr ""
 
-#: views/api_tokens.py:177
-msgid "Token secrets are only displayed once, immediately after creation."
-msgstr ""
-
-#: views/api_tokens.py:207
+#: views/api_tokens.py:169
 msgid "Never"
 msgstr ""
 

--- a/wagtail/users/tests/test_api_tokens_admin.py
+++ b/wagtail/users/tests/test_api_tokens_admin.py
@@ -52,35 +52,19 @@ class TestAPITokenAdmin(TestCase):
         self.assertContains(response, 'name="name"')
         self.assertContains(response, 'name="user"')
 
-    def test_create_shows_secret_exactly_once(self):
+    def test_create_shows_secret_on_post_response(self):
         self.client.force_login(self.root)
         response = self.client.post(
             reverse("wagtailusers_api_tokens:add"),
             {"user": self.root.pk, "name": "deploy bot"},
         )
         token = APIToken.objects.get()
-        # POST/redirect/GET to the one-time secret page
-        self.assertRedirects(
-            response,
-            reverse("wagtailusers_api_tokens:created", args=[token.pk]),
-            fetch_redirect_response=False,
-        )
-        created = self.client.get(response["Location"])
-        self.assertEqual(created.status_code, 200)
-        self.assertContains(created, token.prefix)
-        matches = TOKEN_RE.findall(created.content.decode())
+        # The token is rendered directly in the POST response (no redirect).
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, token.prefix)
+        matches = TOKEN_RE.findall(response.content.decode())
         self.assertEqual(len(matches), 1)
         plaintext = matches[0]
-
-        # The one-time page does not serve the secret twice.
-        second = self.client.get(response["Location"], follow=True)
-        self.assertEqual(len(second.redirect_chain), 1)
-        self.assertEqual(second.redirect_chain[0][1], 302)
-        self.assertContains(
-            second,
-            "Token secrets are only displayed once, immediately after creation.",
-        )
-        self.assertNotContains(second, plaintext)
 
         # The full secret is never shown anywhere else.
         self.assertNotContains(self.get("index"), plaintext)
@@ -107,7 +91,7 @@ class TestAPITokenAdmin(TestCase):
             reverse("wagtailusers_api_tokens:add"),
             {"user": plain.pk, "name": "my token"},
         )
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(APIToken.objects.get().user, plain)
 
     def test_create_for_other_user_requires_change_user_perm(self):

--- a/wagtail/users/views/api_tokens.py
+++ b/wagtail/users/views/api_tokens.py
@@ -2,12 +2,10 @@ import django_filters
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.forms import CharField, CheckboxSelectMultiple, Form, ModelChoiceField
-from django.shortcuts import get_object_or_404, redirect
-from django.urls import path, reverse
+from django.shortcuts import redirect
+from django.template.response import TemplateResponse
 from django.utils.functional import cached_property
-from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
-from django.views import View
 
 from wagtail.admin.filters import (
     DateRangePickerWidget,
@@ -19,14 +17,11 @@ from wagtail.admin.ui.components import MediaContainer
 from wagtail.admin.ui.side_panels import StatusSidePanel
 from wagtail.admin.ui.tables import Column, TitleColumn
 from wagtail.admin.views import generic
-from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
 from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.admin.widgets.boolean_radio_select import BooleanRadioSelect
 from wagtail.log_actions import log
 from wagtail.models import APIToken
 from wagtail.users.utils import get_manageable_token_owners, user_can_manage_token
-
-CREATED_SESSION_KEY = "wagtail_apitoken_created"
 
 
 class APITokenForm(Form):
@@ -134,58 +129,17 @@ class CreateView(generic.CreateView):
             user=owner, name=form.cleaned_data["name"]
         )
         log(self.object, "wagtail.apitoken.create", user=self.request.user)
-        # Stash the secret in the session for a single display on the
-        # redirected-to page (POST/redirect/GET, so a refresh cannot
-        # re-submit and mint a duplicate token). Keyed by pk so multiple
-        # pending secrets can coexist.
-        stash = self.request.session.get(CREATED_SESSION_KEY, {})
-        stash[str(self.object.pk)] = plaintext
-        self.request.session[CREATED_SESSION_KEY] = stash
-        return redirect(self.get_success_url())
-
-    def get_success_url(self):
-        return reverse("wagtailusers_api_tokens:created", args=[self.object.pk])
-
-
-class CreatedView(WagtailAdminTemplateMixin, View):
-    """Displays a newly-created token's secret exactly once."""
-
-    template_name = "wagtailusers/api_tokens/created.html"
-    page_title = _("API token created")
-    model = APIToken
-    index_url_name = None
-    header_icon = ""
-
-    def get_breadcrumbs_items(self):
-        items = [
-            {
-                "url": reverse(self.index_url_name),
-                "label": capfirst(self.model._meta.verbose_name_plural),
-            },
-        ]
-        items.append({"url": "", "label": self.get_page_title()})
-        return self.breadcrumbs_items + items
-
-    def get(self, request, pk):
-        # Peek before consuming: a stale link or prefetch must not wipe the
-        # one-time secret.
-        stash = request.session.get(CREATED_SESSION_KEY, {})
-        plaintext = stash.get(str(pk))
-        if plaintext is None:
-            messages.warning(
-                request,
-                _("Token secrets are only displayed once, immediately after creation."),
-            )
-            return redirect("wagtailusers_api_tokens:index")
-        self.object = get_object_or_404(APIToken, pk=pk)
-        del stash[str(pk)]
-        if stash:
-            request.session[CREATED_SESSION_KEY] = stash
-        else:
-            del request.session[CREATED_SESSION_KEY]
-        return self.render_to_response(
-            self.get_context_data(object=self.object, token=plaintext)
+        return TemplateResponse(
+            self.request,
+            "wagtailusers/api_tokens/created.html",
+            self.get_created_context(plaintext),
         )
+
+    def get_created_context(self, plaintext):
+        context = super().get_context_data(token=plaintext)
+        context["page_title"] = _("API token created")
+        context["header_title"] = _("API token created")
+        return context
 
 
 class APITokenStatusSidePanel(StatusSidePanel):
@@ -270,15 +224,6 @@ class APITokenViewSet(ModelViewSet):
     add_view_class = CreateView
     edit_view_class = EditView
     delete_view_class = RevokeView
-
-    @property
-    def created_view(self):
-        return self.construct_view(CreatedView)
-
-    def get_urlpatterns(self):
-        return super().get_urlpatterns() + [
-            path("created/<int:pk>/", self.created_view, name="created"),
-        ]
 
     def get_form_class(self, for_update=False):
         if for_update:


### PR DESCRIPTION
Part of #14504. This switches our admin API token creation flow to directly display generated tokens in the POST response, rather than the previous POST -> redirect -> GET flow, which kept them as plain text in sessions. The new approach doesn’t handle refreshes as well (submits a new POST, creates a new token), but most browsers have "confirm form resubmission" dialogs anyway these days.

I’m not sure if this change is a bug fix / security fix / enhancement. I didn’t feel comfortable with keeping tokens in the session, if sessions leaked the tokens would be very simple to reuse and have no expiry.

### AI usage

AI-generated first draft with pi + DeepSeek V4 Flash. Manually edited and reviewed.