### PR TITLE
Extend the rich-text feature registry to allow adding rewriters

### DIFF
--- a/docs/extending/rich_text_internals.md
+++ b/docs/extending/rich_text_internals.md
@@ -234,30 +234,110 @@ def register_embed_handler(features):
     features.register_embed_type(MyCustomEmbedHandler)
 ```
 
-### Registering generic rewrite handlers
+### Registering front-end rewriters
 
-If you need to add a new rich text feature that does not fit the pattern of the LinkHandler or the EmbedHandler, you can register an entirely new rewriter alongside your converter rule.
+Link and embed handlers cover tags keyed on a `linktype` or `embedtype`. For a feature that stores some other markup of its own, you can register an arbitrary rewriter to be applied when the rich text is rendered.
 
-Rewriters must be callables, that receive a single argument - the rich-text HTML - and are registered with the `register_frontend_rewriter` call on the rich-text `features` object. By convention they are written as classes with a `__call__` method, but a function would also suffice for simple replacers.
+```{eval-rst}
+.. method:: FeatureRegistry.register_frontend_rewriter(rewriter, order=0)
+
+This method registers a callable to be applied to the database representation of rich text when rendering it on the front end.
+
+The ``rewriter`` must be a callable taking a single argument - the rich text HTML as a string - and returning the rewritten HTML. By convention these are written as classes with a ``__call__`` method, so that compiled regular expressions can be held as class attributes, but a plain function is also fine for simple replacements.
+
+A rewriter is instantiated once and reused for the lifetime of the process, across all requests and threads, so it must not store per-request state on ``self``.
+
+Optionally, a rewriter may also define an ``extract_references(html)`` method, yielding reference tuples in the same way as :ref:`rewrite handlers <rich_text_rewrite_handlers>`, so that objects referred to by your tag are recorded in the reference index. Rewriters that do not refer to model instances can leave it undefined.
+```
+
+The example below marks up a phrase in a different language, which [WCAG 2.1 success criterion 3.1.2](https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts.html) requires on pages that mix languages, so that a screen reader pronounces the phrase correctly.
+
+Storing the language needs no rewriter: a converter rule maps a Draftail inline style to a `<span lang="...">` tag in the database, and because `expand_db_html` leaves tags it does not recognize alone, that span reaches the template as it was stored. What the rewriter adds is the matching `dir` attribute. Deriving it on render rather than storing it means editors only record which language a phrase is in, and correcting or extending the logic later also fixes content that has already been published.
 
 ```python
-class MaoriRewriter:
-    TAG_RE = re.compile(r"<maori>(.+?)</maori>")
+# my_app/wagtail_hooks.py
 
-    def replace_tag(self, match):
-        content = match.groups(1)[0]
-        return '<span lang="mi">{content}</span>'.format(content=content)
+import re
+
+from django.utils.translation import get_language_info
+
+import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+from wagtail import hooks
+from wagtail.admin.rich_text.converters.html_to_contentstate import (
+    InlineStyleElementHandler,
+)
+
+
+class LanguageDirectionRewriter:
+    FIND_LANG_SPAN = re.compile(r'<span\b[^>]*\blang="([\w-]+)"[^>]*>')
+
+    def add_direction(self, match):
+        try:
+            is_rtl = get_language_info(match.group(1))["bidi"]
+        except KeyError:  # not a language Django knows about
+            is_rtl = False
+
+        tag = match.group(0)
+        return tag[:-1] + ' dir="rtl">' if is_rtl else tag
 
     def __call__(self, html):
-        return self.TAG_RE.sub(self.replace_tag, html)
+        return self.FIND_LANG_SPAN.sub(self.add_direction, html)
 
 
 @hooks.register("register_rich_text_features")
