### PR TITLE
Fix child_of filter for draft pages

### DIFF
--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -174,7 +174,16 @@ class ChildOfFilter(BaseFilterBackend):
                 if parent_page_id < 0:
                     raise ValueError()
 
-                parent_page = view.get_base_queryset().get(id=parent_page_id)
+                parent_page = Page.objects.get(id=parent_page_id)
+
+                # Draft pages are valid parents, but their children must not
+                # be exposed through the public API.
+                if not parent_page.live:
+                    return queryset.none()
+
+                # Live pages must belong to the current site's public queryset.
+                if not view.get_base_queryset().filter(id=parent_page_id).exists():
+                    raise BadRequestError("parent page doesn't exist")
             except ValueError as e:
                 if request.GET["child_of"] == "root":
                     parent_page = view.get_root_page()
@@ -234,7 +243,16 @@ class DescendantOfFilter(BaseFilterBackend):
                 if parent_page_id < 0:
                     raise ValueError()
 
-                parent_page = view.get_base_queryset().get(id=parent_page_id)
+                parent_page = Page.objects.get(id=parent_page_id)
+
+                # Draft pages are valid ancestors, but their descendants must
+                # not be exposed through the public API.
+                if not parent_page.live:
+                    return queryset.none()
+
+                # Live pages must belong to the current site's public queryset.
+                if not view.get_base_queryset().filter(id=parent_page_id).exists():
+                    raise BadRequestError("ancestor page doesn't exist")
             except ValueError as e:
                 if request.GET["descendant_of"] == "root":
                     parent_page = view.get_root_page()

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -739,6 +739,17 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
         page_id_list = self.get_page_id_list(content)
         self.assertEqual(page_id_list, [16, 18, 19])
 
+    def test_child_of_draft_page_returns_empty_queryset(self):
+        page = models.BlogIndexPage.objects.get(id=5)
+        page.unpublish()
+
+        response = self.get_response(child_of=5)
+        content = json.loads(response.content.decode("UTF-8"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content["meta"]["total_count"], 0)
+        self.assertEqual(content["items"], [])
+
     def test_child_of_root(self):
         # "root" gets children of the homepage of the current site
         response = self.get_response(child_of="root")


### PR DESCRIPTION
Fixes the child_of API filter when the requested parent page is a draft.

Draft pages are valid parent pages, but their children should not be exposed through the public API. The filter now returns an empty queryset with a 200 response for draft parent pages.

Also preserves the existing behavior of returning a 400 error when a live parent page is not part of the current site's public queryset.

### Tests

- Added regression test for child_of with a draft page
- Ran TestPageListing: 101 tests passed
- git diff --check passes