### PR TITLE
Expand more details of ForeignKey, ManyToManyField, GenericRelation in APIv3

### DIFF
--- a/wagtail/api/v3/schemas/generators/read.py
+++ b/wagtail/api/v3/schemas/generators/read.py
@@ -2,8 +2,9 @@ import copy
 from typing import Any, Callable, Literal, cast
 
 from django.core.exceptions import FieldDoesNotExist
-from django.db.models import ForeignKey, Model
+from django.db.models import Model
 from django.db.models.fields import Field
+from django.db.models.fields.related import RelatedField
 from django.db.models.fields.reverse_related import ForeignObjectRel
 from ninja import Schema
 from ninja.errors import ConfigError
@@ -293,9 +294,12 @@ class SchemaGenerator:
 
 
 def foreign_key_schema(generator: SchemaGenerator, field: Field) -> FieldSchema:
-    field = cast(ForeignKey, field)
+    field = cast(RelatedField, field)
     schema = generator.get_foreign_key_schema(field.related_model)
-    schema = (schema | None) if field.null else schema
+    if field.many_to_many or field.one_to_many:
+        schema = list[schema]  # ty: ignore[invalid-type-form]
+    elif field.null:
+        schema = schema | None
     return cast(type, schema), None, None
 
 
@@ -358,7 +362,7 @@ def rich_text_schema(generator: SchemaGenerator, field: Field) -> FieldSchema:
 
 
 read_generator = SchemaGenerator()
-read_generator.register_field_schema(ForeignKey, foreign_key_schema)
+read_generator.register_field_schema(RelatedField, foreign_key_schema)
 read_generator.register_field_schema(ForeignObjectRel, reverse_related_schema)
 read_generator.register_field_schema(StreamField, streamfield_schema)
 read_generator.register_field_schema(TaggableManager, tags_schema)

--- a/wagtail/api/v3/schemas/generators/read.py
+++ b/wagtail/api/v3/schemas/generators/read.py
@@ -115,18 +115,16 @@ class SchemaGenerator:
         return self._reverse_related_schema_cache[model]
 
     def get_foreign_key_schema(self, model: type[Model]) -> type[Schema]:
