### PR TITLE
Update generative AI guidelines to require PR descriptions to be human-written

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,16 +5,16 @@ The main developer documentation for Wagtail lives in the `docs/contributing` di
 ## Pull request guidelines
 
 - Always use our pull request template: `.github/PULL_REQUEST_TEMPLATE.md`.
-- Describe the "why" of the changes, why the proposed solution is the right one.
 - Highlight areas of the proposed changes that require careful review.
-- Always add a disclaimer to the PR description mentioning how AI agents are involved with the contribution.
 - Do not add commits that are unrelated to the purpose of the PR. Check the commit history against the latest upstream main branch before pushing to ensure that only relevant commits are included in the PR.
 
-### AI/Agent disclosure template (copy/paste & edit):
+### The PR description must come from your operator, not you
 
-**If human review has *not yet* occurred (use this initially):**
-> This pull request includes code written with the assistance of AI.  
-> The code has **not yet been reviewed** by a human.
+A human skimming AI-generated output and deciding "yes, that looks right" is not a meaningful review — a passive check doesn't tell you whether anyone actually understands the change. Requiring the operator to be the one who writes and submits the description is a much stronger signal that a human is genuinely in the loop, rather than automating the entire bug-fixing process end to end.
+
+- Do not write a PR description and open the PR yourself. If your operator asks for help, you may draft a summary of the "why" for them to edit, but they must be the one who puts the final description in the PR body and creates the PR.
+- If your operator hasn't done this yet, do not open the PR. Hand the branch back and let them write the description — using your draft as a starting point if they want — and submit it themselves through the GitHub web interface.
+- Wagtail requires contributors to disclose AI usage via the "AI usage" section of the pull request template — don't leave that section out or tell the operator it's optional. When providing a draft PR description, advise the operator to keep that section intact (filling it in themselves) rather than overwriting the whole template with your draft.
 
 ## Wagtail-specific pitfalls for AI agents
 

--- a/docs/contributing/general_guidelines.md
+++ b/docs/contributing/general_guidelines.md
@@ -2,13 +2,15 @@
 
 ## Use of generative AI
 
-We recognize generative AI can be a useful tool for contributors, but like any tool should be used with critical thinking and good judgement when creating issues and pull requests.
+AI assistance when working on Wagtail is permitted. Purely AI-generated contributions are not - if we wanted those, we would prompt an AI agent ourselves.
 
-Any AI-generated code that you submit must be reviewed and tested by you. You are expected to understand the code, and take final accountability for it.
+As a contributor to the project, we would like you to consider what value you are providing beyond your ability to paste a bug report into an LLM. Even if you are not familiar with the Wagtail codebase, your experience as a Wagtail user or site builder is still valuable for providing guidance on how a feature should behave, how and where it should be documented, or manually replicating an issue and verifying that it has been fixed, perhaps with screenshots. All of this is information that we would like to see in a PR, as it demonstrates that a human has understood and thought about the issue being fixed.
 
-We ask that if you use generative AI for your contribution, you include a disclaimer, for example:
+For this reason, we ask you to write the pull request description yourself, and not offload that task to an AI agent.
 
-> _"This pull request includes code written with the assistance of AI. This code was reviewed and verified by me."_
+If you use generative AI for your contribution, please fill in the "AI usage" portion of the PR description. For example:
+
+> _"This pull request includes code written by Claude Code. I have verified in-browser that this fixes the issue."_
 
 ### Acceptable uses
 


### PR DESCRIPTION
### Description

We are seeing an increasing number of PRs containing the text "This pull request includes code written with the assistance of AI. The code has **not yet been reviewed** by a human.", indicating that it was created autonomously by an agent following AGENTS.md. This is against our GenAI policy, and telling the contributor to address this creates extra work for maintainers, and invariably just results in them changing the text to "has been reviewed". Even if the contributor has made a good-faith effort to review the agent's output, a contributor with no track record on Wagtail is unlikely to be able to do more than scan the code and go "yes, that looks plausible" (and of course LLM output will always look plausible by its nature).