-def register_maori_feature(features):
-    features.register_frontend_rewriter(MaoriRewriter(), order=300)
+def register_language_features(features):
+    for code in ["nl", "ar"]:
+        feature_name = f"lang-{code}"
+        style = f"LANG_{code.upper()}"
+
+        # 1. Give Draftail a toolbar control for the language.
+        features.register_editor_plugin(
+            "draftail",
+            feature_name,
+            draftail_features.InlineStyleFeature(
+                {
+                    "type": style,
+                    "label": code,
+                    "description": get_language_info(code)["name_local"],
+                }
+            ),
+        )
+
+        # 2. Convert between that style and a <span lang="..."> tag in the database.
+        features.register_converter_rule(
+            "contentstate",
+            feature_name,
+            {
+                "from_database_format": {
+                    f'span[lang="{code}"]': InlineStyleElementHandler(style),
+                },
+                "to_database_format": {
+                    "style_map": {
+                        style: {"element": "span", "props": {"lang": code}},
+                    },
+                },
+            },
+        )
+
+    # 3. Derive the text direction when the content is rendered.
+    features.register_frontend_rewriter(LanguageDirectionRewriter())
 ```
 
-Note that as the rewriters do not have any defined specificity, the registration method takes an optional `order` value, in case the order of execution is significant. The default Link and Embed rewriters have an order of 100 and 200, respectively, so you will usually want to add your rewriters after these (with a larger number for `order`).
+With those features enabled on a rich text field, `<span lang="ar">مرحبا</span>` in the database renders as `<span lang="ar" dir="rtl">مرحبا</span>`.
+
+#### Rewriter ordering
+
+Rewriters have no inherent specificity, so `register_frontend_rewriter` takes an optional `order` argument for the cases where the order of execution matters. It follows the same convention as [`hooks.register`](admin_hooks): the default is `0`, rewriters sharing an order run in registration order, and a negative order runs earlier.
+
+Wagtail's own link and embed rewriters run before anything registered at the default order, so by default your rewriter sees fully expanded `<a href="...">` and embed markup rather than the `<a linktype="...">` and `<embed embedtype="..." />` tags held in the database. This is almost always what you want.
+
+Passing a negative `order` runs your rewriter before Wagtail's, letting you pre-empt them:
+
+```python
+features.register_frontend_rewriter(MyEmbedOverride(), order=-1)
+```
+
+This is occasionally useful for overriding how Wagtail renders a tag, but registering a [link handler](rich_text_rewrite_handlers) or an embed handler is usually the better tool, since those are keyed on `linktype` / `embedtype` rather than having to re-match the tag yourself.
 
 ## Editor widgets
 

--- a/docs/extending/rich_text_internals.md
+++ b/docs/extending/rich_text_internals.md
@@ -331,13 +331,11 @@ Rewriters have no inherent specificity, so `register_frontend_rewriter` takes an
 
 Wagtail's own link and embed rewriters run before anything registered at the default order, so by default your rewriter sees fully expanded `<a href="...">` and embed markup rather than the `<a linktype="...">` and `<embed embedtype="..." />` tags held in the database. This is almost always what you want.
 
-Passing a negative `order` runs your rewriter before Wagtail's, letting you pre-empt them:
+A negative order runs your rewriter before Wagtail's own. That matters if your feature stores extra data on a tag Wagtail already handles: link and embed handlers build their opening tag from scratch, so `<a linktype="page" id="3" data-tone="quiet">` reaches the template as `<a href="/…/">`, and a rewriter at the default order never sees the extra attribute.
 
 ```python
-features.register_frontend_rewriter(MyEmbedOverride(), order=-1)
+features.register_frontend_rewriter(LinkToneRewriter(), order=-1)
 ```
-
-This is occasionally useful for overriding how Wagtail renders a tag, but registering a [link handler](rich_text_rewrite_handlers) or an embed handler is usually the better tool, since those are keyed on `linktype` / `embedtype` rather than having to re-match the tag yourself.
 
 ## Editor widgets
 

--- a/docs/extending/rich_text_internals.md
+++ b/docs/extending/rich_text_internals.md
@@ -170,9 +170,9 @@ class UserLinkHandler(LinkHandler):
         return '<a href="mailto:%s">' % user.email
 ```
 
-### Registering rewrite handlers
+### Registering link rewrite handlers
 
-Rewrite handlers must also be registered with the feature registry via the [register rich text features](register_rich_text_features) hook. Independent methods for registering both link handlers and embed handlers are provided.
+Link rewrite handlers must also be registered with the feature registry via the [register rich text features](register_rich_text_features) hook. Independent methods for registering both link handlers and embed handlers are provided.
 
 ```{eval-rst}
 .. method:: FeatureRegistry.register_link_type(handler)
@@ -233,6 +233,31 @@ from my_app.handlers import MyCustomEmbedHandler
 def register_embed_handler(features):
     features.register_embed_type(MyCustomEmbedHandler)
 ```
+
+### Registering generic rewrite handlers
+
+If you need to add a new rich text feature that does not fit the pattern of the LinkHandler or the EmbedHandler, you can register an entirely new rewriter alongside your converter rule.
+
+Rewriters must be callables, that receive a single argument - the rich-text HTML - and are registered with the `register_frontend_rewriter` call on the rich-text `features` object. By convention they are written as classes with a `__call__` method, but a function would also suffice for simple replacers.
+
+```python
+class MaoriRewriter:
+    TAG_RE = re.compile(r"<maori>(.+?)</maori>")
+
+    def replace_tag(self, match):
+        content = match.groups(1)[0]
+        return '<span lang="mi">{content}</span>'.format(content=content)
+
+    def __call__(self, html):
+        return self.TAG_RE.sub(self.replace_tag, html)
+
+
+@hooks.register("register_rich_text_features")
+def register_maori_feature(features):
+    features.register_frontend_rewriter(MaoriRewriter(), order=300)
+```
+
+Note that as the rewriters do not have any defined specificity, the registration method takes an optional `order` value, in case the order of execution is significant. The default Link and Embed rewriters have an order of 100 and 200, respectively, so you will usually want to add your rewriters after these (with a larger number for `order`).
 
 ## Editor widgets
 