-        """Build a minimal schema for a foreign key's related model.
-
-        Rather than a full nested schema, this only exposes the related model's
-        primary key(s) (which may be composite) and a ``meta.type`` label, to
-        keep foreign key fields cheap and avoid unbounded recursion through
-        relations.
+        """Build a nested schema for a foreign key's related model, without
+        following any reverse relations (to avoid infinite recursion).
         """
         if model not in self._foreign_key_schema_cache:
-            pk_names = self._get_pk_names(model)
             name = f"{model._meta.object_name}ForeignKeySchema"
-            schema = create_schema(
-                model, name=f"{name}Base", fields=pk_names, base_class=BaseSchema
+            schema = self.build_schema(
+                model,
+                name=f"{name}Base",
+                base_class=BaseSchema,
+                follow_reverse_related=False,
             )
             meta_schema = self._narrowed_meta_schema(
                 BaseSchema.model_fields["meta"].annotation, model

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -1153,9 +1153,33 @@
           },
           "meta": {
             "$ref": "#/components/schemas/AdvertMetaSchema"
+          },
+          "tags": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
+          },
+          "text": {
+            "maxLength": 255,
+            "title": "Text",
+            "type": "string"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
           }
         },
-        "required": ["meta"],
+        "required": ["meta", "text"],
         "title": "AdvertForeignKeySchema",
         "type": "object"
       },

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -19106,6 +19106,46 @@
       },
       "ManyToManyBlogPageCreateSchema": {
         "properties": {
+          "adverts": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Adverts",
+            "type": "array"
+          },
+          "blog_categories": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Blog Categories",
+            "type": "array"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/RichTextInputSchema"
+              }
+            ],
+            "default": "",
+            "features": [
+              "embed",
+              "image",
+              "hr",
+              "link",
+              "bold",
+              "italic",
+              "h2",
+              "h3",
+              "h4",
+              "ol",
+              "ul",
+              "document-link"
+            ],
+            "title": "Body"
+          },
           "meta": {
             "$ref": "#/components/schemas/ManyToManyBlogPageCreateMetaSchema"
           },
@@ -19167,7 +19207,7 @@
             "type": "string"
           }
         },
-        "required": ["meta", "title"],
+        "required": ["meta", "title", "adverts", "blog_categories"],
         "title": "ManyToManyBlogPageCreateSchema",
         "type": "object"
       },
@@ -19339,6 +19379,60 @@
       },
       "ManyToManyBlogPagePatchSchema": {
         "properties": {
+          "adverts": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Adverts"
+          },
+          "blog_categories": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Blog Categories"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/RichTextInputSchema"
+              }
+            ],
+            "default": "",
+            "features": [
+              "embed",
+              "image",
+              "hr",
+              "link",
+              "bold",
+              "italic",
+              "h2",
+              "h3",
+              "h4",
+              "ol",
+              "ul",
+              "document-link"
+            ],
+            "title": "Body"
+          },
           "meta": {
             "anyOf": [
               {
@@ -19419,6 +19513,45 @@
       },
       "ManyToManyBlogPageSchema": {
         "properties": {
+          "adverts": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Adverts",
+            "type": "array"
+          },
+          "blog_categories": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Blog Categories",
+            "type": "array"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body",
+            "x-rich-text-features": [
+              "embed",
+              "image",
+              "hr",
+              "link",
+              "bold",
+              "italic",
+              "h2",
+              "h3",
+              "h4",
+              "ol",
+              "ul",
+              "document-link"
+            ]
+          },
           "id": {
             "title": "Id",
             "type": "integer"
@@ -19431,7 +19564,7 @@
             "type": "string"
           }
         },
-        "required": ["meta", "id", "title"],
+        "required": ["meta", "id", "title", "adverts", "blog_categories"],
         "title": "ManyToManyBlogPageSchema",
         "type": "object"
       },
@@ -23037,6 +23170,20 @@
       },
       "PageWithGenericRelationSchema": {
         "properties": {
+          "generic_relation": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Generic Relation"
+          },
           "id": {
             "title": "Id",
             "type": "integer"

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -1138,6 +1138,27 @@
         "title": "AdvertCreateSchema",
         "type": "object"
       },
+      "AdvertForeignKeySchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/AdvertMetaSchema"
+          }
+        },
+        "required": ["meta"],
+        "title": "AdvertForeignKeySchema",
+        "type": "object"
+      },
       "AdvertMetaSchema": {
         "properties": {
           "detail_url": {
@@ -1978,6 +1999,60 @@
         },
         "required": ["meta", "id", "title"],
         "title": "BasePageSchema",
+        "type": "object"
+      },
+      "BlogCategoryForeignKeySchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/BlogCategoryMetaSchema"
+          }
+        },
+        "required": ["meta"],
+        "title": "BlogCategoryForeignKeySchema",
+        "type": "object"
+      },
+      "BlogCategoryMetaSchema": {
+        "properties": {
+          "type": {
+            "const": "tests.BlogCategory",
+            "title": "Type",
+            "type": "string"
+          },
+          "warnings": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/RichTextRemoval"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warnings"
+          }
+        },
+        "required": ["type"],
+        "title": "BlogCategoryMetaSchema",
         "type": "object"
       },
       "BlogEntryPageCarouselItemCreateSchema": {
@@ -19515,14 +19590,14 @@
         "properties": {
           "adverts": {
             "items": {
-              "type": "integer"
+              "$ref": "#/components/schemas/AdvertForeignKeySchema"
             },
             "title": "Adverts",
             "type": "array"
           },
           "blog_categories": {
             "items": {
-              "type": "integer"
+              "$ref": "#/components/schemas/BlogCategoryForeignKeySchema"
             },
             "title": "Blog Categories",
             "type": "array"
@@ -19564,7 +19639,7 @@
             "type": "string"
           }
         },
-        "required": ["meta", "id", "title", "adverts", "blog_categories"],
+        "required": ["meta", "id", "title"],
         "title": "ManyToManyBlogPageSchema",
         "type": "object"
       },
@@ -23171,18 +23246,11 @@
       "PageWithGenericRelationSchema": {
         "properties": {
           "generic_relation": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Generic Relation"
+            "items": {
+              "$ref": "#/components/schemas/RelatedGenericRelationForeignKeySchema"
+            },
+            "title": "Generic Relation",
+            "type": "array"
           },
           "id": {
             "title": "Id",
@@ -24297,6 +24365,60 @@
           "created_at"
         ],
         "title": "RedirectSchema",
+        "type": "object"
+      },
+      "RelatedGenericRelationForeignKeySchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/RelatedGenericRelationMetaSchema"
+          }
+        },
+        "required": ["meta"],
+        "title": "RelatedGenericRelationForeignKeySchema",
+        "type": "object"
+      },
+      "RelatedGenericRelationMetaSchema": {
+        "properties": {
+          "type": {
+            "const": "tests.RelatedGenericRelation",
+            "title": "Type",
+            "type": "string"
+          },
+          "warnings": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/RichTextRemoval"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warnings"
+          }
+        },
+        "required": ["type"],
+        "title": "RelatedGenericRelationMetaSchema",
         "type": "object"
       },
       "RequiredDatePageCreateMetaSchema": {

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -811,6 +811,27 @@
         "title": "AdvertCreateSchema",
         "type": "object"
       },
+      "AdvertForeignKeySchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/AdvertMetaSchema"
+          }
+        },
+        "required": ["meta"],
+        "title": "AdvertForeignKeySchema",
+        "type": "object"
+      },
       "AdvertMetaSchema": {
         "properties": {
           "detail_url": {
@@ -1570,6 +1591,60 @@
         },
         "required": ["meta", "title"],
         "title": "BasePageSchema",
+        "type": "object"
+      },
+      "BlogCategoryForeignKeySchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/BlogCategoryMetaSchema"
+          }
+        },
+        "required": ["meta"],
+        "title": "BlogCategoryForeignKeySchema",
+        "type": "object"
+      },
+      "BlogCategoryMetaSchema": {
+        "properties": {
+          "type": {
+            "const": "tests.BlogCategory",
+            "title": "Type",
+            "type": "string"
+          },
+          "warnings": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/RichTextRemoval"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warnings"
+          }
+        },
+        "required": ["type"],
+        "title": "BlogCategoryMetaSchema",
         "type": "object"
       },
       "BlogEntryPageCarouselItemCreateSchema": {
@@ -14965,14 +15040,14 @@
         "properties": {
           "adverts": {
             "items": {
-              "type": "integer"
+              "$ref": "#/components/schemas/AdvertForeignKeySchema"
             },
             "title": "Adverts",
             "type": "array"
           },
           "blog_categories": {
             "items": {
-              "type": "integer"
+              "$ref": "#/components/schemas/BlogCategoryForeignKeySchema"
             },
             "title": "Blog Categories",
             "type": "array"
@@ -15014,7 +15089,7 @@
             "type": "string"
           }
         },
-        "required": ["meta", "id", "title", "adverts", "blog_categories"],
+        "required": ["meta", "id", "title"],
         "title": "ManyToManyBlogPageSchema",
         "type": "object"
       },
@@ -17703,18 +17778,11 @@
       "PageWithGenericRelationSchema": {
         "properties": {
           "generic_relation": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "integer"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Generic Relation"
+            "items": {
+              "$ref": "#/components/schemas/RelatedGenericRelationForeignKeySchema"
+            },
+            "title": "Generic Relation",
+            "type": "array"
           },
           "id": {
             "title": "Id",
@@ -18611,6 +18679,60 @@
           "created_at"
         ],
         "title": "RedirectSchema",
+        "type": "object"
+      },
+      "RelatedGenericRelationForeignKeySchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/RelatedGenericRelationMetaSchema"
+          }
+        },
+        "required": ["meta"],
+        "title": "RelatedGenericRelationForeignKeySchema",
+        "type": "object"
+      },
+      "RelatedGenericRelationMetaSchema": {
+        "properties": {
+          "type": {
+            "const": "tests.RelatedGenericRelation",
+            "title": "Type",
+            "type": "string"
+          },
+          "warnings": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/RichTextRemoval"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warnings"
+          }
+        },
+        "required": ["type"],
+        "title": "RelatedGenericRelationMetaSchema",
         "type": "object"
       },
       "RequiredDatePageCreateMetaSchema": {

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -14665,6 +14665,46 @@
       },
       "ManyToManyBlogPageCreateSchema": {
         "properties": {
+          "adverts": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Adverts",
+            "type": "array"
+          },
+          "blog_categories": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Blog Categories",
+            "type": "array"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/RichTextInputSchema"
+              }
+            ],
+            "default": "",
+            "features": [
+              "embed",
+              "image",
+              "hr",
+              "link",
+              "bold",
+              "italic",
+              "h2",
+              "h3",
+              "h4",
+              "ol",
+              "ul",
+              "document-link"
+            ],
+            "title": "Body"
+          },
           "meta": {
             "$ref": "#/components/schemas/ManyToManyBlogPageCreateMetaSchema"
           },
@@ -14688,7 +14728,7 @@
             "type": "string"
           }
         },
-        "required": ["meta", "title"],
+        "required": ["meta", "title", "adverts", "blog_categories"],
         "title": "ManyToManyBlogPageCreateSchema",
         "type": "object"
       },
@@ -14827,6 +14867,60 @@
       },
       "ManyToManyBlogPagePatchSchema": {
         "properties": {
+          "adverts": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Adverts"
+          },
+          "blog_categories": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Blog Categories"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/RichTextInputSchema"
+              }
+            ],
+            "default": "",
+            "features": [
+              "embed",
+              "image",
+              "hr",
+              "link",
+              "bold",
+              "italic",
+              "h2",
+              "h3",
+              "h4",
+              "ol",
+              "ul",
+              "document-link"
+            ],
+            "title": "Body"
+          },
           "meta": {
             "anyOf": [
               {
@@ -14869,6 +14963,45 @@
       },
       "ManyToManyBlogPageSchema": {
         "properties": {
+          "adverts": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Adverts",
+            "type": "array"
+          },
+          "blog_categories": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Blog Categories",
+            "type": "array"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body",
+            "x-rich-text-features": [
+              "embed",
+              "image",
+              "hr",
+              "link",
+              "bold",
+              "italic",
+              "h2",
+              "h3",
+              "h4",
+              "ol",
+              "ul",
+              "document-link"
+            ]
+          },
           "id": {
             "title": "Id",
             "type": "integer"
@@ -14881,7 +15014,7 @@
             "type": "string"
           }
         },
-        "required": ["meta", "id", "title"],
+        "required": ["meta", "id", "title", "adverts", "blog_categories"],
         "title": "ManyToManyBlogPageSchema",
         "type": "object"
       },
@@ -17569,6 +17702,20 @@
       },
       "PageWithGenericRelationSchema": {
         "properties": {
+          "generic_relation": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Generic Relation"
+          },
           "id": {
             "title": "Id",
             "type": "integer"

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -826,9 +826,33 @@
           },
           "meta": {
             "$ref": "#/components/schemas/AdvertMetaSchema"
+          },
+          "tags": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
+          },
+          "text": {
+            "maxLength": 255,
+            "title": "Text",
+            "type": "string"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
           }
         },
-        "required": ["meta"],
+        "required": ["meta", "text"],
         "title": "AdvertForeignKeySchema",
         "type": "object"
       },

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -299,6 +299,10 @@ class RelatedGenericRelation(models.Model):
 class PageWithGenericRelation(Page):
     generic_relation = GenericRelation("tests.RelatedGenericRelation")
 
+    api_fields = [
+        APIField("generic_relation"),
+    ]
+
 
 class PageWithOldStyleRouteMethod(Page):
     """
@@ -2247,6 +2251,12 @@ class ManyToManyBlogPage(Page):
     # make first_published_at editable on this page model
     settings_panels = Page.settings_panels + [
         FieldPanel("first_published_at"),
+    ]
+
+    api_fields = [
+        APIField("body", writable=True),
+        APIField("adverts", writable=True),
+        APIField("blog_categories", writable=True),
     ]
 
 


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->

Ref: #14565. Aiming for release in 8.1 as this changes the shape of the API responses

### Description

<!-- Please describe the problem you're fixing. -->
Fixes inconsistency where `ManyToManyField` and `GenericRelation` are serialized as an array of primary keys instead of the standardised `{"meta": {"type": ...}, "id": ...}` wrapper we use for `ForeignKey`s.

Also update our ForeignKey schemas to include the full schema defined in the related model's `api_fields` instead of just the thin wrapper, except that we don't follow reverse-related accessors to avoid infinite recursion.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
GitHub Copilot in VSCode for code completion.