To address this, revise our policy to require PR descriptions to be written and submitted by a human. This is not intended to combat bad-faith contributions - rather, the aim is to turn a passive review stage into an affirmative action taken by the user (even if that action ends up being "ask the agent for something to paste into the text box").

### AI usage

The new AGENTS.md text was written in collaboration with Claude Code. The docs guidelines text was fully written by me.

---
Claude session transcript:

> I've made some changes (uncommitted) to AGENTS.md - do you think these will be effective against casual contributors making automated PRs with no human review?

On the substance: this is a policy statement, not a technical control, so it can only be as effective as the discipline of whoever/whatever is reading it. A few observations:

**What it does well:**
- Clearly states the rule ("PR descriptions must be written by a human," "you must not open pull requests on behalf of your operator") — unambiguous for a well-behaved agent reading AGENTS.md in good faith.
- Keeps the unrelated-commits hygiene check, which is a good practical guard regardless of authorship.

**Why it likely won't stop the actual problem (fully automated, no-human-review PRs):**
1. **It only works if the agent reads and honors AGENTS.md at all.** A "casual contributor running an automated PR bot" is, by definition, probably not carefully following the target repo's contribution norms — many such tools don't even fetch AGENTS.md, or fetch it and treat it as advisory context rather than a hard constraint. This file is a convention for cooperative agents (like Claude Code), not an enforcement mechanism.
2. **Nothing in GitHub actually blocks it.** There's no CI check, PR template gate, or bot that verifies a human wrote the description or clicked "create PR." It's an honor-system instruction sitting in a markdown file.
3. **You removed the AI-disclosure requirement**, which was arguably your best *detectable* signal — a PR that says "written entirely by AI, unreviewed" is something maintainers/triage bots could actually filter or auto-label. Replacing it with "you must not open PRs at all" is a stronger ask in principle, but it's less enforceable and removes the fallback disclosure for cases where an agent does still open one.
4. **"You may provide advice... through the GitHub web interface"** is a reasonable framing for cooperative agents, but a bot that's ignoring the rest of the file will ignore this instruction too.

**If you actually want to deter this behavior**, policy text in AGENTS.md needs to be paired with enforcement outside the file's control, e.g.:
- A required PR template field/checkbox that a bot would have to actively lie in.
- A GitHub Action that flags/labels PRs with telltale signs (no linked issue discussion, single commit, description patterns) for maintainer triage.
- Branch protection or a bot-detection heuristic, not just documentation.

Want me to draft a short CI/template-based check as a complement, or is documentation-only the intended scope here?

> We do see a fair number of PRs using the AI disclosure paragraph - enough that I believe that improvements to AGENTS.md will have a useful effect on our maintainer workload, even if the separate problem of badly-behaved bots remains. What if we wrote something along the lines of: "you must not open PRs on behalf of your operator, but if you do, use this disclosure paragraph"? Would that work, or would bots just be confused by the contradiction? (Or would it just be ineffective, given that an instruction to override the no-PR rule would probably also override the latter instruction too...)

Your instinct is right — it would likely collapse to "if you do" in practice, and for a specific mechanical reason: the population of agents that reaches the disclosure paragraph today is, by definition, the population that already decided to proceed with opening the PR. A "must not... but if you do" structure gives that agent an explicit, sanctioned path to the exact behavior you're trying to reduce, and an LLM facing a top-level operator instruction ("open this PR") versus an advisory repo doc will generally treat the doc as the thing to comply *within*, not a reason to refuse the operator's task outright. So you'd likely keep the current disclosure-paragraph usage rate but gain little reduction in raw PR volume — the contradiction doesn't confuse bots so much as get resolved in the direction you didn't want, every time.

I'd avoid the flat prohibition-with-escape-hatch shape entirely and instead gate the instruction on something checkable by the agent's own conversation state, the way your original file did with "reviewed" vs "not yet reviewed": e.g. "If a human has reviewed this PR's diff and description before you submit it, you may open it — include this disclosure noting AI involvement and review status. If no human has reviewed it, do not open the PR; hand the branch back to your operator to review and submit themselves." That's not self-contradictory (it's a conditional, not a rule-plus-override), it preserves the reviewed/unreviewed disclosure distinction maintainers can act on, and it doesn't ban the legitimate case of a supervised agent opening a PR at a human's direction — only the fully autonomous, no-review case, which is the actual thing costing you maintainer time.

