### PR TITLE
Remove obsolete USE_L10N code paths

### DIFF
--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -236,7 +236,7 @@ def file_overwrite_check(app_configs, **kwargs):
 @register("datetime_format")
 def datetime_format_check(app_configs, **kwargs):
     """
-    If L10N is enabled, check if WAGTAIL_* formats are compatible with Django input formats.
+    Check if WAGTAIL_* formats are compatible with Django input formats.
     See https://docs.djangoproject.com/en/stable/topics/i18n/formatting/#creating-custom-format-files
     See https://docs.wagtail.org/en/stable/reference/settings.html#wagtail-date-format-wagtail-datetime-format-wagtail-time-format
     """
@@ -245,9 +245,6 @@ def datetime_format_check(app_configs, **kwargs):
     from django.utils import formats
 
     errors = []
-
-    if not getattr(settings, "USE_L10N", False):
-        return errors
 
     for code, label in settings.LANGUAGES:
         for wagtail_setting, django_setting in [

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -541,7 +541,7 @@ class TestPageExplorer(WagtailTestUtils, TestCase):
         self.assertContains(response, "1-153 of 153")
         self.assertEqual(len(response.context["pages"]), 153)
 
-    @override_settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True)
+    @override_settings(USE_THOUSAND_SEPARATOR=True)
     def test_no_thousand_separators_in_bulk_action_checkbox(self):
         """
         Test that the USE_THOUSAND_SEPARATOR setting does mess up object IDs in

--- a/wagtail/admin/tests/test_checks.py
+++ b/wagtail/admin/tests/test_checks.py
@@ -22,7 +22,6 @@ class TestDateTimeChecks(PageFixturesMixin, WagtailTestUtils, TestCase):
             ],
             WAGTAIL_DATE_FORMAT="%m/%d/%Y",
             WAGTAIL_TIME_FORMAT="%H:%M",
-            USE_L10N=True,
         ):
             errors = datetime_format_check(None)
 
@@ -38,7 +37,6 @@ class TestDateTimeChecks(PageFixturesMixin, WagtailTestUtils, TestCase):
             ],
             WAGTAIL_DATE_FORMAT="%d.%m.%Y.",
             WAGTAIL_TIME_FORMAT="%H:%M",
-            USE_L10N=True,
         ):
             errors = datetime_format_check(None)
 
@@ -52,25 +50,6 @@ class TestDateTimeChecks(PageFixturesMixin, WagtailTestUtils, TestCase):
         ]
         self.assertEqual(errors, expected_errors)
 
-    def test_datetime_format_with_unsupported_date_not_using_l10n(self):
-        """
-        Test that the check doesn't raise an error when USE_L10N is False.
-        """
-
-        with override_settings(
-            WAGTAIL_CONTENT_LANGUAGES=[
-                ("en", "English"),
-            ],
-            LANGUAGES=[
-                ("en", "English"),
-            ],
-            WAGTAIL_DATE_FORMAT="%d.%m.%Y.",
-            WAGTAIL_TIME_FORMAT="%H:%M",
-            USE_L10N=False,
-        ):
-            errors = datetime_format_check(None)
-        self.assertEqual(errors, [])
-
     def test_datetime_format_with_unsupported_datetime_and_time(self):
         with override_settings(
             WAGTAIL_CONTENT_LANGUAGES=[
@@ -81,7 +60,6 @@ class TestDateTimeChecks(PageFixturesMixin, WagtailTestUtils, TestCase):
             ],
             WAGTAIL_DATETIME_FORMAT="%d.%m.%Y. %H:%M",
             WAGTAIL_TIME_FORMAT="%I:%M %p",
-            USE_L10N=True,
         ):
             errors = datetime_format_check(None)
 
@@ -111,7 +89,6 @@ class TestDateTimeChecks(PageFixturesMixin, WagtailTestUtils, TestCase):
             ],
             WAGTAIL_DATETIME_FORMAT="%d.%m.%Y. %H:%M",
             FORMAT_MODULE_PATH=["wagtail.admin.tests.formats"],
-            USE_L10N=True,
         ):
             errors = datetime_format_check(None)
 
@@ -127,7 +104,6 @@ class TestDateTimeChecks(PageFixturesMixin, WagtailTestUtils, TestCase):
             ],
             WAGTAIL_DATETIME_FORMAT="%m.%d.%Y. %H:%M",
             FORMAT_MODULE_PATH=["wagtail.admin.tests.formats"],
-            USE_L10N=True,
         ):
             errors = datetime_format_check(None)
 

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -1521,7 +1521,7 @@ class TestInlinePanel(PageFixturesMixin, WagtailTestUtils, TestCase):
         # render_js_init must provide the JS initializer
         self.assertIn("var panel = new InlinePanel(", panel.render_html())
 
-    @override_settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True)
+    @override_settings(USE_THOUSAND_SEPARATOR=True)
     def test_no_thousand_separators_in_js(self):
         """
         Test that the USE_THOUSAND_SEPARATOR setting does not screw up the rendering of numbers

--- a/wagtail/admin/tests/test_reports_views.py
+++ b/wagtail/admin/tests/test_reports_views.py
@@ -819,9 +819,6 @@ class TestFilteredLogEntriesResultsView(TestFilteredLogEntriesView):
     results_only = True
 
 
-@override_settings(
-    USE_L10N=True,
-)
 class TestExcelDateFormatter(TestCase):
     def test_all_locales(self):
         formatter = ExcelDateFormatter()

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1749,7 +1749,7 @@ class TestImageEditView(AdminTemplateTestUtils, WagtailTestUtils, TestCase):
         with self.assertRaises(type(old_rendition).DoesNotExist):
             old_rendition.refresh_from_db()
 
-    @override_settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True)
+    @override_settings(USE_THOUSAND_SEPARATOR=True)
     def test_no_thousand_separators_in_focal_point_editor(self):
         large_image = Image.objects.create(
             title="Test image",


### PR DESCRIPTION
Fixes #14559

### Description

Django now always enables localized formatting, so `USE_L10N` no longer controls runtime behavior. This removes the remaining live-code guard, the obsolete false-branch test, and redundant test overrides while preserving the separate `USE_THOUSAND_SEPARATOR` regression coverage. Historical changelog and release-note references are intentionally unchanged.

### Verification

- `python runtests.py wagtail.admin.tests.test_checks wagtail.admin.tests.test_reports_views wagtail.admin.tests.pages.test_explorer_view wagtail.admin.tests.test_edit_handlers wagtail.images.tests.test_admin_views` (439 tests passed)
- `ruff check` on all six changed files
- `ruff format --check` on all six changed files
- `git diff --check`