--- a/wagtail/rich_text/__init__.py
+++ b/wagtail/rich_text/__init__.py
@@ -45,9 +45,9 @@ def get_rewriter():
         },
     )
 
-    features.register_frontend_rewriter(link_rewriter, 100)
-    features.register_frontend_rewriter(embed_rewriter, 200)
-    return MultiRuleRewriter(features.get_frontend_rewriters())
+    return MultiRuleRewriter(
+        features.get_frontend_rewriters([link_rewriter, embed_rewriter])
+    )
 
 
 def expand_db_html(html):

--- a/wagtail/rich_text/__init__.py
+++ b/wagtail/rich_text/__init__.py
@@ -1,6 +1,7 @@
 import re
 from functools import lru_cache
 from html import unescape
+from operator import itemgetter
 
 from django.core.validators import MaxLengthValidator, MinLengthValidator
 from django.db.models import Model
@@ -45,9 +46,11 @@ def get_rewriter():
         },
     )
 
-    return MultiRuleRewriter(
-        features.get_frontend_rewriters([link_rewriter, embed_rewriter])
+    rewriters = sorted(
+        [(link_rewriter, 0), (embed_rewriter, 0), *features.get_frontend_rewriters()],
+        key=itemgetter(1),
     )
+    return MultiRuleRewriter([rewriter[0] for rewriter in rewriters])
 
 
 def expand_db_html(html):

--- a/wagtail/rich_text/__init__.py
+++ b/wagtail/rich_text/__init__.py
@@ -21,32 +21,33 @@ features = FeatureRegistry()
 
 @lru_cache(maxsize=None)
 def get_rewriter():
-    embed_rules = features.get_embed_types()
     link_rules = features.get_link_types()
-    return MultiRuleRewriter(
-        [
-            LinkRewriter(
-                bulk_rules={
-                    linktype: handler.expand_db_attributes_many
-                    for linktype, handler in link_rules.items()
-                },
-                reference_extractors={
-                    linktype: handler.extract_references
-                    for linktype, handler in link_rules.items()
-                },
-            ),
-            EmbedRewriter(
-                bulk_rules={
-                    embedtype: handler.expand_db_attributes_many
-                    for embedtype, handler in embed_rules.items()
-                },
-                reference_extractors={
-                    embedtype: handler.extract_references
-                    for embedtype, handler in embed_rules.items()
-                },
-            ),
-        ]
+    link_rewriter = LinkRewriter(
+        bulk_rules={
+            linktype: handler.expand_db_attributes_many
+            for linktype, handler in link_rules.items()
+        },
+        reference_extractors={
+            linktype: handler.extract_references
+            for linktype, handler in link_rules.items()
+        },
     )
+
+    embed_rules = features.get_embed_types()
+    embed_rewriter = EmbedRewriter(
+        bulk_rules={
+            embedtype: handler.expand_db_attributes_many
+            for embedtype, handler in embed_rules.items()
+        },
+        reference_extractors={
+            embedtype: handler.extract_references
+            for embedtype, handler in embed_rules.items()
+        },
+    )
+
+    features.register_frontend_rewriter(link_rewriter, 100)
+    features.register_frontend_rewriter(embed_rewriter, 200)
+    return MultiRuleRewriter(features.get_frontend_rewriters())
 
 
 def expand_db_html(html):

--- a/wagtail/rich_text/feature_registry.py
+++ b/wagtail/rich_text/feature_registry.py
@@ -38,6 +38,11 @@ class FeatureRegistry:
         # HTML fragment to replace it with
         self.embed_types = {}
 
+        # a series of rewriter classes, and their ordering, for rewriting custom tags in the
+        # database representation of richtext into the frontend representation. Used for adding an
+        # entirely new concept to rich text, outside of the default link and embed rewriters
+        self.frontend_rewriters = []
+
         # a dict of dicts, one for each converter backend (editorhtml, contentstate etc);
         # each dict is a mapping of feature names to 'rule' objects that define how to convert
         # that feature's elements between editor representation and database representation
@@ -103,6 +108,18 @@ class FeatureRegistry:
         if not self.has_scanned_for_features:
             self._scan_for_features()
         return list(self.converter_rules_by_converter.get(converter_name, {}))
+
+    def register_frontend_rewriter(self, rewriter, order=300):
+        self.frontend_rewriters.append({"rewriter": rewriter, "order": order})
+
+    def get_frontend_rewriters(self):
+        if not self.has_scanned_for_features:
+            self._scan_for_features()
+
+        return [
+            r["rewriter"]
+            for r in sorted(self.frontend_rewriters, key=lambda e: e["order"])
+        ]
 
     @staticmethod
     def function_as_entity_handler(identifier, fn):

--- a/wagtail/rich_text/feature_registry.py
+++ b/wagtail/rich_text/feature_registry.py
@@ -1,3 +1,5 @@
+from operator import itemgetter
+
 from wagtail import hooks
 
 
@@ -110,23 +112,17 @@ class FeatureRegistry:
         return list(self.converter_rules_by_converter.get(converter_name, {}))
 
     def register_frontend_rewriter(self, rewriter, order=0):
-        self.frontend_rewriters.append({"rewriter": rewriter, "order": order})
+        self.frontend_rewriters.append((rewriter, order))
 
-    def get_frontend_rewriters(self, builtin_rewriters=()):
+    def get_frontend_rewriters(self):
         """
-        Return all registered rewriters in order, merged with `builtin_rewriters`.
-        Those are passed in rather than registered, so that building the rewriter
-        leaves the registry unchanged.
+        Return the registered (rewriter, order) pairs, sorted by order. A negative
+        order runs before Wagtail's own link and embed rewriters.
         """
         if not self.has_scanned_for_features:
             self._scan_for_features()
 
-        rewriters = [
-            *((0, rewriter) for rewriter in builtin_rewriters),
-            *((r["order"], r["rewriter"]) for r in self.frontend_rewriters),
-        ]
-        # sorted() is stable, so an equal order keeps the sequence above
-        return [rewriter for _, rewriter in sorted(rewriters, key=lambda pair: pair[0])]
+        return sorted(self.frontend_rewriters, key=itemgetter(1))
 
     @staticmethod
     def function_as_entity_handler(identifier, fn):

--- a/wagtail/rich_text/feature_registry.py
+++ b/wagtail/rich_text/feature_registry.py
@@ -109,17 +109,24 @@ class FeatureRegistry:
             self._scan_for_features()
         return list(self.converter_rules_by_converter.get(converter_name, {}))
 
-    def register_frontend_rewriter(self, rewriter, order=300):
+    def register_frontend_rewriter(self, rewriter, order=0):
         self.frontend_rewriters.append({"rewriter": rewriter, "order": order})
 
-    def get_frontend_rewriters(self):
+    def get_frontend_rewriters(self, builtin_rewriters=()):
+        """
+        Return all registered rewriters in order, merged with `builtin_rewriters`.
+        Those are passed in rather than registered, so that building the rewriter
+        leaves the registry unchanged.
+        """
         if not self.has_scanned_for_features:
             self._scan_for_features()
 
-        return [
-            r["rewriter"]
-            for r in sorted(self.frontend_rewriters, key=lambda e: e["order"])
+        rewriters = [
+            *((0, rewriter) for rewriter in builtin_rewriters),
+            *((r["order"], r["rewriter"]) for r in self.frontend_rewriters),
         ]
+        # sorted() is stable, so an equal order keeps the sequence above
+        return [rewriter for _, rewriter in sorted(rewriters, key=lambda pair: pair[0])]
 
     @staticmethod
     def function_as_entity_handler(identifier, fn):

--- a/wagtail/rich_text/rewriters.py
+++ b/wagtail/rich_text/rewriters.py
@@ -239,4 +239,7 @@ class MultiRuleRewriter:
 
     def extract_references(self, html):
         for rewriter in self.rewriters:
-            yield from rewriter.extract_references(html)
+            # rewriters registered via register_frontend_rewriter need only be callable
+            extract_references = getattr(rewriter, "extract_references", None)
+            if extract_references is not None:
+                yield from extract_references(html)

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -5,6 +5,7 @@ import django_filters
 from django import forms
 from django.http import HttpResponse
 from django.utils.safestring import mark_safe
+from django.utils.translation import get_language_info
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail import hooks
@@ -172,38 +173,57 @@ def register_intro_rule(features):
     )
 
 
-# register 'green' as a rich text feature which converts a `green` contentstate block
-# to a <green> tag in db HTML and vice versa, and registers a rewriter for it that
-# add an inline style
+# register a 'lang-<code>' rich text feature per language, which converts a run of text
+# to a <span lang="..."> tag in db HTML and vice versa, plus a rewriter that adds the
+# matching dir attribute on render
 @hooks.register("register_rich_text_features")
-def register_green_feature(features):
-    features.register_converter_rule(
-        "contentstate",
-        "green",
-        {
-            "from_database_format": {
-                "green": InlineStyleElementHandler("green"),
-            },
-            "to_database_format": {"style_map": {"green": "green"}},
-        },
-    )
+def register_language_features(features):
+    class LanguageDirectionRewriter:
+        FIND_LANG_SPAN = re.compile(r'<span\b[^>]*\blang="([\w-]+)"[^>]*>')
 
-    class GreenRewriter:
-        TAG_RE = re.compile(r"<green>(.+?)</green>")
+        def add_direction(self, match):
+            try:
+                is_rtl = get_language_info(match.group(1))["bidi"]
+            except KeyError:
+                is_rtl = False
 
-        def replace_tag(self, match):
-            content = match.groups(1)[0]
-            return '<span class="make-me-green">{content}</span>'.format(
-                content=content
-            )
-
-        def extract_references(self, html):
-            return []
+            tag = match.group(0)
+            return tag[:-1] + ' dir="rtl">' if is_rtl else tag
 
         def __call__(self, html):
-            return self.TAG_RE.sub(self.replace_tag, html)
+            return self.FIND_LANG_SPAN.sub(self.add_direction, html)
 
-    features.register_frontend_rewriter(GreenRewriter(), order=300)
+    for code in ["nl", "ar"]:
+        feature_name = f"lang-{code}"
+        style = f"LANG_{code.upper()}"
+
+        features.register_editor_plugin(
+            "draftail",
+            feature_name,
+            draftail_features.InlineStyleFeature(
+                {
+                    "type": style,
+                    "label": code,
+                    "description": get_language_info(code)["name_local"],
+                }
+            ),
+        )
+        features.register_converter_rule(
+            "contentstate",
+            feature_name,
+            {
+                "from_database_format": {
+                    f'span[lang="{code}"]': InlineStyleElementHandler(style),
+                },
+                "to_database_format": {
+                    "style_map": {
+                        style: {"element": "span", "props": {"lang": code}},
+                    },
+                },
+            },
+        )
+
+    features.register_frontend_rewriter(LanguageDirectionRewriter())
 
 
 # and use a second registered rich-text feature which collides with an existing rewriter but *should not* be triggered because of the ordering
@@ -242,7 +262,7 @@ def register_embed_overlapping_feature(features):
         def __call__(self, html):
             return self.TAG_RE.sub(self.replace_tag, html)
 
-    features.register_frontend_rewriter(EmbedOverlappingRewriter(), order=1)
+    features.register_frontend_rewriter(EmbedOverlappingRewriter(), order=-1)
 
 
 class PanicMenuItem(ActionMenuItem):

--- a/wagtail/test/testapp/wagtail_hooks.py
+++ b/wagtail/test/testapp/wagtail_hooks.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import django_filters
 from django import forms
@@ -16,7 +17,10 @@ from wagtail.admin.panels import (
     PublishingPanel,
     TabbedInterface,
 )
-from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElementHandler
+from wagtail.admin.rich_text.converters.html_to_contentstate import (
+    BlockElementHandler,
+    InlineStyleElementHandler,
+)
 from wagtail.admin.search import SearchArea
 from wagtail.admin.site_summary import SummaryItem
 from wagtail.admin.ui.components import Component
@@ -26,6 +30,7 @@ from wagtail.admin.views.account import BaseSettingsPanel
 from wagtail.admin.widgets import Button
 from wagtail.permission_policies import ModelPermissionPolicy
 from wagtail.permissions import register_permission_policy
+from wagtail.rich_text import rewriters
 from wagtail.snippets.bulk_actions.snippet_bulk_action import SnippetBulkAction
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.chooser import SnippetChooserViewSet
@@ -165,6 +170,79 @@ def register_intro_rule(features):
             },
         },
     )
