### PR TITLE
Rewind image uploads after validation

### DIFF
--- a/wagtail/images/fields.py
+++ b/wagtail/images/fields.py
@@ -190,13 +190,13 @@ class WagtailImageField(ImageField):
                 code="invalid_image",
             ) from exc
 
-        if hasattr(f, "seek") and callable(f.seek):
-            f.seek(0)
-
         if f is not None:
             self.check_image_file_size(f)
             self.check_image_file_format(f)
             self.check_image_pixel_size(f)
+
+        if hasattr(f, "seek") and callable(f.seek):
+            f.seek(0)
 
         return f
 

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -953,6 +953,44 @@ class TestWagtailImageField(TestCase):
             self.assertIsInstance(to_python.image, WillowImageFile)
             self.assertEqual(to_python.content_type, "image/png")
 
+    def test_to_python_resets_file_position_with_inmemoryfile(self):
+        f = WagtailImageField()
+        self.image.seek(0)
+        content = self.image.read()
+        self.image.seek(0)
+        file = InMemoryUploadedFile(
+            self.image, "", self.filename, "image/png", self.image_size, None
+        )
+        to_python = f.to_python(file)
+        self.assertEqual(to_python.read(), content)
+
+    def test_to_python_resets_file_position_with_temporary_file(self):
+        f = WagtailImageField()
+        with TemporaryUploadedFile(
+            "test_temp.png", "image/png", self.image_size, None
+        ) as tmp_file:
+            self.image.seek(0)
+            content = self.image.read()
+            tmp_file.write(content)
+            tmp_file.seek(0)
+
+            to_python = f.to_python(tmp_file)
+            self.assertEqual(to_python.read(), content)
+
+    @override_settings(WAGTAILIMAGES_MAX_IMAGE_PIXELS=None)
+    def test_to_python_resets_file_position_with_pixel_size_check_disabled(self):
+        f = WagtailImageField()
+        with TemporaryUploadedFile(
+            "test_temp.png", "image/png", self.image_size, None
+        ) as tmp_file:
+            self.image.seek(0)
+            content = self.image.read()
+            tmp_file.write(content)
+            tmp_file.seek(0)
+
+            to_python = f.to_python(tmp_file)
+            self.assertEqual(to_python.read(), content)
+
     def test_to_python_raises_error_with_invalid_image_file(self):
         msg = (
             "Upload a valid image. The file you uploaded was either not an "


### PR DESCRIPTION
Fixes #5853

### Description

Rewind uploaded image files after validation so subsequent readers receive the complete contents. Pixel validation reads from temporary uploads, which previously moved the cursor again after the file had already been rewound.

Adds coverage for temporary uploads, in-memory uploads, and disabled pixel limits. The temporary-upload tests fail without the fix and all 7 targeted tests pass with it. The broader image/document suite passed 1,057 tests with 10 skips, and the admin suite passed 2,169 tests with 13 skips and 5 expected failures. Ruff lint and format checks pass.

The rewind applies to successful validation. Rejected uploads retain the cursor position where validation stopped; the upload view discards files with file-field validation errors.

### AI usage

This pull request includes code written with the assistance of AI. The code has **not yet been reviewed** by a human.

AI assisted with investigation, code, tests, automated checks, reviews, and this description.
