### PR TITLE
Prevent meta schema name collision for models used in foreign keys

### DIFF
--- a/docs/advanced_topics/api/v3/schema.md
+++ b/docs/advanced_topics/api/v3/schema.md
@@ -41,7 +41,9 @@ An unknown content type returns `404`.
 
 ## How schemas are generated
 
-Schemas are generated at runtime from the project's models and panels, not hand-written. The read side comes from a model's `api_fields`, and the write side additionally requires a field to be a real editable model field declared `APIField(..., writable=True)`. A field that is readable but not exposed as writable appears in `read` but not in `create` or `patch`.
+Schemas are generated at runtime from the project's models and panels. The read side comes from a model's `api_fields`, and the write side additionally requires a field to be a real editable model field declared `APIField(..., writable=True)`. A field that is readable but not exposed as writable appears in `read` but not in `create` or `patch`.
+
+Note: avoid using the same model name across multiple apps. Schemas aren’t prefixed with the app label, so a `BlogPage` in two different apps would collide. Similarly, avoid using the same names for type variables, as they will also create confusion in the generated project-wide schema.
 
 Because the generic `pages` entry is for discovery across all page types, only its `read` schema is populated today: its `create` and `patch` directions fall back to a `Not yet available` placeholder. Use a concrete page type registration (for example `tests.BlogPage`) to get actionable `create` and `patch` schemas.
 

--- a/wagtail/api/v3/schemas/generators/read.py
+++ b/wagtail/api/v3/schemas/generators/read.py
@@ -128,7 +128,9 @@ class SchemaGenerator:
                 model, name=f"{name}Base", fields=pk_names, base_class=BaseSchema
             )
             meta_schema = self._narrowed_meta_schema(
-                BaseSchema.model_fields["meta"].annotation, model
+                BaseSchema.model_fields["meta"].annotation,
+                model,
+                name=f"{model._meta.object_name}ForeignKeyMetaSchema",
             )
             self._foreign_key_schema_cache[model] = self.extend_schema(
                 schema, name, {"meta": (meta_schema, ..., None)}
@@ -192,7 +194,11 @@ class SchemaGenerator:
         meta_field = base_class.model_fields.get("meta")
         if meta_field is not None:
             extra_fields["meta"] = (
-                self._narrowed_meta_schema(meta_field.annotation, model),
+                self._narrowed_meta_schema(
+                    meta_field.annotation,
+                    model,
+                    name=f"{model._meta.object_name}MetaSchema",
+                ),
                 ...,
                 None,
             )
@@ -268,7 +274,7 @@ class SchemaGenerator:
 
     @staticmethod
     def _narrowed_meta_schema(
-        base_meta_schema: type[Schema], model: type[Model]
+        base_meta_schema: type[Schema], model: type[Model], *, name: str
     ) -> type[Schema]:
         """Narrow ``base_meta_schema``'s ``type`` to a ``Literal`` for ``model``.
 
@@ -281,11 +287,17 @@ class SchemaGenerator:
         ``build_schema``'s own ``meta`` field override, so the narrowing is
         baked into the same dynamic class as any other extra field rather
         than needing a second subclassing pass over the finished schema.
+
+        ``name`` is caller-supplied (rather than derived here from ``model``)
+        because different call sites narrow different base meta schemas for
+        the same model (e.g. the full read schema vs. a nested foreign-key
+        schema) - reusing one naming scheme for both would produce two
+        distinctly-shaped schemas under the same name.
         """
         return cast(
             type[Schema],
             type(base_meta_schema)(
-                f"{model._meta.object_name}MetaSchema",
+                name,
                 (base_meta_schema,),
                 {"__annotations__": {"type": Literal[model._meta.label]}},  # ty: ignore[invalid-type-form]
             ),

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -4947,28 +4947,7 @@
         "title": "BusinessSubIndexSchema",
         "type": "object"
       },
-      "CollectionForeignKeySchema": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "ID"
-          },
-          "meta": {
-            "$ref": "#/components/schemas/CollectionMetaSchema"
-          }
-        },
-        "required": ["meta"],
-        "title": "CollectionForeignKeySchema",
-        "type": "object"
-      },
-      "CollectionMetaSchema": {
+      "CollectionForeignKeyMetaSchema": {
         "properties": {
           "type": {
             "const": "wagtailcore.Collection",
@@ -4998,7 +4977,28 @@
           }
         },
         "required": ["type"],
-        "title": "CollectionMetaSchema",
+        "title": "CollectionForeignKeyMetaSchema",
+        "type": "object"
+      },
+      "CollectionForeignKeySchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/CollectionForeignKeyMetaSchema"
+          }
+        },
+        "required": ["meta"],
+        "title": "CollectionForeignKeySchema",
         "type": "object"
       },
       "CommentableJSONPageCreateMetaSchema": {
@@ -10037,28 +10037,7 @@
         "title": "DocumentDetailMetaSchema",
         "type": "object"
       },
