### PR TITLE
Reject over-long inputs to get_supported_content_language_variant

### DIFF
--- a/wagtail/coreutils.py
+++ b/wagtail/coreutils.py
@@ -32,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 WAGTAIL_APPEND_SLASH = getattr(settings, "WAGTAIL_APPEND_SLASH", True)
 
+LANGUAGE_CODE_MAX_LENGTH = 500
+
 
 def camelcase_to_underscore(str):
     # https://djangosnippets.org/snippets/585/
@@ -281,8 +283,14 @@ def get_content_languages():
     return dict(content_languages)
 
 
-@functools.lru_cache(maxsize=1000)
 def get_supported_content_language_variant(lang_code, strict=False):
+    if not lang_code or len(lang_code) > LANGUAGE_CODE_MAX_LENGTH:
+        raise LookupError(lang_code)
+    return _get_supported_content_language_variant(lang_code, strict=strict)
+
+
+@functools.lru_cache(maxsize=1000)
+def _get_supported_content_language_variant(lang_code, strict=False):
     """
     Return the language code that's listed in supported languages, possibly
     selecting a more generic variant. Raise LookupError if nothing is found.
@@ -295,25 +303,24 @@ def get_supported_content_language_variant(lang_code, strict=False):
     This is equvilant to Django's `django.utils.translation.get_supported_content_language_variant`
     but reads the `WAGTAIL_CONTENT_LANGUAGES` setting instead.
     """
-    if lang_code:
-        # If 'fr-ca' is not supported, try special fallback or language-only 'fr'.
-        possible_lang_codes = [lang_code]
-        try:
-            possible_lang_codes.extend(LANG_INFO[lang_code]["fallback"])
-        except KeyError:
-            pass
-        generic_lang_code = lang_code.split("-")[0]
-        possible_lang_codes.append(generic_lang_code)
-        supported_lang_codes = get_content_languages()
+    # If 'fr-ca' is not supported, try special fallback or language-only 'fr'.
+    possible_lang_codes = [lang_code]
+    try:
+        possible_lang_codes.extend(LANG_INFO[lang_code]["fallback"])
+    except KeyError:
+        pass
+    generic_lang_code = lang_code.split("-")[0]
+    possible_lang_codes.append(generic_lang_code)
+    supported_lang_codes = get_content_languages()
 
-        for code in possible_lang_codes:
-            if code in supported_lang_codes and check_for_language(code):
-                return code
-        if not strict:
-            # if fr-fr is not supported, try fr-ca.
-            for supported_code in supported_lang_codes:
-                if supported_code.startswith(generic_lang_code + "-"):
-                    return supported_code
+    for code in possible_lang_codes:
+        if code in supported_lang_codes and check_for_language(code):
+            return code
+    if not strict:
+        # if fr-fr is not supported, try fr-ca.
+        for supported_code in supported_lang_codes:
+            if supported_code.startswith(generic_lang_code + "-"):
+                return supported_code
     raise LookupError(lang_code)
 
 
@@ -341,7 +348,7 @@ def reset_cache(**kwargs):
     """
     if kwargs["setting"] in ("WAGTAIL_CONTENT_LANGUAGES", "LANGUAGES", "LANGUAGE_CODE"):
         get_content_languages.cache_clear()
-        get_supported_content_language_variant.cache_clear()
+        _get_supported_content_language_variant.cache_clear()
 
 
 def multigetattr(item, accessor):

--- a/wagtail/tests/test_utils.py
+++ b/wagtail/tests/test_utils.py
@@ -15,7 +15,9 @@ from django.utils.translation import _trans
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.coreutils import (
+    LANGUAGE_CODE_MAX_LENGTH,
     InvokeViaAttributeShortcut,
+    _get_supported_content_language_variant,
     accepts_kwarg,
     camelcase_to_underscore,
     cautious_slugify,
@@ -358,6 +360,35 @@ class TestGetSupportedContentLanguageVariant(TestCase):
             g("xyz")
         with self.assertRaises(LookupError):
             g("xy-zz")
+
+    def test_check_for_language_lang_code_max_length(self):
+        # Overly long codes are rejected before the cached lookup, so they are
+        # not retained as cache keys, potentially consuming too much memory.
+        # Codes at the maximum length can reach the cached lookup.
+        for length, is_valid, cache_size in [
+            (LANGUAGE_CODE_MAX_LENGTH - 1, True, 1),
+            (LANGUAGE_CODE_MAX_LENGTH, True, 1),
+            (LANGUAGE_CODE_MAX_LENGTH + 1, False, 0),
+        ]:
+            _get_supported_content_language_variant.cache_clear()
+            with self.subTest(length=length):
+                if is_valid:
+                    self.assertEqual(
+                        get_supported_content_language_variant(
+                            f"de-{'a' * (length - 3)}"
+                        ),
+                        "de",
+                    )
+                else:
+                    with self.assertRaises(LookupError):
+                        get_supported_content_language_variant(
+                            f"de-{'a' * (length - 3)}"
+                        )
+
+                self.assertEqual(
+                    _get_supported_content_language_variant.cache_info().currsize,
+                    cache_size,
+                )
 
     @override_settings(
         WAGTAIL_CONTENT_LANGUAGES=[


### PR DESCRIPTION
Analogous to Django's fix for CVE-2026-15337 (https://github.com/django/django/commit/224dbc832586ad5cfb0237c2ff30d14baeaddc6f). An attacker with the ability to pass arbitrary language codes to get_supported_content_language_variant could consume process memory by passing excessively long strings. This is not exploitable within Wagtail itself, as all calls to this function are made with already-bounded values from configuration files, and this function is not documented for use in third-party code. However, this is being patched in the interest of security hardening.

Many thanks to Kaya Emre Arikan for the report.


### AI usage

Github Copilot for code completion
