### PR TITLE
Fix interrupted workflow resume state corruption

### DIFF
--- a/wagtail/models/workflows.py
+++ b/wagtail/models/workflows.py
@@ -199,6 +199,7 @@ class WorkflowState(models.Model):
             "status": self.status,
         }
 
+    @transaction.atomic
     def resume(self, user=None):
         """Put a STATUS_NEEDS_CHANGES workflow state back into STATUS_IN_PROGRESS, and restart the current task"""
         from wagtail.models import AbstractPage

--- a/wagtail/tests/test_workflow.py
+++ b/wagtail/tests/test_workflow.py
@@ -352,6 +352,28 @@ class TestPageWorkflows(PageFixturesMixin, WagtailTestUtils, TestCase):
         self.assertEqual(workflow_state.current_task_state.task, task_2)
         self.assertTrue(workflow_state.is_active)
 
+    def test_resume_workflow_rolls_back_if_update_fails(self):
+        data = self.start_workflow()
+        workflow_state = data["workflow_state"]
+
+        workflow_state.current_task_state.approve(user=None)
+        workflow_state.refresh_from_db()
+        workflow_state.current_task_state.reject(user=None)
+        workflow_state.refresh_from_db()
+
+        rejected_task_state = workflow_state.current_task_state
+        self.assertEqual(workflow_state.status, WorkflowState.STATUS_NEEDS_CHANGES)
+
+        with mock.patch.object(
+            WorkflowState, "update", side_effect=RuntimeError("Update failed")
+        ):
+            with self.assertRaises(RuntimeError):
+                workflow_state.resume(user=None)
+
+        workflow_state.refresh_from_db()
+        self.assertEqual(workflow_state.status, WorkflowState.STATUS_NEEDS_CHANGES)
+        self.assertEqual(workflow_state.current_task_state, rejected_task_state)
+
     def test_tasks_with_status_on_resubmission(self):
         # test that a Workflow rejected and resumed shows the status of the latest tasks when _`all_tasks_with_status` is called
         data = self.start_workflow()


### PR DESCRIPTION
Fixes #14586

### Description

`WorkflowState.resume()` could leave a workflow in an inconsistent state if the operation was interrupted after saving the intermediate `IN_PROGRESS` state but before `update()` completed.

This could result in:

```text
status: in_progress
current_task_state: None
```

This change wraps `WorkflowState.resume()` in `transaction.atomic` so that the workflow state is rolled back if the resume operation fails partway through.

A regression test has also been added to verify that the workflow remains in its previous state when `update()` fails during `resume()`.

The issue was reproduced locally before the fix and verified again after the fix.

### AI usage

GitHub Copilot was used for minor assistance during development.