### PR TITLE
Add autosave coverage for new children in top-level InlinePanels

### DIFF
--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -4248,6 +4248,100 @@ class TestNestedInlinePanel(PageFixturesMixin, WagtailTestUtils, TestCase):
         )
 
 
+class TestAutosaveTopLevelInlinePanel(PageFixturesMixin, WagtailTestUtils, TestCase):
+    """
+    Autosave coverage for a *newly added* child in a top-level InlinePanel.
+
+    TestNestedInlinePanel.test_post_edit_with_json_response only asserts
+    field_updates for a nested formset; the top-level `speakers` formset there
+    already carries an id, so the "new child in a top-level formset" path is
+    not exercised anywhere. If the id in field_updates never reaches the open
+    form, the next autosave posts the same id-less child again and the server
+    inserts a duplicate. See #14568.
+    """
+
+    fixtures = ["test.json"]
+
+    def setUp(self):
+        self.christmas_page = EventPage.objects.get(url_path="/home/events/christmas/")
+        self.speaker = self.christmas_page.speakers.first()
+        # Draft, so that form.save(commit=not page.live) commits child objects
+        # to the database, which is the state an editor is in while drafting.
+        self.christmas_page.unpublish()
+        self.user = self.login()
+
+    def _post_data(self, related_links):
+        return nested_form_data(
+            {
+                "title": "Christmas",
+                "date_from": "2017-12-25",
+                "date_to": "2017-12-25",
+                "slug": "christmas",
+                "audience": "public",
+                "location": "The North Pole",
+                "cost": "Free",
+                "carousel_items": inline_formset([]),
+                "speakers": inline_formset(
+                    [
+                        {
+                            "id": self.speaker.id,
+                            "first_name": "Jeff",
+                            "last_name": "Christmas",
+                            "awards": inline_formset([]),
+                        },
+                    ],
+                    initial=1,
+                ),
+                "related_links": related_links,
+                "head_counts": inline_formset([]),
+            }
+        )
+
+    def _autosave(self, post_data):
+        response = self.client.post(
+            reverse("wagtailadmin_pages:edit", args=(self.christmas_page.id,)),
+            post_data,
+            headers={"Accept": "application/json"},
+        )
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+        self.assertTrue(response_json["success"])
+        return response_json
+
+    def test_field_updates_carries_id_for_new_top_level_child(self):
+        post_data = self._post_data(
+            inline_formset(
+                [{"title": "Santa's blog", "link_external": "http://example.com/"}]
+            )
+        )
+        response_json = self._autosave(post_data)
+
+        new_link = self.christmas_page.related_links.get(title="Santa's blog")
+        self.assertEqual(
+            response_json["field_updates"],
+            {
+                "related_links-INITIAL_FORMS": "1",
+                "related_links-0-id": str(new_link.id),
+            },
+        )
+
+    def test_autosave_after_applying_field_updates_does_not_duplicate(self):
+        post_data = self._post_data(
+            inline_formset(
+                [{"title": "Santa's blog", "link_external": "http://example.com/"}]
+            )
+        )
+        response_json = self._autosave(post_data)
+        self.assertEqual(self.christmas_page.related_links.count(), 1)
+
+        # Apply field_updates to the payload, as AutosaveController is meant to
+        # apply them to the open form, then autosave again.
+        post_data.update(response_json["field_updates"])
+        self._autosave(post_data)
+
+        self.assertEqual(self.christmas_page.related_links.count(), 1)
+
+
 @override_settings(WAGTAIL_I18N_ENABLED=True)
 class TestLocaleSelector(PageFixturesMixin, WagtailTestUtils, TestCase):
     fixtures = ["test.json"]


### PR DESCRIPTION
Refs #14568. Test coverage only, this is not the fix.

### Description

`TestNestedInlinePanel.test_post_edit_with_json_response` is the only test that asserts the contents of `field_updates` for a page, and it only covers a nested formset. The top-level `speakers` formset in that fixture already has an id, so "new child in a top-level formset", which is the most common InlinePanel shape there is, was never exercised.

Two tests close that gap, both on the existing test app, no new models:

- `test_field_updates_carries_id_for_new_top_level_child` asserts that `get_field_updates_for_resave()` emits the new child's pk, so an open form has what it needs to avoid re-posting an id-less child.
- `test_autosave_after_applying_field_updates_does_not_duplicate` is the positive control. Apply those updates before the next autosave and the child count stays at one.

Both pass on `main` today. They are here to stop the server half of the autosave contract regressing while the client half is investigated. In #14568 the same InlinePanel child gets inserted once per autosave cycle because the id in `field_updates` never reaches the open form, and the server side is provably not at fault.

I have a third test that replays an autosave POST verbatim without applying `field_updates`, which reproduces the duplicate exactly. I left it out on purpose. The server does not promise idempotency there, and since the defect looks client-side that test would still fail after a fix rather than turning green. It is written up in #14568 instead.

`ruff format` and `ruff check` clean, tests run with `python runtests.py wagtail.admin.tests.pages.test_edit_page`.

### AI usage

Claude Code was used throughout: the investigation behind #14568, drafting these tests, and the wording of this description and the issue. Everything here has been human reviewed, I have read, run and verified all of it.
