### PR TITLE
Change Renovate configuration to run less often and on fewer dependencies

### DIFF
--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -74,6 +74,16 @@
       "groupName": "Python linters and formatters dependencies",
     },
 
+    // The wagtail version pinned in the project template is owned by the
+    // release process (updated in "Version bump to ..." commits), so ignore
+    // it here. Scoped by file path so any real wagtail dependency reported
+    // elsewhere is still tracked.
+    {
+      "matchFileNames": ["wagtail/project_template/requirements.txt"],
+      "matchPackageNames": ["wagtail"],
+      "enabled": false,
+    },
+
     // Front-end linters and formatters (prettier, eslint, stylelint plus
     // their plugins/configs) across package.json and .pre-commit-config.yaml.
     // `enabled: true` overrides the js-category disable above for just

--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -59,8 +59,7 @@
     // Group linter and formatter updates into a single PR. Regex patterns
     // (delimited by `/`) catch both the pep621 dep (e.g. "ruff") and any
     // related pre-commit hook (e.g. the repo URL "astral-sh/ruff-pre-commit"),
-    // so a single rule handles both managers. django-stubs is included here
-    // to avoid standalone stub update PRs.
+    // so a single rule handles both managers.
     {
       "matchPackageNames": [
         "/ruff/",
@@ -74,21 +73,18 @@
       "groupName": "Python linters and formatters dependencies",
     },
 
-    // The wagtail version pinned in the project template is owned by the
-    // release process (updated in "Version bump to ..." commits), so ignore
-    // it here. Scoped by file path so any real wagtail dependency reported
-    // elsewhere is still tracked.
-    {
-      "matchFileNames": ["wagtail/project_template/requirements.txt"],
-      "matchPackageNames": ["wagtail"],
-      "enabled": false,
-    },
-
     // Group all dependency updates inside the project template (its
     // requirements.txt and Dockerfile) into a single PR.
     {
       "matchFileNames": ["wagtail/project_template/**"],
       "groupName": "Project template dependencies",
+    },
+
+    // Wagtail is pinned in this file and only updated as part of releases.
+    {
+      "matchFileNames": ["wagtail/project_template/requirements.txt"],
+      "matchPackageNames": ["wagtail"],
+      "enabled": false,
     },
 
     // Group all CI updates (GitHub Actions + CircleCI) into a single PR.

--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -22,17 +22,16 @@
   },
 
   "packageRules": [
-    // Major updates of ESLint dependencies usually require code changes
-    // (new config, renamed rules), so park them on the Dependency Dashboard
-    // for approval instead of opening long-lived PRs.
-    {
-      "matchPackageNames": ["/eslint/"],
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true,
-    },
+    // Default to "off" for JS dependencies, specific ones are enabled below.
     {
       "matchCategories": ["js"],
       "enabled": false,
+    },
+
+    {
+      "matchPackageNames": ["/prettier/", "/stylelint/"],
+      "enabled": true,
+      "groupName": "Front-end linters and formatters dependencies",
     },
 
     // Runtime dependencies in [project.dependencies] are user-facing.
@@ -83,16 +82,6 @@
       "matchFileNames": ["wagtail/project_template/requirements.txt"],
       "matchPackageNames": ["wagtail"],
       "enabled": false,
-    },
-
-    // Front-end linters and formatters (prettier, eslint, stylelint plus
-    // their plugins/configs) across package.json and .pre-commit-config.yaml.
-    // `enabled: true` overrides the js-category disable above for just
-    // these packages so the npm versions get tracked too.
-    {
-      "matchPackageNames": ["/prettier/", "/eslint/", "/stylelint/"],
-      "enabled": true,
-      "groupName": "Front-end linters and formatters dependencies",
     },
 
     // Group all dependency updates inside the project template (its

--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -61,11 +61,13 @@
     // Group linter and formatter updates into a single PR. Regex patterns
     // (delimited by `/`) catch both the pep621 dep (e.g. "ruff") and any
     // related pre-commit hook (e.g. the repo URL "astral-sh/ruff-pre-commit"),
-    // so a single rule handles both managers.
+    // so a single rule handles both managers. django-stubs is included here
+    // to avoid standalone stub update PRs.
     {
       "matchPackageNames": [
         "/ruff/",
         "/ty/",
+        "/django-stubs/",
         "/doc8/",
         "/semgrep/",
         "/curlylint/",

--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -23,6 +23,14 @@
   },
 
   "packageRules": [
+    // Major updates of ESLint dependencies usually require code changes
+    // (new config, renamed rules), so park them on the Dependency Dashboard
+    // for approval instead of opening long-lived PRs.
+    {
+      "matchPackageNames": ["/eslint/"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+    },
     {
       "matchCategories": ["js"],
       "enabled": false,

--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -108,5 +108,13 @@
       "matchCategories": ["ci"],
       "groupName": "CI configuration dependencies",
     },
+
+    // Elasticsearch service versions are deliberate test-matrix choices
+    // exercising supported upgrade paths, so major bumps are made by hand.
+    {
+      "matchPackageNames": ["docker.elastic.co/elasticsearch/elasticsearch"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false,
+    },
   ],
 }

--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -7,7 +7,7 @@
     "helpers:pinGitHubActionDigests",
   ],
 
-  // Run once a month, on the first day of the month before 4am.
+  // First day of the month before 4am.
   "schedule": ["* 0-3 1 * *"],
   "timezone": "Etc/UTC",
   "prConcurrentLimit": 10,
@@ -16,8 +16,7 @@
 
   "minimumReleaseAge": "7 days",
 
-  // Periodically refresh uv.lock to catch transitive dependency updates.
-  // Inherits the global monthly schedule.
+  // Periodically refresh lockfiles to catch transitive dependency updates.
   "lockFileMaintenance": {
     "enabled": true,
   },

--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -17,9 +17,9 @@
   "minimumReleaseAge": "7 days",
 
   // Periodically refresh uv.lock to catch transitive dependency updates.
+  // Inherits the global monthly schedule.
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 6am on monday"],
   },
 
   "packageRules": [

--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -7,8 +7,8 @@
     "helpers:pinGitHubActionDigests",
   ],
 
-  // Run weekly.
-  "schedule": ["before 6am on monday"],
+  // Run once a month, on the first day of the month before 4am.
+  "schedule": ["* 0-3 1 * *"],
   "timezone": "Etc/UTC",
   "prConcurrentLimit": 10,
 


### PR DESCRIPTION
Revises Renovate to stop opening PRs for dependencies we don’t want to automate the upgrades of. And run less often.

### AI usage

AI draft manually reviewed and edited