### PR TITLE
Use `add_unredirected_header` to pass authorization headers to Facebook/Instagram embed APIs

### DIFF
--- a/wagtail/embeds/finders/facebook.py
+++ b/wagtail/embeds/finders/facebook.py
@@ -71,7 +71,9 @@ class FacebookOEmbedFinder(OEmbedFinder):
 
         # Configure request
         request = Request(endpoint + "?" + urlencode(params))  # noqa: S310 - scheme controlled through configured endpoints, not exploitable
-        request.add_header("Authorization", f"Bearer {self.app_id}|{self.app_secret}")
+        request.add_unredirected_header(
+            "Authorization", f"Bearer {self.app_id}|{self.app_secret}"
+        )
 
         # Perform request
         try:

--- a/wagtail/embeds/finders/instagram.py
+++ b/wagtail/embeds/finders/instagram.py
@@ -55,7 +55,9 @@ class InstagramOEmbedFinder(OEmbedFinder):
 
         # Configure request
         request = Request(endpoint + "?" + urlencode(params))  # noqa: S310 - scheme controlled through configured endpoints, not exploitable
-        request.add_header("Authorization", f"Bearer {self.app_id}|{self.app_secret}")
+        request.add_unredirected_header(
+            "Authorization", f"Bearer {self.app_id}|{self.app_secret}"
+        )
 
         # Perform request
         try:

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -807,6 +807,10 @@ class TestInstagramOEmbed(TestCase):
             "https://graph.facebook.com/v11.0/instagram_oembed?url=https%3A%2F%2Finstagram.com%2Fp%2FCHeRxmnDSYe%2F&format=json",
         )
         self.assertEqual(request.get_header("Authorization"), "Bearer 123|abc")
+        # the auth header must be unredirected, so it isn't leaked to a redirect target
+        self.assertNotIn("Authorization", request.headers)
+        self.assertIn("Authorization", request.unredirected_hdrs)
+        self.assertEqual(request.unredirected_hdrs["Authorization"], "Bearer 123|abc")
 
     @patch("urllib.request.urlopen")
     def test_instagram_oembed_photo_embed(self, urlopen):
@@ -915,6 +919,10 @@ class TestFacebookOEmbed(TestCase):
             "https://graph.facebook.com/v11.0/oembed_video?url=https%3A%2F%2Ffb.watch%2FABC123eew%2F&format=json",
         )
         self.assertEqual(request.get_header("Authorization"), "Bearer 123|abc")
+        # the auth header must be unredirected, so it isn't leaked to a redirect target
+        self.assertNotIn("Authorization", request.headers)
+        self.assertIn("Authorization", request.unredirected_hdrs)
+        self.assertEqual(request.unredirected_hdrs["Authorization"], "Bearer 123|abc")
 
     def test_facebook_request_denied_401(self):
         err = HTTPError(


### PR DESCRIPTION
In the event that the API endpoint returns a redirect, a header added with `add_header` would leak the auth token to the target of that redirect. This is only a theoretical concern, as there is no reason to believe that these endpoints would ever redirect, but addressed here in the interests of security hardening.

Many thanks to furojido for the report.

### AI usage

Test assertions were written by Claude Code (the approach of checking `headers` and `unredirected_hdrs` to bypass `get_header` would have been non-obvious without consulting the urllib source) and verified by me.