### PR TITLE
Return an empty result for ?child_of= a draft page

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changelog
 
  * Fix: Avoid redundant writes back to the cache on `get_rendition` and `get_renditions` (Mason Lyons, Matt Westcott)
  * Fix: Allow `ChooserBlock.bulk_to_python()` to resolve records with primary keys that need converting to their native type, such as UUIDs (Saksham Chawla)
+ * Fix: Return an empty result from the API's `?child_of=` filter when the parent page is a draft, instead of a 400 error (Kunal Kumar)
  * Maintenance: Drop support for Python 3.10
  * Maintenance: Remove obsolete use of `USE_L10N` setting (DresdenGman)
 

--- a/docs/releases/8.1.md
+++ b/docs/releases/8.1.md
@@ -20,6 +20,7 @@ depth: 1
 
  * Avoid redundant writes back to the cache on `get_rendition` and `get_renditions` (Mason Lyons, Matt Westcott)
  * Allow `ChooserBlock.bulk_to_python()` to resolve records with primary keys that need converting to their native type, such as UUIDs (Saksham Chawla)
+ * Return an empty result from the API's `?child_of=` filter when the parent page is a draft, instead of a 400 error (Kunal Kumar)
 
 ### Documentation
 

--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -181,6 +181,14 @@ class ChildOfFilter(BaseFilterBackend):
                 else:
                     raise BadRequestError("child_of must be a positive integer") from e
             except Page.DoesNotExist as e:
+                # `get_base_queryset()` excludes pages that are not live, so a
+                # draft parent lands here even though it exists. Headless
+                # previews legitimately ask for a draft page's children, and an
+                # unpublished page simply has none to return yet -- so answer
+                # with an empty result rather than an error. Anything genuinely
+                # missing, or live but outside this site, still gets the 400.
+                if Page.objects.filter(id=parent_page_id, live=False).exists():
+                    return queryset.none()
                 raise BadRequestError("parent page doesn't exist") from e
 
             queryset = queryset.child_of(parent_page)

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -761,6 +761,20 @@ class TestPageListing(PageFixturesMixin, WagtailTestUtils, TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {"message": "parent page doesn't exist"})
 
+    def test_child_of_draft_page_returns_empty_result(self):
+        # A draft parent is missing from the base queryset but does exist. A
+        # headless preview asks for its children legitimately, so it should get
+        # an empty list rather than a 400. See #14085.
+        parent = Page.objects.get(id=5)
+        parent.live = False
+        parent.save(update_fields=["live"])
+
+        response = self.get_response(child_of=5)
+        content = json.loads(response.content.decode("UTF-8"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.get_page_id_list(content), [])
+
     def test_child_of_not_integer_gives_error(self):
         response = self.get_response(child_of="abc")
         content = json.loads(response.content.decode("UTF-8"))


### PR DESCRIPTION
Fixes #14085.

`ChildOfFilter` resolves the parent through `view.get_base_queryset()`, which
contains only live pages, so a draft parent raises `Page.DoesNotExist` and is
reported as `400 parent page doesn't exist` (`wagtail/api/v2/filters.py:183`).
The page does exist — it simply has no published children yet.
`wagtail-headless-preview` asks for the children of the page being previewed, so
previewing any unpublished page turns into a bad-request error.

### The obvious fix is wrong, and a test says so

Treating "absent from the base queryset" as "return empty" breaks
`test_child_of_page_thats_not_in_same_site_gives_error`: the root page is also
absent from that queryset, for an unrelated reason, and that test asserts a 400.

So the check keys on the page being **not live** specifically. A draft parent
returns an empty result; a live page outside the current site keeps its 400; a
genuinely missing id keeps its 400.

### Verified

```
wagtail.api                     744 tests, OK
revert only filters.py            1 failure — the added test, nothing else
ruff check / format --check       clean
```

Changelog entries added to `CHANGELOG.txt` and `docs/releases/8.1.md`.

### A question rather than an assumption

Lines 213, 246 and 275 of the same file have the identical shape for
`descendant_of`, `ancestor_of` and `translation_of`. The issue names only
`child_of`, so I have left them alone — happy to extend if you would prefer.

---

*Written with AI assistance. The test runs above were executed and the numbers
are copied from those runs; the interaction with the existing site-scope test was
found by running it rather than by inspection.*