+
+
+# register 'green' as a rich text feature which converts a `green` contentstate block
+# to a <green> tag in db HTML and vice versa, and registers a rewriter for it that
+# add an inline style
+@hooks.register("register_rich_text_features")
+def register_green_feature(features):
+    features.register_converter_rule(
+        "contentstate",
+        "green",
+        {
+            "from_database_format": {
+                "green": InlineStyleElementHandler("green"),
+            },
+            "to_database_format": {"style_map": {"green": "green"}},
+        },
+    )
+
+    class GreenRewriter:
+        TAG_RE = re.compile(r"<green>(.+?)</green>")
+
+        def replace_tag(self, match):
+            content = match.groups(1)[0]
+            return '<span class="make-me-green">{content}</span>'.format(
+                content=content
+            )
+
+        def extract_references(self, html):
+            return []
+
+        def __call__(self, html):
+            return self.TAG_RE.sub(self.replace_tag, html)
+
+    features.register_frontend_rewriter(GreenRewriter(), order=300)
+
+
+# and use a second registered rich-text feature which collides with an existing rewriter but *should not* be triggered because of the ordering
+@hooks.register("register_rich_text_features")
+def register_embed_overlapping_feature(features):
+    features.register_converter_rule(
+        "contentstate",
+        "embed_overlapping",
+        {
+            "from_database_format": {
+                "embed_overlapping": InlineStyleElementHandler("embed_overlapping"),
+            },
+            "to_database_format": {
+                "style_map": {"embed_overlapping": "embed_overlapping"}
+            },
+        },
+    )
+
+    class EmbedOverlappingRewriter:
+        TAG_RE = rewriters.FIND_EMBED_TAG
+
+        def replace_tag(self, match):
+            # Make a conditional replacement, so that if it
+            # matches, we can replace it with something that
+            # prevents the "real" embed handler running, but
+            # that we can also essentially "pass" on the
+            # blob, without replacing anything in it
+            attrs = rewriters.extract_attrs(match.group(1))
+            if "audio_source" in attrs:
+                return '<audio controls src="{}"></audio>'.format(attrs["audio_source"])
+            return match.group(0)
+
+        def extract_references(self, html):
+            return []
+
+        def __call__(self, html):
+            return self.TAG_RE.sub(self.replace_tag, html)
+
+    features.register_frontend_rewriter(EmbedOverlappingRewriter(), order=1)
 
 
 class PanicMenuItem(ActionMenuItem):