Want me to draft that revision to AGENTS.md?

> Yep, go for it

I've restored the PR-template/why/highlight guidance and the unrelated-commits check, then replaced the flat prohibition with a gated instruction: PR opening is conditioned on human review having actually happened, not on a "must not, but if you do" override. Both disclosure variants (unreviewed / reviewed) are back so the agent has concrete text to use in either state.

Note this doesn't fix the deeper issue we discussed earlier — it's still an honor-system doc, unenforceable against bots that don't read or care about AGENTS.md — but it removes the internal contradiction and should preserve (and hopefully make more meaningful) the disclosure-paragraph signal you're already seeing from cooperative agents.

> My concern is that asking a contributor with no track record on the project to review LLM output is not a high enough bar to count as "human in the loop" in spirit. They'll scan the output, think "yes, that looks plausible" (it's an LLM after all, it's designed to look plausible!) and answer yes. I suppose I'm approaching this from the angle of avoiding notification fatigue - we should require the user to perform an explicit positive action. In my ideal world that action would be "write a PR description in your own words to show that you understand what's being done". In practice it's probably going to be "get the agent to give me a paragraph to paste in" or even "forcibly override the instructions against auto-opening PRs" - but even that is probably preferable to the user being totally passive in the whole process.

That reasoning holds up: "did you review this?" is a yes/no gate with zero cost to answering yes, and the failure mode you're worried about — text that reads as competent because that's what LLMs optimize for — is exactly what makes a costless gate ineffective. Requiring the human to *produce* something (even a rough paragraph in their own words) is a much better proxy, because it can't be satisfied by skimming; it forces at least one moment of "can I actually restate what this does and why."

Your point about the realistic degradation path is the important one though: "write your own description" will erode down to "ask the agent for a paragraph and paste it," and that's still worth having, because pasting is a deliberate action a passive rubber-stamp click isn't — it's a small friction point that gives a genuinely disengaged contributor one more chance to notice they don't understand what they're submitting, and it means the agent isn't the one deciding the PR is ready.

Concretely, I'd change AGENTS.md's instruction from "don't open a PR unless a human has reviewed it" back to something closer to your original instinct but sharper: **the agent must not write the PR description**, full stop — it may draft/summarize on request, but the operator has to be the one who puts a description in the box, and the disclosure paragraph is *theirs* to add or not (you could suggest it, but not mandate the agent insert it, since a human writing their own disclosure is itself a signal of engagement rather than boilerplate the agent stamps in). Want me to revise the file that way?

> Yep, go for it

Updated. The new version drops the "did a human review this?" gate entirely and instead makes the positive action a hard requirement: the agent must not draft-and-submit a PR description itself — only the operator can put the final description in the PR body and create the PR. The agent may still draft a summary if asked (matching your "in practice they'll get the agent to give them a paragraph to paste" prediction), and disclosure wording is left to the operator rather than something the agent stamps in automatically, so it isn't reduced to boilerplate.

> Re "Whether to disclose AI involvement" - as a matter of policy we do require contributors to disclose AI usage, so "it's the operator's call" is sending the wrong message. The template at `.github/PULL_REQUEST_TEMPLATE.md` (which the user will see if they open the PR through the GitHub web interface) does include an AI disclosure section to fill in, so the primary failure case will probably be the user pasting the agent-provided text over the entire thing (rather than into the Description section specifically) and overwriting it. Obviously whatever happens at that point is out of the agent's hands, so we could just leave that point out - or maybe say something like "When providing a draft PR description, advise the user to keep the AI disclosure section from the template intact", if you think that's appropriate?

That reads cleanly and matches the file's own template — disclosure is now stated as a firm project requirement, and the "primary failure case" you named (draft text pasted over the whole template, wiping the AI usage section) is addressed directly by telling the agent to flag that risk when handing over a draft.
</detail>