### PR TITLE
Allow historical form-page models to be instantiated

### DIFF
--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -183,7 +183,7 @@ class FormMixin:
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if not hasattr(self, "landing_page_template"):
+        if not hasattr(self, "landing_page_template") and hasattr(self, "template"):
             name, ext = os.path.splitext(self.template)
             self.landing_page_template = name + "_landing" + ext
 

--- a/wagtail/contrib/forms/tests/test_models.py
+++ b/wagtail/contrib/forms/tests/test_models.py
@@ -1,8 +1,10 @@
+from django.apps import apps
 from django.core import mail
 from django.core.exceptions import ValidationError
-from django.test import TestCase, override_settings
+from django.db.migrations.state import ProjectState
+from django.test import SimpleTestCase, TestCase, override_settings
 
-from wagtail.contrib.forms.models import FormSubmission
+from wagtail.contrib.forms.models import FormMixin, FormSubmission
 from wagtail.contrib.forms.tests.utils import (
     make_form_page,
     make_form_page_with_custom_submission,
@@ -847,6 +849,23 @@ class TestNonHtmlExtension(PageFixturesMixin, TestCase):
         self.assertEqual(
             form_page.landing_page_template, "tests/form_page_landing.jade"
         )
+
+
+class TestFormMixin(SimpleTestCase):
+    def test_instantiate_historical_model(self):
+        historical_model = ProjectState.from_apps(apps).apps.get_model(
+            "tests", "FormPage"
+        )
+        self.assertEqual(historical_model(title="test").title, "test")
+
+    def test_landing_page_template_from_base_class(self):
+        class BaseForm:
+            landing_page_template = "custom_landing.html"
+
+        class Form(FormMixin, BaseForm):
+            template = "form.html"
+
+        self.assertEqual(Form().landing_page_template, "custom_landing.html")
 
 
 class TestFormFieldCleanNameCreation(PageFixturesMixin, WagtailTestUtils, TestCase):


### PR DESCRIPTION
Fixes #11911

### Description

Only derive the default landing-page template when a `template` attribute exists. This lets Django instantiate historical form-page models during data migrations while preserving the existing constructor behaviour and inherited landing-template overrides.

Adds a regression using Django's historical model state and coverage for inherited landing-template overrides. Automated tests reproduce the original `AttributeError` without the fix. With the fix, 132 forms tests and 441 forms/admin/API tests pass; Ruff lint and format checks pass.

### AI usage

This pull request includes code written with the assistance of AI. The code has **not yet been reviewed** by a human.

AI assisted with investigation, code, tests, automated checks, reviews, and this description.