-      "DocumentForeignKeySchema": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "ID"
-          },
-          "meta": {
-            "$ref": "#/components/schemas/DocumentMetaSchema"
-          }
-        },
-        "required": ["meta"],
-        "title": "DocumentForeignKeySchema",
-        "type": "object"
-      },
-      "DocumentMetaSchema": {
+      "DocumentForeignKeyMetaSchema": {
         "properties": {
           "type": {
             "const": "wagtaildocs.Document",
@@ -10088,7 +10067,28 @@
           }
         },
         "required": ["type"],
-        "title": "DocumentMetaSchema",
+        "title": "DocumentForeignKeyMetaSchema",
+        "type": "object"
+      },
+      "DocumentForeignKeySchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/DocumentForeignKeyMetaSchema"
+          }
+        },
+        "required": ["meta"],
+        "title": "DocumentForeignKeySchema",
         "type": "object"
       },
       "DocumentPatchSchema": {
@@ -17342,28 +17342,7 @@
         "title": "ImageDetailMetaSchema",
         "type": "object"
       },
-      "ImageForeignKeySchema": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "ID"
-          },
-          "meta": {
-            "$ref": "#/components/schemas/ImageMetaSchema"
-          }
-        },
-        "required": ["meta"],
-        "title": "ImageForeignKeySchema",
-        "type": "object"
-      },
-      "ImageMetaSchema": {
+      "ImageForeignKeyMetaSchema": {
         "properties": {
           "type": {
             "const": "wagtailimages.Image",
@@ -17393,7 +17372,28 @@
           }
         },
         "required": ["type"],
-        "title": "ImageMetaSchema",
+        "title": "ImageForeignKeyMetaSchema",
+        "type": "object"
+      },
+      "ImageForeignKeySchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ImageForeignKeyMetaSchema"
+          }
+        },
+        "required": ["meta"],
+        "title": "ImageForeignKeySchema",
         "type": "object"
       },
       "ImagePatchSchema": {
@@ -21904,6 +21904,39 @@
         "title": "PageFilterSchema",
         "type": "object"
       },
+      "PageForeignKeyMetaSchema": {
+        "properties": {
+          "type": {
+            "const": "wagtailcore.Page",
+            "title": "Type",
+            "type": "string"
+          },
+          "warnings": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/RichTextRemoval"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warnings"
+          }
+        },
+        "required": ["type"],
+        "title": "PageForeignKeyMetaSchema",
+        "type": "object"
+      },
       "PageForeignKeySchema": {
         "properties": {
           "id": {
@@ -21918,11 +21951,146 @@
             "title": "ID"
           },
           "meta": {
-            "$ref": "#/components/schemas/abc__PageMetaSchema__2"
+            "$ref": "#/components/schemas/PageForeignKeyMetaSchema"
           }
         },
         "required": ["meta"],
         "title": "PageForeignKeySchema",
+        "type": "object"
+      },
+      "PageMetaSchema": {
+        "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "detail_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail Url"
+          },
+          "first_published_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Published At"
+          },
+          "html_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Html Url"
+          },
+          "locale": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Locale"
+          },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "search_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Description"
+          },
+          "seo_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seo Title"
+          },
+          "show_in_menus": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Show In Menus"
+          },
+          "slug": {
+            "title": "Slug",
+            "type": "string"
+          },
+          "type": {
+            "const": "wagtailcore.Page",
+            "title": "Type",
+            "type": "string"
+          },
+          "warnings": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/RichTextRemoval"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warnings"
+          }
+        },
+        "required": ["type", "slug"],
+        "title": "PageMetaSchema",
         "type": "object"
       },
       "PageMoveSchema": {
@@ -22313,7 +22481,7 @@
             "title": "ID"
           },
           "meta": {
-            "$ref": "#/components/schemas/abc__PageMetaSchema__1"
+            "$ref": "#/components/schemas/PageMetaSchema"
           },
           "title": {
             "title": "Title",
@@ -36795,174 +36963,6 @@
         },
         "required": ["meta", "id", "title"],
         "title": "FormPageSchema",