--- a/wagtail/tests/test_rich_text.py
+++ b/wagtail/tests/test_rich_text.py
@@ -4,6 +4,7 @@ from django.forms.models import modelform_factory
 from django.test import TestCase, override_settings
 from django.utils import translation
 
+from wagtail.admin.rich_text.converters.contentstate import ContentstateConverter
 from wagtail.fields import RichTextField
 from wagtail.models import Locale, Site
 from wagtail.rich_text import (
@@ -11,6 +12,9 @@ from wagtail.rich_text import (
     RichTextMaxLengthValidator,
     RichTextMinLengthValidator,
     expand_db_html,
+    extract_references_from_rich_text,
+    features,
+    get_rewriter,
 )
 from wagtail.rich_text.feature_registry import FeatureRegistry
 from wagtail.rich_text.pages import PageLinkHandler
@@ -271,23 +275,35 @@ class TestFeatureRegistry(TestCase):
         self.assertIsNone(features.get_editor_plugin("made_up_editor", "blockquote"))
         self.assertIsNone(features.get_editor_plugin("draftail", "made_up_feature"))
 
-    def test_rewriters_registry(self):
-        # testapp/wagtail_hooks.py defines a rich text feature and rewriter for
-        # each "green" and "embedoverlapping" - test that it comes back in the
-        # list, and is in the correct order
-        features = FeatureRegistry()
+    def test_frontend_rewriters_are_returned_in_order(self):
+        # testapp/wagtail_hooks.py registers an EmbedOverlappingRewriter (order=-1)
+        # and a LanguageDirectionRewriter (default order)
+        registry = FeatureRegistry()
 
-        rewriters = features.get_frontend_rewriters()
-        # Expect only the two added rewriters -- Link and Embed are added later
-        self.assertEqual(len(rewriters), 2)
-
-        embed_overlapping_rewriter = rewriters[0]
         self.assertEqual(
-            embed_overlapping_rewriter.__class__.__name__,
-            "EmbedOverlappingRewriter",
+            [type(r).__name__ for r in registry.get_frontend_rewriters()],
+            ["EmbedOverlappingRewriter", "LanguageDirectionRewriter"],
         )
-        green_rewriter = rewriters[-1]
-        self.assertEqual(green_rewriter.__class__.__name__, "GreenRewriter")
+
+    def test_builtin_rewriters_run_first_unless_order_is_negative(self):
+        registry = FeatureRegistry()
+
+        rewriters = registry.get_frontend_rewriters(["link", "embed"])
+        self.assertEqual(
+            [r if isinstance(r, str) else type(r).__name__ for r in rewriters],
+            ["EmbedOverlappingRewriter", "link", "embed", "LanguageDirectionRewriter"],
+        )
+
+    def test_frontend_rewriters_sort_is_stable(self):
+        registry = FeatureRegistry()
+        registry.has_scanned_for_features = True
+        registry.frontend_rewriters = []
+
+        registry.register_frontend_rewriter("late", order=999)
+        registry.register_frontend_rewriter("first")
+        registry.register_frontend_rewriter("second")
+
+        self.assertEqual(registry.get_frontend_rewriters(), ["first", "second", "late"])
 
 
 class TestLinkRewriterTagReplacing(TestCase):
@@ -471,10 +487,39 @@ class TestRichTextLengthValidators(TestCase):
 
 
 class TestCustomRichTextRewriter(TestCase):
-    def test_custom_tag_replacement(self):
-        expanded = expand_db_html("<green>traffic light</green>")
-        self.assertNotIn("<green>", expanded)
-        self.assertEqual(expanded, '<span class="make-me-green">traffic light</span>')
+    def test_left_to_right_language_is_left_alone(self):
+        self.assertEqual(
+            expand_db_html('<p>They call it <span lang="nl">geweldig</span>.</p>'),
+            '<p>They call it <span lang="nl">geweldig</span>.</p>',
+        )
+
+    def test_right_to_left_language_gains_a_direction(self):
+        self.assertEqual(
+            expand_db_html(
+                '<p>He said <span lang="ar">\u0645\u0631\u062d\u0628\u0627</span>.</p>'
+            ),
+            '<p>He said <span lang="ar" dir="rtl">\u0645\u0631\u062d\u0628\u0627</span>.</p>',
+        )
+
+    def test_other_attributes_are_preserved(self):
+        self.assertEqual(
+            expand_db_html('<span class="quote" lang="he">x</span>'),
+            '<span class="quote" lang="he" dir="rtl">x</span>',
+        )
+
+    def test_language_feature_round_trips_through_the_editor(self):
+        converter = ContentstateConverter(features=["lang-nl", "lang-ar"])
+        for code in ["nl", "ar"]:
+            with self.subTest(code=code):
+                db_html = (
+                    f'<p data-block-key="00000">x <span lang="{code}">y</span>.</p>'
+                )
+                self.assertEqual(
+                    converter.to_database_format(
+                        converter.from_database_format(db_html)
+                    ),
+                    db_html,
+                )
 
     def test_ordering_expecting_replacement(self):
         url = "https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg"
@@ -483,7 +528,6 @@ class TestCustomRichTextRewriter(TestCase):
                 url
             )
         )
