### PR TITLE
Add code examples for APIField(..., writable=True) in v3 docs

### DIFF
--- a/docs/advanced_topics/api/v3/pages.md
+++ b/docs/advanced_topics/api/v3/pages.md
@@ -132,7 +132,7 @@ A successful create returns `201` with the type-specific page detail. The creati
 Beyond `title`, `slug`, and the `meta` envelope, you can submit any of the following, subject to the page type's declared `api_fields`:
 
 -   Built-in writable page fields where present, for example `seo_title`, `search_description`, and `show_in_menus`;
--   Custom model fields the project exposes as writable API fields (declared `writable`);
+-   Custom model fields the project exposes as writable API fields (declared `APIField(..., writable=True)` — see [](api_v3_schema));
 -   StreamField values, as the internal list of blocks;
 -   Rich text field values, using the input formats described in [](api_v3);
 -   `ForeignKey` relations;

--- a/docs/advanced_topics/api/v3/schema.md
+++ b/docs/advanced_topics/api/v3/schema.md
@@ -43,6 +43,58 @@ An unknown content type returns `404`.
 
 Schemas are generated at runtime from the project's models and panels, not hand-written. The read side comes from a model's `api_fields`, and the write side additionally requires a field to be a real editable model field declared `APIField(..., writable=True)`. A field that is readable but not exposed as writable appears in `read` but not in `create` or `patch`.
 
+### Exposing writable fields
+
+To allow a field to be submitted when creating or updating content through the API, declare it with `writable=True`:
+
+```python
+# blog/models.py
+
+from wagtail.api import APIField
+from wagtail.models import Page
+
+
+class BlogPage(Page):
+    body = RichTextField()
+    feed_image = models.ForeignKey(
+        "wagtailimages.Image", null=True, blank=True, on_delete=models.SET_NULL
+    )
+    internal_notes = models.TextField(blank=True)
+
+    api_fields = [
+        APIField("body", writable=True),
+        APIField("feed_image", writable=True),
+        APIField("internal_notes"),  # readable only — in read schema, not create/patch
+    ]
+```
+
+Fields without `writable=True` still appear in API read responses and the `read` schema, but are omitted from the `create` and `patch` schemas. Only real model fields can be writable: computed properties and custom `serializer` fields that do not map to an editable model field cannot be marked writable.
+
+For inline child relations (`InlinePanel` / `ParentalKey`), mark the relation writable and declare the child model's fields as writable too:
+
+```python
+from modelcluster.fields import ParentalKey
+from wagtail.models import Orderable
+
+
+class BlogPageCarouselItem(Orderable):
+    page = ParentalKey("blog.BlogPage", related_name="carousel_items")
+    caption = models.CharField(max_length=255)
+
+    api_fields = [
+        APIField("caption", writable=True),
+    ]
+
+
+class BlogPage(Page):
+    # ...
+
+    api_fields = [
+        APIField("body", writable=True),
+        APIField("carousel_items", writable=True),
+    ]
+```
+
 Because the generic `pages` entry is for discovery across all page types, only its `read` schema is populated today: its `create` and `patch` directions fall back to a `Not yet available` placeholder. Use a concrete page type registration (for example `tests.BlogPage`) to get actionable `create` and `patch` schemas.
 
 ## Compared with the v2 API


### PR DESCRIPTION
Fixes part of #14565

### Description

The v3 API tracking issue notes there is no code example of `writable=True`. This adds concrete examples to the schema discovery docs showing:

- How to declare writable vs read-only `APIField`s on a page model
- How to expose inline child relations (`ParentalKey` / `InlinePanel`) for write operations

Also adds a cross-reference from the pages docs "Writable fields" section.

### AI usage

AI assistance was used to draft the documentation text; the examples were verified against existing Wagtail test models and the v3 schema generator behaviour.

### Test plan

- [x] Documentation follows existing v3 API doc style (checked against `docs/advanced_topics/api/v2/configuration.md` and `schema.md`)
- [ ] Docs build passes (`make html` in `docs/`)


Made with [Cursor](https://cursor.com)