-        "type": "object"
-      },
-      "abc__PageMetaSchema__1": {
-        "properties": {
-          "alias_of": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SimpleBasePageSchema"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "detail_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detail Url"
-          },
-          "first_published_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "First Published At"
-          },
-          "html_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Html Url"
-          },
-          "locale": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locale"
-          },
-          "parent": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SimpleBasePageSchema"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "search_description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Search Description"
-          },
-          "seo_title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Seo Title"
-          },
-          "show_in_menus": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Show In Menus"
-          },
-          "slug": {
-            "title": "Slug",
-            "type": "string"
-          },
-          "type": {
-            "const": "wagtailcore.Page",
-            "title": "Type",
-            "type": "string"
-          },
-          "warnings": {
-            "anyOf": [
-              {
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/RichTextRemoval"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Warnings"
-          }
-        },
-        "required": ["type", "slug"],
-        "title": "PageMetaSchema",
-        "type": "object"
-      },
-      "abc__PageMetaSchema__2": {
-        "properties": {
-          "type": {
-            "const": "wagtailcore.Page",
-            "title": "Type",
-            "type": "string"
-          },
-          "warnings": {
-            "anyOf": [
-              {
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/RichTextRemoval"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Warnings"
-          }
-        },
-        "required": ["type"],
-        "title": "PageMetaSchema",
         "type": "object"
       },
       "abc__PersonPageCreateMetaSchema__1": {

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -1438,6 +1438,39 @@
         "title": "BaseMetaSchema",
         "type": "object"
       },
+      "BasePageForeignKeyMetaSchema": {
+        "properties": {
+          "type": {
+            "const": "basepage.BasePage",
+            "title": "Type",
+            "type": "string"
+          },
+          "warnings": {
+            "anyOf": [
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/RichTextRemoval"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warnings"
+          }
+        },
+        "required": ["type"],
+        "title": "BasePageForeignKeyMetaSchema",
+        "type": "object"
+      },
       "BasePageForeignKeySchema": {
         "properties": {
           "id": {
@@ -1452,7 +1485,7 @@
             "title": "ID"
           },
           "meta": {
-            "$ref": "#/components/schemas/abc__BasePageMetaSchema__2"
+            "$ref": "#/components/schemas/BasePageForeignKeyMetaSchema"
           }
         },
         "required": ["meta"],
@@ -1461,6 +1494,16 @@
       },
       "BasePageMetaSchema": {
         "properties": {
+          "alias_of": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "detail_url": {
             "anyOf": [
               {
@@ -1506,20 +1549,24 @@
             ],
             "title": "Locale"
           },
+          "parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBasePageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
           },
           "type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Type"
+            "const": "basepage.BasePage",
+            "title": "Type",
+            "type": "string"
           },
           "warnings": {
             "anyOf": [
@@ -1543,7 +1590,7 @@
             "title": "Warnings"
           }
         },
-        "required": ["slug"],
+        "required": ["type", "slug"],
         "title": "BasePageMetaSchema",
         "type": "object"
       },
@@ -1561,7 +1608,7 @@
             "title": "ID"
           },
           "meta": {
-            "$ref": "#/components/schemas/abc__BasePageMetaSchema__1"
+            "$ref": "#/components/schemas/BasePageMetaSchema"
           },
           "title": {
             "title": "Title",
@@ -3885,28 +3932,7 @@
         "title": "BusinessSubIndexSchema",
         "type": "object"
       },
-      "CollectionForeignKeySchema": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "ID"
-          },
-          "meta": {
-            "$ref": "#/components/schemas/CollectionMetaSchema"
-          }
-        },
-        "required": ["meta"],
-        "title": "CollectionForeignKeySchema",
-        "type": "object"
-      },
-      "CollectionMetaSchema": {
+      "CollectionForeignKeyMetaSchema": {
         "properties": {
           "type": {
             "const": "wagtailcore.Collection",
@@ -3936,7 +3962,28 @@
           }
         },
         "required": ["type"],
-        "title": "CollectionMetaSchema",
+        "title": "CollectionForeignKeyMetaSchema",
+        "type": "object"
+      },
+      "CollectionForeignKeySchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/CollectionForeignKeyMetaSchema"
+          }
+        },
+        "required": ["meta"],
+        "title": "CollectionForeignKeySchema",
         "type": "object"
       },
       "CommentableJSONPageCreateMetaSchema": {
@@ -7558,28 +7605,7 @@
         "title": "DocumentDetailMetaSchema",
         "type": "object"
       },