-        self.assertIn("", expanded)
         self.assertIn('<audio controls src="{}"></audio>'.format(url), expanded)
         self.assertNotIn("dQw4w9WgXcQ", expanded)
 
@@ -493,3 +537,30 @@ class TestCustomRichTextRewriter(TestCase):
         )
         self.assertIn("dQw4w9WgXcQ", expanded)
         self.assertNotIn("audio controls", expanded)
+
+    def test_builtin_rewriters_are_slotted_into_the_ordering(self):
+        self.assertEqual(
+            [type(r).__name__ for r in get_rewriter().rewriters],
+            [
+                "EmbedOverlappingRewriter",
+                "LinkRewriter",
+                "EmbedRewriter",
+                "LanguageDirectionRewriter",
+            ],
+        )
+
+    def test_building_the_rewriter_does_not_mutate_the_registry(self):
+        before = list(features.get_frontend_rewriters())
+        get_rewriter.cache_clear()
+        try:
+            get_rewriter()
+            get_rewriter.cache_clear()
+            get_rewriter()
+        finally:
+            get_rewriter.cache_clear()
+        self.assertEqual(features.get_frontend_rewriters(), before)
+
+    def test_extract_references_is_optional(self):
+        self.assertEqual(
+            list(extract_references_from_rich_text('<span lang="nl">x</span>')), []
+        )

