### PR TITLE
Handle RESTRICT references in admin deletions

### DIFF
--- a/wagtail/models/reference_index.py
+++ b/wagtail/models/reference_index.py
@@ -75,7 +75,10 @@ class ReferenceGroups:
 
     @cached_property
     def is_protected(self):
-        return any(reference.on_delete == models.PROTECT for reference in self.qs)
+        return any(
+            reference.on_delete in (models.PROTECT, models.RESTRICT)
+            for reference in self.qs
+        )
 
     def count(self):
         """

--- a/wagtail/snippets/tests/test_delete_view.py
+++ b/wagtail/snippets/tests/test_delete_view.py
@@ -133,6 +133,24 @@ class TestSnippetDelete(PageFixturesMixin, WagtailTestUtils, TestCase):
         # Check that the snippet is still here
         self.assertTrue(Advert.objects.filter(pk=self.test_snippet.pk).exists())
 
+    def test_delete_post_with_restricted_reference(self):
+        with self.captureOnCommitCallbacks(execute=True):
+            VariousOnDeleteModel.objects.create(
+                text="Undeletable", on_delete_restrict=self.test_snippet
+            )
+        delete_url = reverse(
+            "wagtailsnippets_tests_advert:delete",
+            args=[quote(self.test_snippet.pk)],
+        )
+        response = self.client.post(delete_url)
+
+        # The reference should prevent deletion rather than raising RestrictedError.
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse("wagtailadmin_home"))
+
+        # Check that the snippet is still here
+        self.assertTrue(Advert.objects.filter(pk=self.test_snippet.pk).exists())
+
     def test_usage_link(self):
         output = StringIO()
         management.call_command("rebuild_references_index", stdout=output)

--- a/wagtail/tests/test_reference_index.py
+++ b/wagtail/tests/test_reference_index.py
@@ -507,7 +507,13 @@ class TestDescribeOnDelete(PageFixturesMixin, TestCase):
                 referrer, references = usage[0]
                 reference = references[0]
 
-                self.assertIs(usage.is_protected, "on_delete_protect" in init_kwargs)
+                self.assertIs(
+                    usage.is_protected,
+                    any(
+                        field_name in init_kwargs
+                        for field_name in ("on_delete_protect", "on_delete_restrict")
+                    ),
+                )
                 self.assertEqual(usage.count(), 1)
                 self.assertEqual(referrer, obj)
                 self.assertEqual(len(references), 1)


### PR DESCRIPTION
### Description

Deleting an object that is referenced through `on_delete=models.RESTRICT` currently reaches Django's deletion collector and raises `RestrictedError`. The admin's existing reference-index guard recognises only `models.PROTECT`, despite both relation types preventing deletion in this direct-delete case.

Treat `models.RESTRICT` references as protected in the reference index. This reuses Wagtail's existing protected-reference UI and permission handling, preventing the unhandled exception before deletion is attempted.

Regression coverage verifies that restricted references are marked as protected and that deleting a referenced snippet is blocked without raising `RestrictedError`.

### Areas for review

Please confirm that treating `RESTRICT` as protected in `ReferenceGroups.is_protected` is the intended UX for direct admin deletion. Django can allow `RESTRICT` in cascade-deletion scenarios; this change intentionally concerns the admin's direct deletion flow, where the reference remains.

### Verification

- `.venv/bin/ruff check wagtail/models/reference_index.py wagtail/tests/test_reference_index.py wagtail/snippets/tests/test_delete_view.py`
- `.venv/bin/ruff format --check wagtail/models/reference_index.py wagtail/tests/test_reference_index.py wagtail/snippets/tests/test_delete_view.py`
- `.venv/bin/python runtests.py -- wagtail.tests.test_reference_index wagtail.snippets.tests.test_delete_view wagtail.snippets.tests.test_bulk_actions.test_bulk_delete` (50 tests passed)

### AI usage

This pull request includes code written with the assistance of AI.  
The code has **not yet been reviewed** by a human.

AI assistance was used to trace the deletion path, propose the targeted change, and draft this PR description. Automated verification was run with the focused Wagtail test suite and Ruff checks listed above.