-      "DocumentForeignKeySchema": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "ID"
-          },
-          "meta": {
-            "$ref": "#/components/schemas/DocumentMetaSchema"
-          }
-        },
-        "required": ["meta"],
-        "title": "DocumentForeignKeySchema",
-        "type": "object"
-      },
-      "DocumentMetaSchema": {
+      "DocumentForeignKeyMetaSchema": {
         "properties": {
           "type": {
             "const": "wagtaildocs.Document",
@@ -7609,7 +7635,28 @@
           }
         },
         "required": ["type"],
-        "title": "DocumentMetaSchema",
+        "title": "DocumentForeignKeyMetaSchema",
+        "type": "object"
+      },
+      "DocumentForeignKeySchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/DocumentForeignKeyMetaSchema"
+          }
+        },
+        "required": ["meta"],
+        "title": "DocumentForeignKeySchema",
         "type": "object"
       },
       "DocumentPatchSchema": {
@@ -13337,28 +13384,7 @@
         "title": "ImageDetailMetaSchema",
         "type": "object"
       },
-      "ImageForeignKeySchema": {
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "ID"
-          },
-          "meta": {
-            "$ref": "#/components/schemas/ImageMetaSchema"
-          }
-        },
-        "required": ["meta"],
-        "title": "ImageForeignKeySchema",
-        "type": "object"
-      },
-      "ImageMetaSchema": {
+      "ImageForeignKeyMetaSchema": {
         "properties": {
           "type": {
             "const": "wagtailimages.Image",
@@ -13388,7 +13414,28 @@
           }
         },
         "required": ["type"],
-        "title": "ImageMetaSchema",
+        "title": "ImageForeignKeyMetaSchema",
+        "type": "object"
+      },
+      "ImageForeignKeySchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ID"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ImageForeignKeyMetaSchema"
+          }
+        },
+        "required": ["meta"],
+        "title": "ImageForeignKeySchema",
         "type": "object"
       },
       "ImagePatchSchema": {
@@ -26515,141 +26562,6 @@
           "is_superuser"
         ],
         "title": "WhoAmIUserSchema",
-        "type": "object"
-      },
-      "abc__BasePageMetaSchema__1": {
-        "properties": {
-          "alias_of": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SimpleBasePageSchema"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "detail_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Detail Url"
-          },
-          "first_published_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "First Published At"
-          },
-          "html_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Html Url"
-          },
-          "locale": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Locale"
-          },
-          "parent": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SimpleBasePageSchema"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "slug": {
-            "title": "Slug",
-            "type": "string"
-          },
-          "type": {
-            "const": "basepage.BasePage",
-            "title": "Type",
-            "type": "string"
-          },
-          "warnings": {
-            "anyOf": [
-              {
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/RichTextRemoval"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Warnings"
-          }
-        },
-        "required": ["type", "slug"],
-        "title": "BasePageMetaSchema",
-        "type": "object"
-      },
-      "abc__BasePageMetaSchema__2": {
-        "properties": {
-          "type": {
-            "const": "basepage.BasePage",
-            "title": "Type",
-            "type": "string"
-          },
-          "warnings": {
-            "anyOf": [
-              {
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/RichTextRemoval"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Warnings"
-          }
-        },
-        "required": ["type"],
-        "title": "BasePageMetaSchema",
         "type": "object"
       },
       "abc__EventPageCreateMetaSchema__1": {


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->

### Description

<!-- Please describe the problem you're fixing. -->
This fixes meta schema name collision for models used in ForeignKeys. This is noticeable in the snapshot as we have `abc__PageMetaSchema__1` and `abc__PageMetaSchema__2`, and even more noticeable in the bakerydemo (look for `abc__` prefixed schemas).

The remaining `abc__` prefixed schemas are known "issues", i.e. because we have similarly-named models `EventPage`, `FormPage`, etc. in the `testapp` and `demosite` apps.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->

Claude Code with Sonnet 5 in VSCode was used to identify the cause and generate an initial fix, but I tweaked and reviewed it before submitting.