--- a/wagtail/tests/test_rich_text.py
+++ b/wagtail/tests/test_rich_text.py
@@ -281,17 +281,11 @@ class TestFeatureRegistry(TestCase):
         registry = FeatureRegistry()
 
         self.assertEqual(
-            [type(r).__name__ for r in registry.get_frontend_rewriters()],
-            ["EmbedOverlappingRewriter", "LanguageDirectionRewriter"],
-        )
-
-    def test_builtin_rewriters_run_first_unless_order_is_negative(self):
-        registry = FeatureRegistry()
-
-        rewriters = registry.get_frontend_rewriters(["link", "embed"])
-        self.assertEqual(
-            [r if isinstance(r, str) else type(r).__name__ for r in rewriters],
-            ["EmbedOverlappingRewriter", "link", "embed", "LanguageDirectionRewriter"],
+            [
+                (type(r).__name__, order)
+                for r, order in registry.get_frontend_rewriters()
+            ],
+            [("EmbedOverlappingRewriter", -1), ("LanguageDirectionRewriter", 0)],
         )
 
     def test_frontend_rewriters_sort_is_stable(self):
@@ -299,11 +293,14 @@ class TestFeatureRegistry(TestCase):
         registry.has_scanned_for_features = True
         registry.frontend_rewriters = []
 
-        registry.register_frontend_rewriter("late", order=999)
+        registry.register_frontend_rewriter("late", order=1)
         registry.register_frontend_rewriter("first")
         registry.register_frontend_rewriter("second")
 
-        self.assertEqual(registry.get_frontend_rewriters(), ["first", "second", "late"])
+        self.assertEqual(
+            [rewriter for rewriter, _ in registry.get_frontend_rewriters()],
+            ["first", "second", "late"],
+        )
 
 
 class TestLinkRewriterTagReplacing(TestCase):

