### PR TITLE
Fix copy/alias page history logging the wrong page as source

### DIFF
--- a/wagtail/actions/copy_page.py
+++ b/wagtail/actions/copy_page.py
@@ -287,7 +287,6 @@ class CopyPageAction(BaseAction):
 
         # Log
         if self.log_action:
-            parent = specific_page.get_parent()
             log(
                 instance=page_copy,
                 action=self.log_action,
@@ -302,11 +301,9 @@ class CopyPageAction(BaseAction):
                         },
                     },
                     "source": {
-                        "id": parent.id,
-                        "title": parent.specific_deferred.get_admin_display_title(),
-                    }
-                    if parent
-                    else None,
+                        "id": specific_page.id,
+                        "title": specific_page.get_admin_display_title(),
+                    },
                     "destination": {
                         "id": to.id,
                         "title": to.specific_deferred.get_admin_display_title(),

--- a/wagtail/actions/create_alias.py
+++ b/wagtail/actions/create_alias.py
@@ -193,7 +193,6 @@ class CreatePageAliasAction(BaseAction):
 
         # Log
         if log_action:
-            source_parent = specific_page.get_parent()
             log(
                 instance=alias,
                 action=log_action,
@@ -201,11 +200,9 @@ class CreatePageAliasAction(BaseAction):
                 data={
                     "page": {"id": alias.id, "title": alias.get_admin_display_title()},
                     "source": {
-                        "id": source_parent.id,
-                        "title": source_parent.specific_deferred.get_admin_display_title(),
-                    }
-                    if source_parent
-                    else None,
+                        "id": specific_page.id,
+                        "title": specific_page.get_admin_display_title(),
+                    },
                     "destination": {
                         "id": parent.id,
                         "title": parent.specific_deferred.get_admin_display_title(),

--- a/wagtail/tests/test_audit_log.py
+++ b/wagtail/tests/test_audit_log.py
@@ -341,6 +341,23 @@ class TestAuditLog(TestCase):
             ["wagtail.publish", "wagtail.copy", "wagtail.create"],
         )
 
+        log_entry = PageLogEntry.objects.get(action="wagtail.copy")
+        source_title = self.home_page.get_admin_display_title()
+        # "source" should identify the page that was copied, not its parent
+        self.assertEqual(log_entry.data["source"]["id"], self.home_page.id)
+        self.assertEqual(log_entry.data["source"]["title"], source_title)
+        self.assertEqual(log_entry.message, f"Copied from {source_title}")
+
+    def test_page_create_alias(self):
+        self.home_page.create_alias(update_slug="the-alias")
+
+        log_entry = PageLogEntry.objects.get(action="wagtail.create_alias")
+        source_title = self.home_page.get_admin_display_title()
+        # "source" should identify the page the alias was created from, not its parent
+        self.assertEqual(log_entry.data["source"]["id"], self.home_page.id)
+        self.assertEqual(log_entry.data["source"]["title"], source_title)
+        self.assertEqual(log_entry.message, f"Created an alias of {source_title}")
+
     def test_page_reorder(self):
         section_1 = self.root_page.add_child(
             instance=SimplePage(title="Child 1", slug="child-1", content="hello")

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -3167,7 +3167,8 @@ class TestCopyForTranslation(PageFixturesMixin, TestCase):
         self.assertEqual(log_entry.data["source_locale"]["language_code"], "en")
         self.assertEqual(log_entry.data["page"]["locale"]["language_code"], "fr")
         self.assertEqual(
-            log_entry.message, "Copied for translation from Root (English)"
+            log_entry.message,
+            "Copied for translation from Welcome to the Wagtail test site! (English)",
         )
 
     def test_copy_homepage_slug_exists(self):
@@ -3212,8 +3213,7 @@ class TestCopyForTranslation(PageFixturesMixin, TestCase):
         self.assertEqual(log_entry.data["source_locale"]["language_code"], "en")
         self.assertEqual(log_entry.data["page"]["locale"]["language_code"], "fr")
         self.assertEqual(
-            log_entry.message,
-            "Copied for translation from Welcome to the Wagtail test site! (English)",
+            log_entry.message, "Copied for translation from Events (English)"
         )
 
     def test_copy_childpage_without_parent(self):


### PR DESCRIPTION
Fixes #14585

### Description

`CopyActionFormatter`, `CreateAliasActionFormatter` and `CopyForTranslationActionFormatter` all read `data["source"]["title"]` to say which page a copy, alias, or translation came from. `CopyPageAction` and `CreatePageAliasAction` were populating `"source"` with the *parent* of the copied page (`specific_page.get_parent()`) instead of the page itself, so history entries named an unrelated page - often of a completely different page type, as the issue's repro shows.

Both log calls now reference `specific_page`, the page that was actually copied or aliased, instead of its parent. `"destination"` already correctly identified the target parent, so that key is unchanged. `copy_for_translation` goes through the same `CopyPageAction`/`CreatePageAliasAction` code paths, so it's fixed by the same change.

Added tests in `test_audit_log.py` asserting the logged `source` id/title and rendered message for both `copy()` and `create_alias()`, and updated two existing `copy_for_translation` tests in `test_page_model.py` whose expected messages had the old, incorrect parent title baked in.

### AI usage

Used Claude Code to help locate the root cause and draft the fix and tests. I traced `data["source"]` through `copy_page.py`, `create_alias.py` and the three formatters myself to confirm the bug and the scope of the fix, then reran the affected test modules locally (`test_audit_log`, `test_page_model.TestCopyForTranslation`, `test_translatablemixin`, `test_signals` - 64 tests, all passing) and `ruff check` / `ruff format` before pushing.
