### PR TITLE
Inspect serializer's `to_representation` for best-effort schema in API v3

### DIFF
--- a/wagtail/api/v3/schemas/generators/read.py
+++ b/wagtail/api/v3/schemas/generators/read.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any, Callable, Literal, cast
+from typing import Any, Callable, Literal, cast, get_type_hints
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models import ForeignKey, Model
@@ -77,11 +77,14 @@ class SchemaGenerator:
         than having to reimplement each one for v3.
         """
 
-        from rest_framework.fields import SkipField
-        from rest_framework.serializers import Serializer
+        from rest_framework.fields import Field, SkipField
 
-        serializer = cast(Serializer, copy.deepcopy(api_field.serializer))
+        serializer = cast(Field, copy.deepcopy(api_field.serializer))
         serializer.bind(field_name=api_field.name, parent=None)
+        return_type = get_type_hints(serializer.to_representation).get("return", Any)
+        # allow_null / required may not reflect nullability as the field's
+        # source may resolve to None regardless of those flags.
+        return_type = return_type | None
 
         def resolve(obj: Model, context: dict) -> Any:
             try:
@@ -92,7 +95,7 @@ class SchemaGenerator:
                 return None
             return serializer.to_representation(value)
 
-        return Any, None, staticmethod(resolve)
+        return return_type, None, staticmethod(resolve)
 
     def register_field_schema(
         self,

--- a/wagtail/api/v3/tests/snapshots/openapi.json
+++ b/wagtail/api/v3/tests/snapshots/openapi.json
@@ -2991,6 +2991,17 @@
             ]
           },
           "feed_image_thumbnail": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ImageRenditionDict"
+              },
+              {
+                "$ref": "#/components/schemas/ImageRenditionErrorDict"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Feed Image Thumbnail"
           },
           "id": {
@@ -17480,6 +17491,45 @@
           }
         },
         "title": "ImagePatchSchema",
+        "type": "object"
+      },
+      "ImageRenditionDict": {
+        "properties": {
+          "alt": {
+            "title": "Alt",
+            "type": "string"
+          },
+          "full_url": {
+            "title": "Full Url",
+            "type": "string"
+          },
+          "height": {
+            "title": "Height",
+            "type": "integer"
+          },
+          "url": {
+            "title": "Url",
+            "type": "string"
+          },
+          "width": {
+            "title": "Width",
+            "type": "integer"
+          }
+        },
+        "required": ["url", "full_url", "width", "height", "alt"],
+        "title": "ImageRenditionDict",
+        "type": "object"
+      },
+      "ImageRenditionErrorDict": {
+        "properties": {
+          "error": {
+            "const": "SourceImageIOError",
+            "title": "Error",
+            "type": "string"
+          }
+        },
+        "required": ["error"],
+        "title": "ImageRenditionErrorDict",
         "type": "object"
       },
       "ImageSchema": {

--- a/wagtail/api/v3/tests/snapshots/openapi_basepage.json
+++ b/wagtail/api/v3/tests/snapshots/openapi_basepage.json
@@ -2474,6 +2474,17 @@
             ]
           },
           "feed_image_thumbnail": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ImageRenditionDict"
+              },
+              {
+                "$ref": "#/components/schemas/ImageRenditionErrorDict"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Feed Image Thumbnail"
           },
           "id": {
@@ -13475,6 +13486,45 @@
           }
         },
         "title": "ImagePatchSchema",
+        "type": "object"
+      },
+      "ImageRenditionDict": {
+        "properties": {
+          "alt": {
+            "title": "Alt",
+            "type": "string"
+          },
+          "full_url": {
+            "title": "Full Url",
+            "type": "string"
+          },
+          "height": {
+            "title": "Height",
+            "type": "integer"
+          },
+          "url": {
+            "title": "Url",
+            "type": "string"
+          },
+          "width": {
+            "title": "Width",
+            "type": "integer"
+          }
+        },
+        "required": ["url", "full_url", "width", "height", "alt"],
+        "title": "ImageRenditionDict",
+        "type": "object"
+      },
+      "ImageRenditionErrorDict": {
+        "properties": {
+          "error": {
+            "const": "SourceImageIOError",
+            "title": "Error",
+            "type": "string"
+          }
+        },
+        "required": ["error"],
+        "title": "ImageRenditionErrorDict",
         "type": "object"
       },
       "ImageSchema": {

--- a/wagtail/images/api/fields.py
+++ b/wagtail/images/api/fields.py
@@ -1,9 +1,23 @@
 from collections import OrderedDict
+from typing import Literal
 
 from rest_framework.fields import Field
+from typing_extensions import TypedDict
 
 from ..models import SourceImageIOError
 from ..utils import to_svg_safe_spec
+
+
+class ImageRenditionDict(TypedDict):
+    url: str
+    full_url: str
+    width: int
+    height: int
+    alt: str
+
+
+class ImageRenditionErrorDict(TypedDict):
+    error: Literal["SourceImageIOError"]
 
 
 class ImageRenditionField(Field):
@@ -33,7 +47,7 @@ class ImageRenditionField(Field):
         self.preserve_svg = preserve_svg
         super().__init__(*args, **kwargs)
 
-    def to_representation(self, image):
+    def to_representation(self, image) -> ImageRenditionDict | ImageRenditionErrorDict:
         try:
             if image.is_svg() and self.preserve_svg:
                 filter_spec = to_svg_safe_spec(self.filter_spec)
@@ -42,7 +56,7 @@ class ImageRenditionField(Field):
 
             thumbnail = image.get_rendition(filter_spec)
 
-            return OrderedDict(
+            result = OrderedDict(
                 [
                     ("url", thumbnail.url),
                     ("full_url", thumbnail.full_url),
@@ -51,9 +65,11 @@ class ImageRenditionField(Field):
                     ("alt", thumbnail.alt),
                 ]
             )
+            return ImageRenditionDict(result)
         except SourceImageIOError:
-            return OrderedDict(
+            result = OrderedDict(
                 [
                     ("error", "SourceImageIOError"),
                 ]
             )
+            return ImageRenditionErrorDict(result)


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->

### Description

<!-- Please describe the problem you're fixing. -->
This improves the generated schema of `APIField()` that has a custom `serializer` in APIv3 if the serializer's `to_representation()` has type hints.

To demo this, we add type hints to the `ImageRenditionField`.

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
GitHub Copilot in VSCode for code autocompletion.