### PR TITLE
Commit the rendition delete before regenerating

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Fix: Prevent excessive memory usage when copying a page with many revisions (Taras Panasiuk)
  * Fix: Prevent nested submenu labels from becoming invisible when using the slim sidebar (Neda Gilanian, Sage Abdullah)
  * Docs: Fix broken links to Cloudflare and Handsontable documentation (Roshan Ramani)
+ * Fix: Stop `wagtail_update_image_renditions` deleting the rendition files it has just regenerated (Kunal Kumar)
  * Maintenance: Drop support for Python 3.10
  * Maintenance: Remove obsolete use of `USE_L10N` setting (DresdenGman)
 

--- a/docs/releases/8.1.md
+++ b/docs/releases/8.1.md
@@ -23,6 +23,7 @@ depth: 1
  * Prevent error when accessing the sitemap via an unknown host and no default site is configured (Jawad Khan)
  * Fix excessive memory usage when copying a page with many revisions (Taras Panasiuk)
  * Prevent nested submenu labels from becoming invisible when using the slim sidebar (Neda Gilanian, Sage Abdullah)
+ * Stop `wagtail_update_image_renditions` deleting the rendition files it has just regenerated (Kunal Kumar)
 
 ### Documentation
 

--- a/wagtail/images/management/commands/wagtail_update_image_renditions.py
+++ b/wagtail/images/management/commands/wagtail_update_image_renditions.py
@@ -69,20 +69,27 @@ class Command(BaseCommand):
             .iterator(chunk_size=options["chunk_size"])
         ):
             try:
-                with transaction.atomic():
-                    rendition_filter = rendition.filter
-                    rendition_image = rendition.image
+                rendition_filter = rendition.filter
+                rendition_image = rendition.image
 
-                    # Delete the existing rendition
+                # Delete the existing rendition in a transaction of its own.
+                # Rendition files are removed by a post_delete handler that
+                # defers the storage delete to transaction.on_commit, so that
+                # delete has to have run before the replacement is written.
+                # Otherwise, when the old file is already missing from storage
+                # and the regenerated file therefore lands on exactly the name
+                # the deleted rendition had, the deferred delete removes the
+                # file that was just created.
+                with transaction.atomic():
                     rendition.delete()
 
-                    _progress_bar = progress_bar(progress_bar_current, num_renditions)
-                    self.stdout.write(_progress_bar[0], ending=_progress_bar[1])
-                    progress_bar_current = progress_bar_current + 1
+                _progress_bar = progress_bar(progress_bar_current, num_renditions)
+                self.stdout.write(_progress_bar[0], ending=_progress_bar[1])
+                progress_bar_current = progress_bar_current + 1
 