--- a/wagtail/tests/test_rich_text.py
+++ b/wagtail/tests/test_rich_text.py
@@ -271,6 +271,24 @@ class TestFeatureRegistry(TestCase):
         self.assertIsNone(features.get_editor_plugin("made_up_editor", "blockquote"))
         self.assertIsNone(features.get_editor_plugin("draftail", "made_up_feature"))
 
+    def test_rewriters_registry(self):
+        # testapp/wagtail_hooks.py defines a rich text feature and rewriter for
+        # each "green" and "embedoverlapping" - test that it comes back in the
+        # list, and is in the correct order
+        features = FeatureRegistry()
+
+        rewriters = features.get_frontend_rewriters()
+        # Expect only the two added rewriters -- Link and Embed are added later
+        self.assertEqual(len(rewriters), 2)
+
+        embed_overlapping_rewriter = rewriters[0]
+        self.assertEqual(
+            embed_overlapping_rewriter.__class__.__name__,
+            "EmbedOverlappingRewriter",
+        )
+        green_rewriter = rewriters[-1]
+        self.assertEqual(green_rewriter.__class__.__name__, "GreenRewriter")
+
 
 class TestLinkRewriterTagReplacing(TestCase):
     def test_should_follow_default_behaviour(self):
@@ -450,3 +468,28 @@ class TestRichTextLengthValidators(TestCase):
                 self.assertEqual(validator.clean("<p>U+2764 U+FE0F ❤️</p>"), 16)
                 # Counts symbols with zero-width joiners.
                 self.assertEqual(validator.clean("<p>👨‍👨‍👧</p>"), 5)
+
+
+class TestCustomRichTextRewriter(TestCase):
+    def test_custom_tag_replacement(self):
+        expanded = expand_db_html("<green>traffic light</green>")
+        self.assertNotIn("<green>", expanded)
+        self.assertEqual(expanded, '<span class="make-me-green">traffic light</span>')
+
+    def test_ordering_expecting_replacement(self):
+        url = "https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg"
+        expanded = expand_db_html(
+            '<embed audio_source="{}" embedtype="media" url="https://www.youtube.com/watch?v=dQw4w9WgXcQ"/>'.format(
+                url
+            )
+        )
+        self.assertIn("", expanded)
+        self.assertIn('<audio controls src="{}"></audio>'.format(url), expanded)
+        self.assertNotIn("dQw4w9WgXcQ", expanded)
+
+    def test_ordering_expecting_fallthrough(self):
+        expanded = expand_db_html(
+            '<embed embedtype="media" url="https://www.youtube.com/watch?v=dQw4w9WgXcQ"/>'
+        )
+        self.assertIn("dQw4w9WgXcQ", expanded)
+        self.assertNotIn("audio controls", expanded)


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/4223

### Description

Supersedes #9292, rebased onto `main` with some of the review feedback applied.

- Rebased. `get_rewriter()` was rewritten upstream since #9292 was opened (`expand_db_attributes` → `expand_db_attributes_many`, positional args → keyword args), so the original no longer applied.
- The built-in link and embed rewriters are passed to `get_frontend_rewriters()` rather than registered into the feature registry from inside `get_rewriter()`. Registering them there meant `features.get_frontend_rewriters()` returned different results depending on whether any rich text had been rendered yet, and appended both rewriters a second time if the `lru_cache` was ever cleared.
- `order` now follows the same convention as `hooks.register`: default `0`, ties broken by registration order, and a negative order to run before Wagtail's own rewriters. This replaces the `100`/`200`/`300` constants, which only made sense relative to the built-ins' positions, while keeping the ability to pre-empt a built-in rewriter.
- `extract_references` is now optional on a rewriter. The docs said a plain function would do, but `MultiRuleRewriter.extract_references` called the method on every rewriter, so a function raised `AttributeError` from the reference index - on page save rather than on render.
- The docs example is now the language use case from #4694, and shows both halves: the converter rule that stores `<span lang="…">`, and the rewriter that derives `dir="rtl"` from the language code. The previous example rewrote a `<maori>` tag that nothing put into the database, so copying it gave you a rewriter that never fired.
- Documented that a rewriter is instantiated once and reused for the lifetime of the process, so it must not keep per-request state on `self`.
- `match.groups(1)[0]` → `match.group(1)`. `groups()` takes a default for unmatched groups, not a group number; the original worked by accident. Also removed an `assertIn("", expanded)` that passes unconditionally.


### AI usage

- Improved the docs I initially changed / wrote compared to the original.
- Helped me catch some of bugs / errors in original PR
- Wrote the list above on what's changed compared to the original

I did validate everything AI did and have tested the examples in bakerydemo.