-                    if not purge_only:
-                        # Create a new one
-                        rendition_image.get_rendition(rendition_filter)
+                if not purge_only:
+                    # Create a new one
+                    rendition_image.get_rendition(rendition_filter)
             except:  # noqa:E722
                 logger.exception("Error operating on rendition %d", rendition.id)
                 self.stderr.write(

--- a/wagtail/images/tests/test_management_commands.py
+++ b/wagtail/images/tests/test_management_commands.py
@@ -3,7 +3,14 @@ import warnings
 from io import StringIO
 
 from django.core import management
-from django.test import TestCase, override_settings
+from django.test import (
+    TestCase,
+    TransactionTestCase,
+    override_settings,
+    tag,
+)
+
+from wagtail.models import Collection
 
 from ..management.commands.wagtail_update_image_renditions import progress_bar
 from .utils import Image, get_test_image_file
@@ -137,4 +144,53 @@ class TestUpdateImageRenditions(TestCase):
         output_string = self.REAESC.sub("", output.read())
         self.assertIn(
             f"Successfully processed {total_renditions} rendition(s)\n", output_string
+        )
+
+
+@tag("transaction")
+class TestUpdateImageRenditionsFileDeletion(TransactionTestCase):
+    """
+    Rendition file deletion happens in a post_delete handler that defers the
+    storage delete to transaction.on_commit, so these have to run as a
+    TransactionTestCase for the callback to fire at all.
+    """
+
+    def setUp(self):
+        # TransactionTestCase does not load the migration fixtures.
+        Collection.objects.get_or_create(name="Root", path="0001", depth=1, numchild=0)
+        self.image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(filename="test_image.png", colour="white"),
+        )
+
+    def test_regenerated_rendition_file_survives(self):
+        rendition = self.image.get_rendition("width-100")
+        storage = rendition.file.storage
+        filename = rendition.file.name
+        self.assertTrue(storage.exists(filename))
+
+        management.call_command("wagtail_update_image_renditions", stdout=StringIO())
+
+        rendition = self.image.renditions.get(filter_spec="width-100")
+        self.assertTrue(
+            rendition.file.storage.exists(rendition.file.name),
+            f"{rendition.file.name} was deleted after being regenerated",
+        )
+
+    def test_regenerated_rendition_file_survives_when_the_old_file_is_missing(self):
+        # The reported case: the rendition rows are in the database but
+        # /media/images has been emptied, so the regenerated file lands on
+        # exactly the name the deleted rendition had.
+        rendition = self.image.get_rendition("width-100")
+        storage = rendition.file.storage
+        filename = rendition.file.name
+        storage.delete(filename)
+        self.assertFalse(storage.exists(filename))
+
+        management.call_command("wagtail_update_image_renditions", stdout=StringIO())
+
+        rendition = self.image.renditions.get(filter_spec="width-100")
+        self.assertTrue(
+            rendition.file.storage.exists(rendition.file.name),
+            f"{rendition.file.name} was deleted after being regenerated",
         )


### PR DESCRIPTION
Fixes #11645.

`wagtail_update_image_renditions` deletes and regenerates inside **one**
`transaction.atomic()` block:

```python
with transaction.atomic():
    rendition_filter = rendition.filter
    rendition_image  = rendition.image
    rendition.delete()
    ...
    if not purge_only:
        rendition_image.get_rendition(rendition_filter)
```

but `signal_handlers.post_delete_file_cleanup` defers the storage delete to
`transaction.on_commit`. So the file removal runs *after* the block commits —
that is, after the replacement file has already been written.

### Why the reporter saw it "sometimes"

It depends on whether the old file was still on disk:

- **Old file present** — `storage.save()` finds the name taken and gives the
  regenerated file a fresh name; the deferred delete removes the stale one.
  Everything works. This is the normal case, and why the command has looked
  correct for years.
- **Old file missing** — the reported case: database restored from a fixture,
  `/media/images` emptied. The regenerated file lands on exactly the name the
  deleted rendition had, and the deferred delete removes it. The command still
  reports `Successfully processed N rendition(s)`.

It also explains why `--purge-only` is unaffected: nothing is written after the
delete.

Fixed by committing the delete before regenerating, so the deferred cleanup runs
against the old file rather than the new one.

### A behaviour change worth naming

The delete and the regeneration are no longer atomic together, so a failure
while regenerating now leaves the rendition row deleted rather than rolled back.
I think that is acceptable — renditions regenerate on demand, and it is already
what `--purge-only` does — but it is a real change and I would rather raise it
than bury it. The alternative (keep one transaction and teach the cleanup to skip
a filename the new rendition reused) is more code and more surface area; I have
not done that unasked.

### Verified

```
wagtail.images.tests.test_management_commands     7 tests, OK
wagtail.images (full)                           702 tests, OK
revert only the management command                1 failure
```

Only **one** of the two added tests demonstrates the bug —
`..._when_the_old_file_is_missing` fails on revert. The other (old file present)
passes both before and after; it is a guard for the case that already worked and
is what makes the diagnosis above provable rather than asserted.

---

*Written with AI assistance. The test runs above were executed and the numbers
are copied from those runs.*
